### PR TITLE
Index trusts

### DIFF
--- a/TramsDataApi.Test/Controllers/EstablishmentsControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/EstablishmentsControllerTests.cs
@@ -23,7 +23,7 @@ namespace TramsDataApi.Test.Controllers
             var controller = new EstablishmentsController(gateway.Object);
             var result = controller.GetByUkprn(ukprn);
 
-            result.Should().BeOfType(typeof(NotFoundResult));
+            result.Result.Should().BeOfType(typeof(NotFoundResult));
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace TramsDataApi.Test.Controllers
             var controller = new EstablishmentsController(gateway.Object);
             var result = controller.GetByUkprn(ukprn);
             
-            result.Should().BeEquivalentTo(new OkObjectResult(establishmentResponse));
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(establishmentResponse));
         }
     }
 }

--- a/TramsDataApi.Test/Controllers/TrustsControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/TrustsControllerTests.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FizzWare.NBuilder.PropertyNaming;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using TramsDataApi.Controllers;
-using TramsDataApi.Gateways;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.UseCases;
 using Xunit;
@@ -11,6 +13,11 @@ namespace TramsDataApi.Test.Controllers
 {
     public class TrustsControllerTests
     {
+        public TrustsControllerTests()
+        {
+            BuilderSetup.SetDefaultPropertyName(new RandomValuePropertyNamer(new BuilderSettings()));
+        }
+        
         [Fact]
         public void GetTrustsByUkPrn_ReturnsNotFoundResult_WhenNoTrustsFound()
         {
@@ -18,8 +25,8 @@ namespace TramsDataApi.Test.Controllers
             var ukprn = "mockukprn";
             getTrustsByUkprn.Setup(g => g.Execute(ukprn)).Returns(() => null);
 
-            var controller = new TrustsController(getTrustsByUkprn.Object);
-            var result = controller.Get(ukprn);
+            var controller = new TrustsController(getTrustsByUkprn.Object, new Mock<ISearchTrusts>().Object);
+            var result = controller.GetTrustByUkprn(ukprn);
 
             result.Result.Should().BeOfType(typeof(NotFoundResult));
         }
@@ -52,10 +59,85 @@ namespace TramsDataApi.Test.Controllers
             var getTrustByUkprn = new Mock<IGetTrustByUkprn>();
             getTrustByUkprn.Setup(g => g.Execute(ukprn)).Returns(trustResponse);
             
-            var controller = new TrustsController(getTrustByUkprn.Object);
-            var result = controller.Get(ukprn);
+            var controller = new TrustsController(getTrustByUkprn.Object, new Mock<ISearchTrusts>().Object);
+            var result = controller.GetTrustByUkprn(ukprn);
 
             result.Result.Should().BeEquivalentTo(new OkObjectResult(trustResponse));
+        }
+        
+        [Fact]
+        public void SearchTrusts_ReturnsEmptySetOfTrustListItems_WhenNoTrustsFound()
+        {
+            var groupName = "Mockgroupname";
+            var urn = "Mockurn";
+            var companiesHouseNumber = "Mockcompanieshousenumber";
+
+            var searchTrusts = new Mock<ISearchTrusts>();
+            searchTrusts.Setup(s => s.Execute(groupName, urn, companiesHouseNumber))
+                .Returns(new List<TrustListItemResponse>());
+
+            var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
+            var result = controller.SearchTrusts(groupName, urn, companiesHouseNumber);
+
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(new List<TrustListItemResponse>()));
+        }
+
+        [Fact]
+        public void SearchTrusts_ByGroupNameAndCompaniesHouseNumber_ReturnsListOfTrustListItems_WhenTrustsAreFound()
+        {
+            var groupName = "Mockgroupname";
+            var companiesHouseNumber = "Mockcompanieshousenumber";
+
+            var expectedTrustListItems = Builder<TrustListItemResponse>.CreateListOfSize(5)
+                .All()
+                .With(g => g.GroupName = groupName)
+                .With(g => g.CompaniesHouseNumber = companiesHouseNumber)
+                .Build();
+            
+            var searchTrusts = new Mock<ISearchTrusts>();
+            searchTrusts.Setup(s => s.Execute(groupName, null, companiesHouseNumber))
+                .Returns(expectedTrustListItems);
+
+            var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
+            var result = controller.SearchTrusts(groupName, null, companiesHouseNumber);
+
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedTrustListItems));
+        }
+        
+        
+        [Fact]
+        public void SearchTrusts_ByUrn_ReturnsListOfTrustListItems_WhenTrustsAreFound()
+        {
+            var urn = "Mockurn";
+
+            var expectedTrustListItems = Builder<TrustListItemResponse>.CreateListOfSize(5)
+                .All()
+                .With(g => g.Urn = urn)
+                .Build();
+            
+            var searchTrusts = new Mock<ISearchTrusts>();
+            searchTrusts.Setup(s => s.Execute(null, urn, null))
+                .Returns(expectedTrustListItems);
+
+            var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
+            var result = controller.SearchTrusts(null, urn, null);
+
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedTrustListItems));
+        }
+
+        [Fact]
+        public void SearchTrusts_WithNoParams_ReturnsAllTrusts()
+        {
+            var expectedTrustListItems = Builder<TrustListItemResponse>.CreateListOfSize(5).Build();
+            
+            var searchTrusts = new Mock<ISearchTrusts>();
+            searchTrusts.Setup(s => s.Execute(null, null, null))
+                .Returns(expectedTrustListItems);
+
+            var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
+            var result = controller.SearchTrusts(null, null, null);
+
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedTrustListItems));
         }
     }
 }

--- a/TramsDataApi.Test/Factories/TrustListItemResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/TrustListItemResponseFactoryTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.ResponseModels;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class TrustListItemResponseFactoryTests
+    {
+        [Fact]
+        public void TrustListItemResponseFactory_CreatesTrustListItemResponse_FromGroupLink()
+        {
+            var group = Builder<GroupLink>.CreateNew().Build();
+            var expected = new TrustListItemResponse
+            {
+                Urn = group.Urn,
+                GroupName = group.GroupName,
+                CompaniesHouseNumber = group.CompaniesHouseNumber,
+                Establishments = new List<EstablishmentListItemResponse>()
+            };
+            var result = TrustListItemResponseFactory.Create(group, new List<Establishment>());
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void TrustListItemResponseFactory_ReturnsNull_WhenGroupLinkIsNull()
+        {
+            TrustListItemResponseFactory.Create(null).Should().BeNull();
+        }
+
+        [Fact]
+        public void TrustListItemResponseFactory_ReturnsTrustListItemResponse_WithEstablishmentListItemResponses()
+        {
+            var group = Builder<GroupLink>.CreateNew().Build();
+            var establishments = Builder<Establishment>.CreateListOfSize(5).Build();
+
+            var expected = new TrustListItemResponse
+            {
+                Urn = group.Urn,
+                GroupName = group.GroupName,
+                CompaniesHouseNumber = group.CompaniesHouseNumber,
+                Establishments = establishments
+                    .Select(e => new EstablishmentListItemResponse { Name = e.EstablishmentName, Urn = e.Urn.ToString() })
+                    .ToList()
+            };
+
+            var result = TrustListItemResponseFactory.Create(group, establishments);
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/TrustListItemResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/TrustListItemResponseFactoryTests.cs
@@ -29,7 +29,7 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void TrustListItemResponseFactory_ReturnsNull_WhenGroupLinkIsNull()
         {
-            TrustListItemResponseFactory.Create(null).Should().BeNull();
+            TrustListItemResponseFactory.Create(null, new List<Establishment>()).Should().BeNull();
         }
 
         [Fact]

--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -297,7 +297,10 @@ namespace TramsDataApi.Test.Integration
         [Fact]
         public async Task ShouldReturnAllTrusts_WhenSearchingTrusts_WithNoQueryParameters()
         {
-            var groupLinks = Builder<GroupLink>.CreateListOfSize(10).Build();
+            var groupLinks = Builder<GroupLink>.CreateListOfSize(10)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
+                .Build();
 
             _dbContext.GroupLink.AddRange(groupLinks);
             _dbContext.SaveChanges();
@@ -332,6 +335,8 @@ namespace TramsDataApi.Test.Integration
         {
             var groupName = "Mygroupname";
             var groupLinks = (List<GroupLink>) Builder<GroupLink>.CreateListOfSize(15)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
                 .Build();
 
             var groupLinksWithGroupName = groupLinks.GetRange(0, 5);
@@ -378,6 +383,8 @@ namespace TramsDataApi.Test.Integration
         {
             var companiesHouseNumber = "MyCompaniesHouseNumber";
             var groupLinks = (List<GroupLink>) Builder<GroupLink>.CreateListOfSize(15)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
                 .Build();
 
             var groupLinksWithCompaniesHouseNumber = groupLinks.GetRange(0, 5);
@@ -424,6 +431,8 @@ namespace TramsDataApi.Test.Integration
         {
             var urn = "mockurn";
             var groupLinks = (List<GroupLink>) Builder<GroupLink>.CreateListOfSize(15)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
                 .Build();
 
             groupLinks[0].Urn = urn;
@@ -465,6 +474,8 @@ namespace TramsDataApi.Test.Integration
             var groupName = "mockgroupname";
             
             var groupLinks = (List<GroupLink>) Builder<GroupLink>.CreateListOfSize(15)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
                 .Build();
 
             groupLinks[0].Urn = urn;
@@ -506,12 +517,15 @@ namespace TramsDataApi.Test.Integration
             var urn = "mockurn";
             
             var groupLinks = (List<GroupLink>) Builder<GroupLink>.CreateListOfSize(15)
+                .All()
+                .With(e => e.Urn = _randomGenerator.Int().ToString())
                 .Build();
             groupLinks[0].Urn = urn;
 
             var establishments = Builder<Establishment>.CreateListOfSize(4)
                 .All()
                 .With(e => e.TrustsCode = groupLinks[0].GroupUid)
+                .With(e => e.Urn = _randomGenerator.Int())
                 .Build();
             
             _dbContext.GroupLink.AddRange(groupLinks);

--- a/TramsDataApi.Test/UseCases/SearchTrustsTests.cs
+++ b/TramsDataApi.Test/UseCases/SearchTrustsTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class SearchTrustsTests
+    {
+        [Fact]
+        public void SearchTrusts_ReturnsEmptyList_WhenNoTrustsFound()
+        {
+            var groupName = "groupName";
+            var urn = "urn";
+            var companiesHouseNumber = "companiesHouseNumber";
+            
+            var gateway = new Mock<ITrustGateway>();
+            gateway.Setup(g => g.SearchGroups(groupName, urn, companiesHouseNumber))
+                .Returns(new List<GroupLink>());
+
+            var useCase = new SearchTrusts(gateway.Object);
+            var result = useCase.Execute(groupName, urn, companiesHouseNumber);
+
+            result.Should().BeEquivalentTo(new List<TrustListItemResponse>());
+        }
+
+        [Fact]
+        public void SearchTrusts_ReturnsListOfTrustListItemResponses_WhenTrustsFound()
+        {
+            var groupName = "groupName";
+
+            var expectedTrusts = Builder<GroupLink>.CreateListOfSize(10)
+                .All()
+                .With(g => g.GroupName = groupName)
+                .Build();
+
+            var gateway = new Mock<ITrustGateway>();
+            gateway.Setup(g => g.SearchGroups(groupName, null, null))
+                .Returns(expectedTrusts);
+
+            var expected = expectedTrusts.Select(e => TrustListItemResponseFactory.Create(e)).ToList();
+            var searchTrusts = new SearchTrusts(gateway.Object);
+            var result = searchTrusts.Execute(groupName, null, null);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void SearchTrusts_ShouldGetTrustsWithEstablishments_WhenTrustsAndEstablishmentsAreFound()
+        {
+            var urn = "mockurn";
+
+            var expectedTrust = Builder<GroupLink>
+                .CreateNew()
+                .With(g => g.Urn = urn)
+                .Build();
+
+            var expectedEstablishments = Builder<Establishment>.CreateListOfSize(5).All()
+                .With(e => e.TrustsCode = expectedTrust.GroupUid)
+                .Build();
+
+            var trustGateway = new Mock<ITrustGateway>();
+            var establishmentGateway = new Mock<IEstablishmentGateway>();
+
+            trustGateway.Setup(g => g.SearchGroups(null, urn, null))
+                .Returns(new List<GroupLink> {expectedTrust});
+            establishmentGateway.Setup(g => g.GetByTrustUid(expectedTrust.GroupUid))
+                .Returns(expectedEstablishments);
+
+            var expected = new List<TrustListItemResponse>
+            {
+                TrustListItemResponseFactory.Create(expectedTrust, expectedEstablishments);
+            };
+
+            var searchTrusts = new SearchTrusts(trustGateway.Object, establishmentGateway.Object);
+            var result = searchTrusts.Execute(null, urn, null);
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/EstablishmentsController.cs
+++ b/TramsDataApi/Controllers/EstablishmentsController.cs
@@ -16,7 +16,7 @@ namespace TramsDataApi.Controllers
 
         [HttpGet]
         [Route("establishment/{ukprn}")]
-        public IActionResult GetByUkprn(string ukprn)
+        public ActionResult<EstablishmentResponse> GetByUkprn(string ukprn)
         {
             var establishment = _getEstablishmentByUkprn.Execute(ukprn);
 

--- a/TramsDataApi/Controllers/TrustsController.cs
+++ b/TramsDataApi/Controllers/TrustsController.cs
@@ -10,19 +10,20 @@ using TramsDataApi.UseCases;
 namespace TramsDataApi.Controllers
 {
     [ApiController]
-    [Route("trust")]
     public class TrustsController : ControllerBase
     {
         private readonly IGetTrustByUkprn _getTrustByUkprn;
+        private readonly ISearchTrusts _searchTrusts;
 
-        public TrustsController(IGetTrustByUkprn getTrustByUkprn)
+        public TrustsController(IGetTrustByUkprn getTrustByUkprn, ISearchTrusts searchTrusts)
         {
             _getTrustByUkprn = getTrustByUkprn;
+            _searchTrusts = searchTrusts;
         }
         
         [HttpGet]
-        [Route("{ukprn}")]
-        public ActionResult<TrustResponse> Get(string ukprn)
+        [Route("trust/{ukprn}")]
+        public ActionResult<TrustResponse> GetTrustByUkprn(string ukprn)
         {
             var trust = _getTrustByUkprn.Execute(ukprn);
 
@@ -32,6 +33,15 @@ namespace TramsDataApi.Controllers
             }
 
             return Ok(trust);
+        }
+
+        [HttpGet]
+        [Route("trusts")]
+        public ActionResult<List<TrustListItemResponse>> SearchTrusts(string groupName, string urn,
+            string companiesHouseNumber)
+        {
+            var trusts = _searchTrusts.Execute(groupName, urn, companiesHouseNumber);
+            return Ok(trusts);
         }
     }
 }

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -689,7 +689,7 @@ namespace TramsDataApi.DatabaseModels
 
             modelBuilder.Entity<GroupLink>(entity =>
             {
-                entity.HasNoKey();
+                entity.HasKey(e => e.Urn);
 
                 entity.ToTable("GroupLink", "gias");
 

--- a/TramsDataApi/Factories/EstablishmentListItemResponseFactory.cs
+++ b/TramsDataApi/Factories/EstablishmentListItemResponseFactory.cs
@@ -1,0 +1,17 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.Factories
+{
+    public class EstablishmentListItemResponseFactory
+    {
+        public static EstablishmentListItemResponse Create(Establishment e)
+        {
+            return new EstablishmentListItemResponse
+            {
+                Name = e.EstablishmentName,
+                Urn = e.Urn.ToString()
+            };
+        }
+    }
+}

--- a/TramsDataApi/Factories/TrustListItemResponseFactory.cs
+++ b/TramsDataApi/Factories/TrustListItemResponseFactory.cs
@@ -9,6 +9,11 @@ namespace TramsDataApi.Factories
     {
         public static TrustListItemResponse Create(GroupLink groupLink, IList<Establishment> establishments)
         {
+            if (groupLink == null)
+            {
+                return null;
+            }
+            
             return new TrustListItemResponse
             {
                 Urn = groupLink.Urn,

--- a/TramsDataApi/Factories/TrustListItemResponseFactory.cs
+++ b/TramsDataApi/Factories/TrustListItemResponseFactory.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.Factories
+{
+    public class TrustListItemResponseFactory
+    {
+        public static TrustListItemResponse Create(GroupLink groupLink, IList<Establishment> establishments)
+        {
+            return new TrustListItemResponse
+            {
+                Urn = groupLink.Urn,
+                GroupName = groupLink.GroupName,
+                CompaniesHouseNumber = groupLink.CompaniesHouseNumber,
+                Establishments = establishments.Select(EstablishmentListItemResponseFactory.Create).ToList()
+            };
+        }
+    }
+}

--- a/TramsDataApi/Gateways/ITrustGateway.cs
+++ b/TramsDataApi/Gateways/ITrustGateway.cs
@@ -1,5 +1,5 @@
+using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
-using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Gateways
 {
@@ -7,5 +7,7 @@ namespace TramsDataApi.Gateways
     {
         public Group GetGroupByUkprn(string ukprn);
         public Trust GetIfdTrustByGroupId(string groupId);
+
+        public IList<GroupLink> SearchGroups(string groupName, string urn, string companiesHouseNumber);
     }
 }

--- a/TramsDataApi/Gateways/ITrustGateway.cs
+++ b/TramsDataApi/Gateways/ITrustGateway.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -29,7 +29,8 @@ namespace TramsDataApi.Gateways
         {
             return _dbContext.GroupLink
                 .Where(g => (
-                    (groupName == null || g.GroupName == groupName)
+                    (groupName == null || g.GroupName == groupName) &&
+                    (urn == null || g.Urn == urn)
                 ))
                 .ToList();
         }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -27,7 +27,11 @@ namespace TramsDataApi.Gateways
 
         public IList<GroupLink> SearchGroups(string groupName, string urn, string companiesHouseNumber)
         {
-            return _dbContext.GroupLink.ToList();
+            return _dbContext.GroupLink
+                .Where(g => (
+                    (groupName == null || g.GroupName == groupName)
+                ))
+                .ToList();
         }
     }
 }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -30,7 +30,8 @@ namespace TramsDataApi.Gateways
             return _dbContext.GroupLink
                 .Where(g => (
                     (groupName == null || g.GroupName == groupName) &&
-                    (urn == null || g.Urn == urn)
+                    (urn == null || g.Urn == urn) &&
+                    (companiesHouseNumber == null || g.CompaniesHouseNumber == companiesHouseNumber)
                 ))
                 .ToList();
         }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -27,7 +27,7 @@ namespace TramsDataApi.Gateways
 
         public IList<GroupLink> SearchGroups(string groupName, string urn, string companiesHouseNumber)
         {
-            throw new System.NotImplementedException();
+            return _dbContext.GroupLink.ToList();
         }
     }
 }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels;
 
@@ -22,6 +23,11 @@ namespace TramsDataApi.Gateways
         public Trust GetIfdTrustByGroupId(string groupId)
         {
             return _dbContext.Trust.FirstOrDefault(t => t.TrustRef == groupId);
+        }
+
+        public IList<GroupLink> SearchGroups(string groupName, string urn, string companiesHouseNumber)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/TramsDataApi/ResponseModels/EstablishmentListItemResponse.cs
+++ b/TramsDataApi/ResponseModels/EstablishmentListItemResponse.cs
@@ -1,0 +1,8 @@
+namespace TramsDataApi.ResponseModels
+{
+    public class EstablishmentListItemResponse
+    {
+        public string Urn { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/TramsDataApi/ResponseModels/TrustListItemResponse.cs
+++ b/TramsDataApi/ResponseModels/TrustListItemResponse.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace TramsDataApi.ResponseModels
+{
+    public class TrustListItemResponse
+    {
+        public string Urn { get; set; }
+        public string GroupName { get; set; }
+        public string CompaniesHouseNumber { get; set; }
+        public List<EstablishmentListItemResponse> Establishments { get; set; }
+    }
+}

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -40,6 +40,7 @@ namespace TramsDataApi
             services.AddScoped<IGetTrustByUkprn, GetTrustByUkprn>();
             services.AddScoped<IGetEstablishmentByUkprn, GetEstablishmentByUkprn>();
             services.AddScoped<IGetEstablishmentsByTrustUid, GetEstablishmentsByTrustUid>();
+            services.AddScoped<ISearchTrusts, SearchTrusts>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TramsDataApi/UseCases/ISearchTrusts.cs
+++ b/TramsDataApi/UseCases/ISearchTrusts.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.IO.Compression;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public interface ISearchTrusts
+    {
+        public IList<TrustListItemResponse> Execute(string groupName, string urn, string companiesHouseNumber);
+    }
+}

--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public class SearchTrusts : ISearchTrusts
+    {
+        public IList<TrustListItemResponse> Execute(string groupName, string urn, string companiesHouseNumber)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -9,16 +9,18 @@ namespace TramsDataApi.UseCases
     public class SearchTrusts : ISearchTrusts
     {
         private readonly ITrustGateway _trustGateway;
+        private readonly IEstablishmentGateway _establishmentGateway;
 
-        public SearchTrusts(ITrustGateway trustGateway)
+        public SearchTrusts(ITrustGateway trustGateway, IEstablishmentGateway establishmentGateway)
         {
             _trustGateway = trustGateway;
+            _establishmentGateway = establishmentGateway;
         }
         
         public IList<TrustListItemResponse> Execute(string groupName, string urn, string companiesHouseNumber)
         {
             return _trustGateway.SearchGroups(groupName, urn, companiesHouseNumber)
-                .Select(g => TrustListItemResponseFactory.Create(g))
+                .Select(g => TrustListItemResponseFactory.Create(g, _establishmentGateway.GetByTrustUid(g.GroupUid)))
                 .ToList();
         }
     }

--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -1,13 +1,25 @@
 using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
     public class SearchTrusts : ISearchTrusts
     {
+        private readonly ITrustGateway _trustGateway;
+
+        public SearchTrusts(ITrustGateway trustGateway)
+        {
+            _trustGateway = trustGateway;
+        }
+        
         public IList<TrustListItemResponse> Execute(string groupName, string urn, string companiesHouseNumber)
         {
-            throw new System.NotImplementedException();
+            return _trustGateway.SearchGroups(groupName, urn, companiesHouseNumber)
+                .Select(g => TrustListItemResponseFactory.Create(g))
+                .ToList();
         }
     }
 }


### PR DESCRIPTION
Adds the `/trusts` route to the API, that allows the consumer to search for a list of truncated Trust response objects by `Group Name`, `Urn` or `Companies House Number`