### PR TITLE
Added route to get establishment by URN

### DIFF
--- a/TramsDataApi.Test/Controllers/EstablishmentsControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/EstablishmentsControllerTests.cs
@@ -3,8 +3,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using TramsDataApi.Controllers;
-using TramsDataApi.DatabaseModels;
-using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.UseCases;
 using Xunit;
@@ -13,15 +12,26 @@ namespace TramsDataApi.Test.Controllers
 {
     public class EstablishmentsControllerTests
     {
+        private readonly EstablishmentsController _controller;
+        private readonly Mock<IGetEstablishmentByUkprn> _getEstablishmentByUkprn;
+        private readonly Mock<IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse>> _getEstablishmentByUrn;
+        private const string UKPRN = "mockukprn";
+        private const int URN = 123456789;
+
+        public EstablishmentsControllerTests()
+        {
+            _getEstablishmentByUkprn = new Mock<IGetEstablishmentByUkprn>();
+            _getEstablishmentByUrn = new Mock<IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse>>();
+
+            _controller = new EstablishmentsController(_getEstablishmentByUkprn.Object, _getEstablishmentByUrn.Object);
+        }
+
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsNotFoundResult_WhenNoEstablishmentFound()
         {
-            var gateway = new Mock<IGetEstablishmentByUkprn>();
-            var ukprn = "mockukprn";
-            gateway.Setup(g => g.Execute(ukprn)).Returns(() => null);
+            _getEstablishmentByUkprn.Setup(g => g.Execute(UKPRN)).Returns(() => null);
 
-            var controller = new EstablishmentsController(gateway.Object);
-            var result = controller.GetByUkprn(ukprn);
+            var result = _controller.GetByUkprn(UKPRN);
 
             result.Result.Should().BeOfType(typeof(NotFoundResult));
         }
@@ -29,14 +39,32 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsEstablishmentResponse_WhenEstablishmentFound()
         {
-            var gateway = new Mock<IGetEstablishmentByUkprn>();
-            var ukprn = "mockukprn";
-            var establishmentResponse = Builder<EstablishmentResponse>.CreateNew().With(a => a.Ukprn = ukprn).Build();
-            gateway.Setup(g => g.Execute(ukprn)).Returns(() => establishmentResponse);
+            var establishmentResponse = Builder<EstablishmentResponse>.CreateNew().With(a => a.Ukprn = UKPRN).Build();
+            _getEstablishmentByUkprn.Setup(g => g.Execute(UKPRN)).Returns(() => establishmentResponse);
 
-            var controller = new EstablishmentsController(gateway.Object);
-            var result = controller.GetByUkprn(ukprn);
+            var result = _controller.GetByUkprn(UKPRN);
             
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(establishmentResponse));
+        }
+
+        [Fact]
+        public void GetEstablishmentByUrn_ReturnsNotFoundResult_WhenNoEstablishmentFound()
+        {
+            _getEstablishmentByUrn.Setup(g => g.Execute(It.IsAny<GetEstablishmentByUrnRequest>())).Returns(() => null);
+
+            var result = _controller.GetByUrn(URN);
+
+            result.Result.Should().BeOfType(typeof(NotFoundResult));
+        }
+
+        [Fact]
+        public void GetEstablishmentByUrn_ReturnsEstablishmentResponse_WhenEstablishmentFound()
+        {
+            var establishmentResponse = Builder<EstablishmentResponse>.CreateNew().With(a => a.Urn = URN.ToString()).Build();
+            _getEstablishmentByUrn.Setup(g => g.Execute(It.Is<GetEstablishmentByUrnRequest>(req => req.URN == URN))).Returns(() => establishmentResponse);
+
+            var result = _controller.GetByUrn(URN);
+
             result.Result.Should().BeEquivalentTo(new OkObjectResult(establishmentResponse));
         }
     }

--- a/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
@@ -1,0 +1,316 @@
+﻿using AutoFixture.Xunit2;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.ResponseModels;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class EstablishmentResponseFactoryTests
+    {
+        [Theory]
+        [AutoData]
+        public void EstablishmentResponseFactory_CreatesEstablishmentResponse_FromAnEstablishment(Establishment establishment)
+        {
+            var expected = BuildExpected(establishment, null, null);
+
+            var result = EstablishmentResponseFactory.Create(establishment, null, null);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [AutoData]
+        public void EstablishmentResponseFactory_CreatesEstablishmentResponse_WithAMisEstablishment(Establishment establishment, MisEstablishments misEstablishments)
+        {
+            var expected = BuildExpected(establishment, misEstablishments, null);
+
+            var result = EstablishmentResponseFactory.Create(establishment, misEstablishments, null);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [AutoData]
+        public void EstablishmentResponseFactory_CreatesEstablishmentResponse_WithASmartData(Establishment establishment, SmartData smartData)
+        {
+            var expected = BuildExpected(establishment, null, smartData);
+
+            var result = EstablishmentResponseFactory.Create(establishment, null, smartData);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        private EstablishmentResponse BuildExpected(Establishment establishment, MisEstablishments misEstablishments, SmartData smartData)
+        {
+            var expected = new EstablishmentResponse
+            {
+                Urn = establishment.Urn.ToString(),
+                LocalAuthorityCode = establishment.LaCode,
+                LocalAuthorityName = establishment.LaName,
+                EstablishmentNumber = establishment.EstablishmentNumber,
+                EstablishmentName = establishment.EstablishmentName,
+                EstablishmentType = new NameAndCodeResponse
+                { Name = establishment.TypeOfEstablishmentName, Code = establishment.TypeOfEstablishmentCode },
+                EstablishmentTypeGroup =
+                    new NameAndCodeResponse
+                    {
+                        Name = establishment.EstablishmentTypeGroupName,
+                        Code = establishment.EstablishmentTypeGroupCode
+                    },
+                EstablishmentStatus = new NameAndCodeResponse
+                { Name = establishment.EstablishmentStatusName, Code = establishment.EstablishmentStatusCode },
+                ReasonEstablishmentOpened = new NameAndCodeResponse
+                {
+                    Name = establishment.ReasonEstablishmentOpenedName,
+                    Code = establishment.ReasonEstablishmentOpenedCode
+                },
+                OpenDate = establishment.OpenDate,
+                ReasonEstablishmentClosed = new NameAndCodeResponse
+                {
+                    Name = establishment.ReasonEstablishmentClosedName,
+                    Code = establishment.ReasonEstablishmentClosedCode
+                },
+                CloseDate = establishment.CloseDate,
+                PhaseOfEducation = new NameAndCodeResponse
+                { Name = establishment.PhaseOfEducationName, Code = establishment.PhaseOfEducationCode },
+                StatutoryLowAge = establishment.StatutoryLowAge,
+                StatutoryHighAge = establishment.StatutoryHighAge,
+                Boarders = new NameAndCodeResponse
+                { Name = establishment.BoardersName, Code = establishment.BoardersCode },
+                NurseryProvision = establishment.NurseryProvisionName,
+                OfficialSixthForm =
+                    new NameAndCodeResponse
+                    { Name = establishment.OfficialSixthFormName, Code = establishment.OfficialSixthFormCode },
+                Gender = new NameAndCodeResponse { Name = establishment.GenderName, Code = establishment.GenderCode },
+                ReligiousCharacter = new NameAndCodeResponse
+                { Name = establishment.ReligiousCharacterName, Code = establishment.ReligiousCharacterCode },
+                ReligiousEthos = establishment.ReligiousEthosName,
+                Diocese = new NameAndCodeResponse { Name = establishment.DioceseName, Code = establishment.DioceseCode },
+                AdmissionsPolicy = new NameAndCodeResponse
+                { Name = establishment.AdmissionsPolicyName, Code = establishment.AdmissionsPolicyCode },
+                SchoolCapacity = establishment.SchoolCapacity,
+                SpecialClasses = new NameAndCodeResponse
+                { Name = establishment.SpecialClassesName, Code = establishment.SpecialClassesCode },
+                Census =
+                    new CensusResponse
+                    {
+                        CensusDate = establishment.CensusDate,
+                        NumberOfPupils = establishment.NumberOfPupils,
+                        NumberOfBoys = establishment.NumberOfBoys,
+                        NumberOfGirls = establishment.NumberOfGirls,
+                        PercentageFsm = establishment.PercentageFsm
+                    },
+                TrustSchoolFlag = new NameAndCodeResponse
+                { Name = establishment.TrustSchoolFlagName, Code = establishment.TrustSchoolFlagCode },
+                Trusts = new NameAndCodeResponse { Name = establishment.TrustsName, Code = establishment.TrustsCode },
+                SchoolSponsorFlag = establishment.SchoolSponsorFlagName,
+                SchoolSponsors = establishment.SchoolSponsorsName,
+                FederationFlag = establishment.FederationFlagName,
+                Federations = new NameAndCodeResponse
+                { Name = establishment.FederationsName, Code = establishment.FederationsCode },
+                Ukprn = establishment.Ukprn,
+                FeheiIdentifier = establishment.Feheidentifier,
+                FurtherEducationType = establishment.FurtherEducationTypeName,
+                OfstedLastInspection = establishment.OfstedLastInsp,
+                OfstedSpecialMeasures = new NameAndCodeResponse
+                { Name = establishment.OfstedSpecialMeasuresName, Code = establishment.OfstedSpecialMeasuresCode },
+                LastChangedDate = establishment.LastChangedDate,
+                Address =
+                    new AddressResponse
+                    {
+                        Street = establishment.Street,
+                        Locality = establishment.Locality,
+                        AdditionalLine = establishment.Address3,
+                        Town = establishment.Town,
+                        County = establishment.CountyName,
+                        Postcode = establishment.Postcode
+                    },
+                SchoolWebsite = establishment.SchoolWebsite,
+                TelephoneNumber = establishment.TelephoneNum,
+                HeadteacherTitle = establishment.HeadTitleName,
+                HeadteacherFirstName = establishment.HeadFirstName,
+                HeadteacherLastName = establishment.HeadLastName,
+                HeadteacherPreferredJobTitle = establishment.HeadPreferredJobTitle,
+                InspectorateName = establishment.InspectorateNameName,
+                InspectorateReport = establishment.InspectorateReport,
+                DateOfLastInspectionVisit = establishment.DateOfLastInspectionVisit,
+                DateOfNextInspectionVisit = establishment.NextInspectionVisit,
+                TeenMoth = establishment.TeenMothName,
+                TeenMothPlaces = establishment.TeenMothPlaces,
+                CCF = establishment.CcfName,
+                SENPRU = establishment.SenpruName,
+                EBD = establishment.EbdName,
+                PlacesPRU = establishment.PlacesPru,
+                FTProv = establishment.FtprovName,
+                EdByOther = establishment.EdByOtherName,
+                Section14Approved = establishment.Section41ApprovedName,
+                SEN1 = establishment.Sen1Name,
+                SEN2 = establishment.Sen2Name,
+                SEN3 = establishment.Sen3Name,
+                SEN4 = establishment.Sen4Name,
+                SEN5 = establishment.Sen5Name,
+                SEN6 = establishment.Sen6Name,
+                SEN7 = establishment.Sen7Name,
+                SEN8 = establishment.Sen8Name,
+                SEN9 = establishment.Sen9Name,
+                SEN10 = establishment.Sen10Name,
+                SEN11 = establishment.Sen11Name,
+                SEN12 = establishment.Sen12Name,
+                SEN13 = establishment.Sen13Name,
+                TypeOfResourcedProvision = establishment.TypeOfResourcedProvisionName,
+                ResourcedProvisionOnRoll = establishment.ResourcedProvisionOnRoll,
+                ResourcedProvisionOnCapacity = establishment.ResourcedProvisionCapacity,
+                SenUnitOnRoll = establishment.SenUnitOnRoll,
+                SenUnitCapacity = establishment.SenUnitCapacity,
+                GOR = new NameAndCodeResponse { Name = establishment.GorName, Code = establishment.GorCode },
+                DistrictAdministrative =
+                    new NameAndCodeResponse
+                    {
+                        Name = establishment.DistrictAdministrativeName,
+                        Code = establishment.DistrictAdministrativeCode
+                    },
+                AdministractiveWard = new NameAndCodeResponse
+                { Name = establishment.AdministrativeWardName, Code = establishment.AdministrativeWardCode },
+                ParliamentaryConstituency =
+                    new NameAndCodeResponse
+                    {
+                        Name = establishment.ParliamentaryConstituencyName,
+                        Code = establishment.ParliamentaryConstituencyCode
+                    },
+                UrbanRural =
+                    new NameAndCodeResponse
+                    {
+                        Name = establishment.UrbanRuralName,
+                        Code = establishment.UrbanRuralCode
+                    },
+                GSSLACode = establishment.GsslacodeName,
+                Easting = establishment.Easting,
+                Northing = establishment.Northing,
+                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
+                MSOA = new NameAndCodeResponse { Name = establishment.MsoaName, Code = establishment.MsoaCode },
+                LSOA = new NameAndCodeResponse { Name = establishment.LsoaName, Code = establishment.LsoaCode },
+                SENStat = establishment.Senstat,
+                SENNoStat = establishment.SennoStat,
+                BoardingEstablishment = establishment.BoardingEstablishmentName,
+                PropsName = establishment.PropsName,
+                PreviousLocalAuthority = new NameAndCodeResponse
+                { Name = establishment.PreviousLaName, Code = establishment.PreviousLaCode },
+                PreviousEstablishmentNumber = establishment.PreviousEstablishmentNumber,
+                OfstedRating = establishment.OfstedRatingName,
+                RSCRegion = establishment.RscregionName,
+                Country = establishment.CountryName,
+                UPRN = establishment.Uprn,
+                MISEstablishment = null,
+                MISFurtherEducationEstablishment = null,
+                SMARTData = null,
+                Financial = null,
+                Concerns = null
+            };
+
+            if (misEstablishments != null)
+            {
+                expected.MISEstablishment = new MISEstablishmentResponse
+                {
+                    SiteName = null,
+                    WebLink = misEstablishments.WebLink,
+                    LAESTAB = misEstablishments.Laestab.ToString(),
+                    SchoolName = misEstablishments.SchoolName,
+                    OfstedPhase = misEstablishments.OfstedPhase,
+                    TypeOfEducation = misEstablishments.TypeOfEducation,
+                    SchoolOpenDate = misEstablishments.SchoolOpenDate,
+                    SixthForm = misEstablishments.SixthForm,
+                    DesignatedReligiousCharacter = misEstablishments.DesignatedReligiousCharacter,
+                    ReligiousEthos = misEstablishments.ReligiousEthos,
+                    FaithGrouping = misEstablishments.FaithGrouping,
+                    OfstedRegion = misEstablishments.OfstedRegion,
+                    Region = misEstablishments.Region,
+                    LocalAuthority = misEstablishments.LocalAuthority,
+                    ParliamentaryConstituency = misEstablishments.ParliamentaryConstituency,
+                    Postcode = misEstablishments.Postcode,
+                    IncomeDeprivationAffectingChildrenIndexQuintile =
+                    misEstablishments.TheIncomeDeprivationAffectingChildrenIndexIdaciQuintile.ToString(),
+                    TotalNumberOfPupils = misEstablishments.TotalNumberOfPupils.ToString(),
+                    LatestSection8InspectionNumberSinceLastFullInspection =
+                    misEstablishments.LatestSection8InspectionNumberSinceLastFullInspection,
+                    Section8InspectionRelatedToCurrentSchoolUrn =
+                    misEstablishments.DoesTheSection8InspectionRelateToTheUrnOfTheCurrentSchool,
+                    UrnAtTimeOfSection8Inspection = misEstablishments.UrnAtTimeOfTheSection8Inspection.ToString(),
+                    SchoolNameAtTimeOfSection8Inspection = misEstablishments.SchoolNameAtTimeOfTheLatestSection8Inspection,
+                    SchoolTypeAtTimeOfSection8Inspection = misEstablishments.SchoolTypeAtTimeOfTheLatestSection8Inspection,
+                    NumberOfSection8InspectionsSinceLastFullInspection =
+                    misEstablishments.NumberOfSection8InspectionsSinceTheLastFullInspection.ToString(),
+                    DateOfLatestSection8Inspection = misEstablishments.DateOfLatestSection8Inspection,
+                    Section8InspectionPublicationDate = misEstablishments.Section8InspectionPublicationDate,
+                    LatestSection8InspectionConvertedToFullInspection =
+                    misEstablishments.DidTheLatestSection8InspectionConvertToAFullInspection,
+                    Section8InspectionOverallOutcome = misEstablishments.Section8InspectionOverallOutcome,
+                    InspectionNumberOfLatestFullInspection = misEstablishments.InspectionNumberOfLatestFullInspection,
+                    InspectionType = misEstablishments.InspectionType,
+                    InspectionTypeGrouping = misEstablishments.InspectionTypeGrouping,
+                    InspectionStartDate = misEstablishments.InspectionStartDate,
+                    InspectionEndDate = misEstablishments.InspectionEndDate,
+                    PublicationDate = misEstablishments.PublicationDate,
+                    LatestFullInspectionRelatesToCurrentSchoolUrn =
+                    misEstablishments.DoesTheLatestFullInspectionRelateToTheUrnOfTheCurrentSchool,
+                    SchoolUrnAtTimeOfLastFullInspection = misEstablishments.UrnAtTimeOfLatestFullInspection.ToString(),
+                    LAESTABAtTimeOfLastFullInspection = misEstablishments.LaestabAtTimeOfLatestFullInspection.ToString(),
+                    SchoolNameAtTimeOfLastFullInspection = misEstablishments.SchoolNameAtTimeOfLatestFullInspection,
+                    SchoolTypeAtTimeOfLastFullInspection = misEstablishments.SchoolTypeAtTimeOfLatestFullInspection,
+                    OverallEffectiveness = misEstablishments.OverallEffectiveness.ToString(),
+                    CategoryOfConcern = misEstablishments.CategoryOfConcern,
+                    QualityOfEducation = misEstablishments.QualityOfEducation.ToString(),
+                    BehaviourAndAttitudes = misEstablishments.BehaviourAndAttitudes.ToString(),
+                    PersonalDevelopment = misEstablishments.PersonalDevelopment.ToString(),
+                    EffectivenessOfLeadershipAndManagement =
+                    misEstablishments.EffectivenessOfLeadershipAndManagement.ToString(),
+                    SafeguardingIsEffective = misEstablishments.SafeguardingIsEffective,
+                    EarlyYearsProvision = misEstablishments.EarlyYearsProvisionWhereApplicable.ToString(),
+                    SixthFormProvision = misEstablishments.SixthFormProvisionWhereApplicable.ToString(),
+                    PreviousFullInspectionNumber = misEstablishments.PreviousFullInspectionNumber,
+                    PreviousInspectionStartDate = misEstablishments.PreviousInspectionStartDate,
+                    PreviousInspectionEndDate = misEstablishments.PreviousInspectionEndDate,
+                    PreviousPublicationDate = misEstablishments.PreviousPublicationDate,
+                    PreviousFullInspectionRelatesToUrnOfCurrentSchool =
+                    misEstablishments.DoesThePreviousFullInspectionRelateToTheUrnOfTheCurrentSchool,
+                    UrnAtTheTimeOfPreviousFullInspection = misEstablishments.UrnAtTimeOfPreviousFullInspection.ToString(),
+                    LAESTABAtTheTimeOfPreviousFullInspection =
+                    misEstablishments.LaestabAtTimeOfPreviousFullInspection.ToString(),
+                    SchoolNameAtTheTimeOfPreviousFullInspection =
+                    misEstablishments.SchoolNameAtTimeOfPreviousFullInspection,
+                    SchoolTypeAtTheTimeOfPreviousFullInspection =
+                    misEstablishments.SchoolTypeAtTimeOfPreviousFullInspection,
+                    PreviousFullInspectionOverallEffectiveness =
+                    misEstablishments.PreviousFullInspectionOverallEffectiveness,
+                    PreviousCategoryOfConcern = misEstablishments.PreviousCategoryOfConcern,
+                    PreviousQualityOfEducation = misEstablishments.PreviousQualityOfEducation.ToString(),
+                    PreviousBehaviourAndAttitudes = misEstablishments.PreviousBehaviourAndAttitudes.ToString(),
+                    PreviousPersonalDevelopment = misEstablishments.PreviousPersonalDevelopment.ToString(),
+                    PreviousEffectivenessOfLeadershipAndManagement =
+                    misEstablishments.PreviousEffectivenessOfLeadershipAndManagement.ToString(),
+                    PreviousIsSafeguardingEffective = misEstablishments.PreviousSafeguardingIsEffective,
+                    PreviousEarlyYearsProvision = misEstablishments.PreviousEarlyYearsProvisionWhereApplicable.ToString(),
+                    PreviousSixthFormProvision = misEstablishments.PreviousSixthFormProvisionWhereApplicable
+                };
+            }
+
+            if (smartData != null)
+            {
+                expected.SMARTData = new SMARTDataResponse
+                {
+                    ProbabilityOfDeclining = smartData.ProbabilityOfDeclining.ToString(),
+                    ProbabilityOfStayingTheSame = smartData.ProbabilityOfStayingTheSame.ToString(),
+                    ProbabilityOfImproving = smartData.ProbabilityOfImproving.ToString(),
+                    PredictedChangeInProgress8Score = smartData.PredictedChangeInProgress8Score,
+                    PredictedChanceOfChangeOccurring = smartData.PredictedChanceOfChangeOccuring.ToString(),
+                    TotalNumberOfRisks = smartData.TotalNumberOfRisks.ToString(),
+                    TotalRiskScore = smartData.TotalRiskScore.ToString(),
+                    RiskRatingNum = smartData.RiskRatingNum.ToString()
+                };
+            }
+
+            return expected;
+        }
+    }
+}

--- a/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
@@ -3,11 +3,11 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FizzWare.NBuilder;
-using FizzWare.NBuilder.PropertyNaming;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.Test.Utils;
 using Xunit;
@@ -15,7 +15,7 @@ using Xunit;
 namespace TramsDataApi.Test.Integration
 {
     [Collection("Database")]
-    public class EstablishmentsIntegrationTests : IClassFixture<TramsDataApiFactory>
+    public class EstablishmentsIntegrationTests : IClassFixture<TramsDataApiFactory>, IDisposable
     {
         private readonly HttpClient _client;
         private readonly LegacyTramsDbContext _legacyDbContext;
@@ -24,7 +24,7 @@ namespace TramsDataApi.Test.Integration
         public EstablishmentsIntegrationTests(TramsDataApiFactory fixture)
         {
             _client = fixture.CreateClient();
-            _client.BaseAddress = new Uri("https://trams-api.com/");
+            _client.DefaultRequestHeaders.Add("ApiKey", "testing-api-key");
             _legacyDbContext = fixture.Services.GetRequiredService<LegacyTramsDbContext>();
             _randomGenerator = new RandomGenerator();
         }
@@ -32,291 +32,50 @@ namespace TramsDataApi.Test.Integration
         [Fact]
         public async Task CanGetEstablishmentByUkprn()
         {
-            var establishment = Builder<Establishment>.CreateNew()
-                .With(e => e.Ukprn = "mockukprn")
-                .With(e => e.Urn = _randomGenerator.Next(100000, 199999))
-                .Build();
-            var misEstablishment = Builder<MisEstablishments>.CreateNew().With(m => m.Urn = establishment.Urn).Build();
-            var smartData = Generators.GenerateSmartData(establishment.Urn);
-            _legacyDbContext.Establishment.Add(establishment);
-            _legacyDbContext.MisEstablishments.Add(misEstablishment);
-            _legacyDbContext.SmartData.Add(smartData);
-            _legacyDbContext.SaveChanges();
+            var urn = _randomGenerator.Next(100000, 199999);
+            var expected = AddTestData(urn);
 
-            var expectedMisEstablishmentResponse = new MISEstablishmentResponse
-            {
-                SiteName = null,
-                WebLink = misEstablishment.WebLink,
-                LAESTAB = misEstablishment.Laestab.ToString(),
-                SchoolName = misEstablishment.SchoolName,
-                OfstedPhase = misEstablishment.OfstedPhase,
-                TypeOfEducation = misEstablishment.TypeOfEducation,
-                SchoolOpenDate = misEstablishment.SchoolOpenDate,
-                SixthForm = misEstablishment.SixthForm,
-                DesignatedReligiousCharacter = misEstablishment.DesignatedReligiousCharacter,
-                ReligiousEthos = misEstablishment.ReligiousEthos,
-                FaithGrouping = misEstablishment.FaithGrouping,
-                OfstedRegion = misEstablishment.OfstedRegion,
-                Region = misEstablishment.Region,
-                LocalAuthority = misEstablishment.LocalAuthority,
-                ParliamentaryConstituency = misEstablishment.ParliamentaryConstituency,
-                Postcode = misEstablishment.Postcode,
-                IncomeDeprivationAffectingChildrenIndexQuintile =
-                    misEstablishment.TheIncomeDeprivationAffectingChildrenIndexIdaciQuintile.ToString(),
-                TotalNumberOfPupils = misEstablishment.TotalNumberOfPupils.ToString(),
-                LatestSection8InspectionNumberSinceLastFullInspection =
-                    misEstablishment.LatestSection8InspectionNumberSinceLastFullInspection,
-                Section8InspectionRelatedToCurrentSchoolUrn =
-                    misEstablishment.DoesTheSection8InspectionRelateToTheUrnOfTheCurrentSchool,
-                UrnAtTimeOfSection8Inspection = misEstablishment.UrnAtTimeOfTheSection8Inspection.ToString(),
-                SchoolNameAtTimeOfSection8Inspection = misEstablishment.SchoolNameAtTimeOfTheLatestSection8Inspection,
-                SchoolTypeAtTimeOfSection8Inspection = misEstablishment.SchoolTypeAtTimeOfTheLatestSection8Inspection,
-                NumberOfSection8InspectionsSinceLastFullInspection =
-                    misEstablishment.NumberOfSection8InspectionsSinceTheLastFullInspection.ToString(),
-                DateOfLatestSection8Inspection = misEstablishment.DateOfLatestSection8Inspection,
-                Section8InspectionPublicationDate = misEstablishment.Section8InspectionPublicationDate,
-                LatestSection8InspectionConvertedToFullInspection =
-                    misEstablishment.DidTheLatestSection8InspectionConvertToAFullInspection,
-                Section8InspectionOverallOutcome = misEstablishment.Section8InspectionOverallOutcome,
-                InspectionNumberOfLatestFullInspection = misEstablishment.InspectionNumberOfLatestFullInspection,
-                InspectionType = misEstablishment.InspectionType,
-                InspectionTypeGrouping = misEstablishment.InspectionTypeGrouping,
-                InspectionStartDate = misEstablishment.InspectionStartDate,
-                InspectionEndDate = misEstablishment.InspectionEndDate,
-                PublicationDate = misEstablishment.PublicationDate,
-                LatestFullInspectionRelatesToCurrentSchoolUrn =
-                    misEstablishment.DoesTheLatestFullInspectionRelateToTheUrnOfTheCurrentSchool,
-                SchoolUrnAtTimeOfLastFullInspection = misEstablishment.UrnAtTimeOfLatestFullInspection.ToString(),
-                LAESTABAtTimeOfLastFullInspection = misEstablishment.LaestabAtTimeOfLatestFullInspection.ToString(),
-                SchoolNameAtTimeOfLastFullInspection = misEstablishment.SchoolNameAtTimeOfLatestFullInspection,
-                SchoolTypeAtTimeOfLastFullInspection = misEstablishment.SchoolTypeAtTimeOfLatestFullInspection,
-                OverallEffectiveness = misEstablishment.OverallEffectiveness.ToString(),
-                CategoryOfConcern = misEstablishment.CategoryOfConcern,
-                QualityOfEducation = misEstablishment.QualityOfEducation.ToString(),
-                BehaviourAndAttitudes = misEstablishment.BehaviourAndAttitudes.ToString(),
-                PersonalDevelopment = misEstablishment.PersonalDevelopment.ToString(),
-                EffectivenessOfLeadershipAndManagement =
-                    misEstablishment.EffectivenessOfLeadershipAndManagement.ToString(),
-                SafeguardingIsEffective = misEstablishment.SafeguardingIsEffective,
-                EarlyYearsProvision = misEstablishment.EarlyYearsProvisionWhereApplicable.ToString(),
-                SixthFormProvision = misEstablishment.SixthFormProvisionWhereApplicable.ToString(),
-                PreviousFullInspectionNumber = misEstablishment.PreviousFullInspectionNumber,
-                PreviousInspectionStartDate = misEstablishment.PreviousInspectionStartDate,
-                PreviousInspectionEndDate = misEstablishment.PreviousInspectionEndDate,
-                PreviousPublicationDate = misEstablishment.PreviousPublicationDate,
-                PreviousFullInspectionRelatesToUrnOfCurrentSchool =
-                    misEstablishment.DoesThePreviousFullInspectionRelateToTheUrnOfTheCurrentSchool,
-                UrnAtTheTimeOfPreviousFullInspection = misEstablishment.UrnAtTimeOfPreviousFullInspection.ToString(),
-                LAESTABAtTheTimeOfPreviousFullInspection =
-                    misEstablishment.LaestabAtTimeOfPreviousFullInspection.ToString(),
-                SchoolNameAtTheTimeOfPreviousFullInspection =
-                    misEstablishment.SchoolNameAtTimeOfPreviousFullInspection,
-                SchoolTypeAtTheTimeOfPreviousFullInspection =
-                    misEstablishment.SchoolTypeAtTimeOfPreviousFullInspection,
-                PreviousFullInspectionOverallEffectiveness =
-                    misEstablishment.PreviousFullInspectionOverallEffectiveness,
-                PreviousCategoryOfConcern = misEstablishment.PreviousCategoryOfConcern,
-                PreviousQualityOfEducation = misEstablishment.PreviousQualityOfEducation.ToString(),
-                PreviousBehaviourAndAttitudes = misEstablishment.PreviousBehaviourAndAttitudes.ToString(),
-                PreviousPersonalDevelopment = misEstablishment.PreviousPersonalDevelopment.ToString(),
-                PreviousEffectivenessOfLeadershipAndManagement =
-                    misEstablishment.PreviousEffectivenessOfLeadershipAndManagement.ToString(),
-                PreviousIsSafeguardingEffective = misEstablishment.PreviousSafeguardingIsEffective,
-                PreviousEarlyYearsProvision = misEstablishment.PreviousEarlyYearsProvisionWhereApplicable.ToString(),
-                PreviousSixthFormProvision = misEstablishment.PreviousSixthFormProvisionWhereApplicable
-            };
-
-            var expectedSmartDataResponse = new SMARTDataResponse
-            {
-                ProbabilityOfDeclining = smartData.ProbabilityOfDeclining.ToString(),
-                ProbabilityOfStayingTheSame = smartData.ProbabilityOfStayingTheSame.ToString(),
-                ProbabilityOfImproving = smartData.ProbabilityOfImproving.ToString(),
-                PredictedChangeInProgress8Score = smartData.PredictedChangeInProgress8Score,
-                PredictedChanceOfChangeOccurring = smartData.PredictedChanceOfChangeOccuring.ToString(),
-                TotalNumberOfRisks = smartData.TotalNumberOfRisks.ToString(),
-                TotalRiskScore = smartData.TotalRiskScore.ToString(),
-                RiskRatingNum = smartData.RiskRatingNum.ToString()
-            };
-            
-
-            var expected = new EstablishmentResponse
-            {
-                Urn = establishment.Urn.ToString(),
-                LocalAuthorityCode = establishment.LaCode,
-                LocalAuthorityName = establishment.LaName,
-                EstablishmentNumber = establishment.EstablishmentNumber,
-                EstablishmentName = establishment.EstablishmentName,
-                EstablishmentType = new NameAndCodeResponse
-                    {Name = establishment.TypeOfEstablishmentName, Code = establishment.TypeOfEstablishmentCode},
-                EstablishmentTypeGroup =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.EstablishmentTypeGroupName, Code = establishment.EstablishmentTypeGroupCode
-                    },
-                EstablishmentStatus = new NameAndCodeResponse
-                    {Name = establishment.EstablishmentStatusName, Code = establishment.EstablishmentStatusCode},
-                ReasonEstablishmentOpened = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentOpenedName,
-                    Code = establishment.ReasonEstablishmentOpenedCode
-                },
-                OpenDate = establishment.OpenDate,
-                ReasonEstablishmentClosed = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentClosedName,
-                    Code = establishment.ReasonEstablishmentClosedCode
-                },
-                CloseDate = establishment.CloseDate,
-                PhaseOfEducation = new NameAndCodeResponse
-                    {Name = establishment.PhaseOfEducationName, Code = establishment.PhaseOfEducationCode},
-                StatutoryLowAge = establishment.StatutoryLowAge,
-                StatutoryHighAge = establishment.StatutoryHighAge,
-                Boarders = new NameAndCodeResponse
-                    {Name = establishment.BoardersName, Code = establishment.BoardersCode},
-                NurseryProvision = establishment.NurseryProvisionName,
-                OfficialSixthForm =
-                    new NameAndCodeResponse
-                        {Name = establishment.OfficialSixthFormName, Code = establishment.OfficialSixthFormCode},
-                Gender = new NameAndCodeResponse {Name = establishment.GenderName, Code = establishment.GenderCode},
-                ReligiousCharacter = new NameAndCodeResponse
-                    {Name = establishment.ReligiousCharacterName, Code = establishment.ReligiousCharacterCode},
-                ReligiousEthos = establishment.ReligiousEthosName,
-                Diocese = new NameAndCodeResponse {Name = establishment.DioceseName, Code = establishment.DioceseCode},
-                AdmissionsPolicy = new NameAndCodeResponse
-                    {Name = establishment.AdmissionsPolicyName, Code = establishment.AdmissionsPolicyCode},
-                SchoolCapacity = establishment.SchoolCapacity,
-                SpecialClasses = new NameAndCodeResponse
-                    {Name = establishment.SpecialClassesName, Code = establishment.SpecialClassesCode},
-                Census =
-                    new CensusResponse
-                    {
-                        CensusDate = establishment.CensusDate,
-                        NumberOfPupils = establishment.NumberOfPupils,
-                        NumberOfBoys = establishment.NumberOfBoys,
-                        NumberOfGirls = establishment.NumberOfGirls,
-                        PercentageFsm = establishment.PercentageFsm
-                    },
-                TrustSchoolFlag = new NameAndCodeResponse
-                    {Name = establishment.TrustSchoolFlagName, Code = establishment.TrustSchoolFlagCode},
-                Trusts = new NameAndCodeResponse {Name = establishment.TrustsName, Code = establishment.TrustsCode},
-                SchoolSponsorFlag = establishment.SchoolSponsorFlagName,
-                SchoolSponsors = establishment.SchoolSponsorsName,
-                FederationFlag = establishment.FederationFlagName,
-                Federations = new NameAndCodeResponse
-                    {Name = establishment.FederationsName, Code = establishment.FederationsCode},
-                Ukprn = establishment.Ukprn,
-                FeheiIdentifier = establishment.Feheidentifier,
-                FurtherEducationType = establishment.FurtherEducationTypeName,
-                OfstedLastInspection = establishment.OfstedLastInsp,
-                OfstedSpecialMeasures = new NameAndCodeResponse
-                    {Name = establishment.OfstedSpecialMeasuresName, Code = establishment.OfstedSpecialMeasuresCode},
-                LastChangedDate = establishment.LastChangedDate,
-                Address =
-                    new AddressResponse
-                    {
-                        Street = establishment.Street,
-                        Locality = establishment.Locality,
-                        AdditionalLine = establishment.Address3,
-                        Town = establishment.Town,
-                        County = establishment.CountyName,
-                        Postcode = establishment.Postcode
-                    },
-                SchoolWebsite = establishment.SchoolWebsite,
-                TelephoneNumber = establishment.TelephoneNum,
-                HeadteacherTitle = establishment.HeadTitleName,
-                HeadteacherFirstName = establishment.HeadFirstName,
-                HeadteacherLastName = establishment.HeadLastName,
-                HeadteacherPreferredJobTitle = establishment.HeadPreferredJobTitle,
-                InspectorateName = establishment.InspectorateNameName,
-                InspectorateReport = establishment.InspectorateReport,
-                DateOfLastInspectionVisit = establishment.DateOfLastInspectionVisit,
-                DateOfNextInspectionVisit = establishment.NextInspectionVisit,
-                TeenMoth = establishment.TeenMothName,
-                TeenMothPlaces = establishment.TeenMothPlaces,
-                CCF = establishment.CcfName,
-                SENPRU = establishment.SenpruName,
-                EBD = establishment.EbdName,
-                PlacesPRU = establishment.PlacesPru,
-                FTProv = establishment.FtprovName,
-                EdByOther = establishment.EdByOtherName,
-                Section14Approved = establishment.Section41ApprovedName,
-                SEN1 = establishment.Sen1Name,
-                SEN2 = establishment.Sen2Name,
-                SEN3 = establishment.Sen3Name,
-                SEN4 = establishment.Sen4Name,
-                SEN5 = establishment.Sen5Name,
-                SEN6 = establishment.Sen6Name,
-                SEN7 = establishment.Sen7Name,
-                SEN8 = establishment.Sen8Name,
-                SEN9 = establishment.Sen9Name,
-                SEN10 = establishment.Sen10Name,
-                SEN11 = establishment.Sen11Name,
-                SEN12 = establishment.Sen12Name,
-                SEN13 = establishment.Sen13Name,
-                TypeOfResourcedProvision = establishment.TypeOfResourcedProvisionName,
-                ResourcedProvisionOnRoll = establishment.ResourcedProvisionOnRoll,
-                ResourcedProvisionOnCapacity = establishment.ResourcedProvisionCapacity,
-                SenUnitOnRoll = establishment.SenUnitOnRoll,
-                SenUnitCapacity = establishment.SenUnitCapacity,
-                GOR = new NameAndCodeResponse {Name = establishment.GorName, Code = establishment.GorCode},
-                DistrictAdministrative =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.DistrictAdministrativeName, Code = establishment.DistrictAdministrativeCode
-                    },
-                AdministractiveWard = new NameAndCodeResponse
-                    {Name = establishment.AdministrativeWardName, Code = establishment.AdministrativeWardCode},
-                ParliamentaryConstituency =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.ParliamentaryConstituencyName,
-                        Code = establishment.ParliamentaryConstituencyCode
-                    },
-                UrbanRural =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.UrbanRuralName, Code = establishment.UrbanRuralCode
-                    },
-                GSSLACode = establishment.GsslacodeName,
-                Easting = establishment.Easting,
-                Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
-                MSOA = new NameAndCodeResponse {Name = establishment.MsoaName, Code = establishment.MsoaCode},
-                LSOA = new NameAndCodeResponse {Name = establishment.LsoaName, Code = establishment.LsoaCode},
-                SENStat = establishment.Senstat,
-                SENNoStat = establishment.SennoStat,
-                BoardingEstablishment = establishment.BoardingEstablishmentName,
-                PropsName = establishment.PropsName,
-                PreviousLocalAuthority = new NameAndCodeResponse
-                    {Name = establishment.PreviousLaName, Code = establishment.PreviousLaCode},
-                PreviousEstablishmentNumber = establishment.PreviousEstablishmentNumber,
-                OfstedRating = establishment.OfstedRatingName,
-                RSCRegion = establishment.RscregionName,
-                Country = establishment.CountryName,
-                UPRN = establishment.Uprn,
-                MISEstablishment = expectedMisEstablishmentResponse,
-                MISFurtherEducationEstablishment = null,
-                SMARTData = expectedSmartDataResponse,
-                Financial = null,
-                Concerns = null
-            };
-
-            var httpRequestMessage = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri("https://trams-api.com/establishment/mockukprn"),
-                Headers = { 
-                    { "ApiKey", "testing-api-key" }
-                }
-            };
-
-            var response = await _client.SendAsync(httpRequestMessage);
+            var response = await _client.GetAsync("/establishment/mockukprn");
             var jsonString = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<EstablishmentResponse>(jsonString);
             
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             result.Should().BeEquivalentTo(expected);
-            
+        }
+
+        [Fact]
+        public async Task CanGetEstablishmentByUrn()
+        {
+            var urn = _randomGenerator.Next(100000, 199999);
+            var expected = AddTestData(urn);
+
+            var response = await _client.GetAsync($"/establishment/urn/{urn}");
+            var jsonString = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<EstablishmentResponse>(jsonString);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        private EstablishmentResponse AddTestData(int urn)
+        {
+            var establishment = Builder<Establishment>.CreateNew()
+                .With(e => e.Ukprn = "mockukprn")
+                .With(e => e.Urn = urn)
+                .Build();
+            var misEstablishment = Builder<MisEstablishments>.CreateNew().With(m => m.Urn = establishment.Urn).Build();
+            var smartData = Generators.GenerateSmartData(establishment.Urn);
+
+            _legacyDbContext.Establishment.Add(establishment);
+            _legacyDbContext.MisEstablishments.Add(misEstablishment);
+            _legacyDbContext.SmartData.Add(smartData);
+            _legacyDbContext.SaveChanges();
+
+            return EstablishmentResponseFactory.Create(establishment, misEstablishment, smartData);
+        }
+
+        public void Dispose()
+        {
             _legacyDbContext.Establishment.RemoveRange(_legacyDbContext.Establishment);
             _legacyDbContext.MisEstablishments.RemoveRange(_legacyDbContext.MisEstablishments);
             _legacyDbContext.SmartData.RemoveRange(_legacyDbContext.SmartData);

--- a/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
@@ -14,7 +14,7 @@ namespace TramsDataApi.Test.UseCases
 {
     public class GetEstablishmentByUkprnTests
     {
-        private readonly GetEstablishmentByUkprn _useCase;
+        private readonly GetEstablishment _useCase;
         private readonly Mock<IEstablishmentGateway> _establishmentGateway;
 
         private const string UKPRN = "mockukprn";
@@ -25,7 +25,7 @@ namespace TramsDataApi.Test.UseCases
             BuilderSetup.SetDefaultPropertyName(new RandomValuePropertyNamer(new BuilderSettings()));
 
             _establishmentGateway = new Mock<IEstablishmentGateway>();
-            _useCase = new GetEstablishmentByUkprn(_establishmentGateway.Object);
+            _useCase = new GetEstablishment(_establishmentGateway.Object);
         }
         
         [Fact]

--- a/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
@@ -3,7 +3,9 @@ using FizzWare.NBuilder.PropertyNaming;
 using FluentAssertions;
 using Moq;
 using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.UseCases;
 using Xunit;
@@ -12,195 +14,38 @@ namespace TramsDataApi.Test.UseCases
 {
     public class GetEstablishmentByUkprnTests
     {
+        private readonly GetEstablishmentByUkprn _useCase;
+        private readonly Mock<IEstablishmentGateway> _establishmentGateway;
+
+        private const string UKPRN = "mockukprn";
+        private const int URN = 123456789;
+
         public GetEstablishmentByUkprnTests()
         {
             BuilderSetup.SetDefaultPropertyName(new RandomValuePropertyNamer(new BuilderSettings()));
+
+            _establishmentGateway = new Mock<IEstablishmentGateway>();
+            _useCase = new GetEstablishmentByUkprn(_establishmentGateway.Object);
         }
         
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsNull_WhenNoEstablishmentsAreFound()
         {
-            var ukprn = "mockukprn";
-            var establishmentsGateway = new Mock<IEstablishmentGateway>();
-            establishmentsGateway.Setup(gateway => gateway.GetByUkprn(ukprn)).Returns(() => null);
+            _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(() => null);
 
-            var useCase = new GetEstablishmentByUkprn(establishmentsGateway.Object);
-            useCase.Execute(ukprn).Should().BeNull();
+            _useCase.Execute(UKPRN).Should().BeNull();
         }
 
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsEstablishment_WhenAnEstablishmentIsFound()
         {
-            var ukprn = "mockukprn";
-            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = ukprn).Build();
-            var establishmentGateway = new Mock<IEstablishmentGateway>();
+            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = UKPRN).Build();
 
-            establishmentGateway.Setup(gateway => gateway.GetByUkprn(ukprn)).Returns(establishment);
-            
-            var expected = new EstablishmentResponse
-            {
-                Urn = establishment.Urn.ToString(),
-                LocalAuthorityCode = establishment.LaCode,
-                LocalAuthorityName = establishment.LaName,
-                EstablishmentNumber = establishment.EstablishmentNumber,
-                EstablishmentName = establishment.EstablishmentName,
-                EstablishmentType = new NameAndCodeResponse
-                    {Name = establishment.TypeOfEstablishmentName, Code = establishment.TypeOfEstablishmentCode},
-                EstablishmentTypeGroup =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.EstablishmentTypeGroupName, Code = establishment.EstablishmentTypeGroupCode
-                    },
-                EstablishmentStatus = new NameAndCodeResponse
-                    {Name = establishment.EstablishmentStatusName, Code = establishment.EstablishmentStatusCode},
-                ReasonEstablishmentOpened = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentOpenedName,
-                    Code = establishment.ReasonEstablishmentOpenedCode
-                },
-                OpenDate = establishment.OpenDate,
-                ReasonEstablishmentClosed = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentClosedName,
-                    Code = establishment.ReasonEstablishmentClosedCode
-                },
-                CloseDate = establishment.CloseDate,
-                PhaseOfEducation = new NameAndCodeResponse
-                    {Name = establishment.PhaseOfEducationName, Code = establishment.PhaseOfEducationCode},
-                StatutoryLowAge = establishment.StatutoryLowAge,
-                StatutoryHighAge = establishment.StatutoryHighAge,
-                Boarders = new NameAndCodeResponse
-                    {Name = establishment.BoardersName, Code = establishment.BoardersCode},
-                NurseryProvision = establishment.NurseryProvisionName,
-                OfficialSixthForm =
-                    new NameAndCodeResponse
-                        {Name = establishment.OfficialSixthFormName, Code = establishment.OfficialSixthFormCode},
-                Gender = new NameAndCodeResponse {Name = establishment.GenderName, Code = establishment.GenderCode},
-                ReligiousCharacter = new NameAndCodeResponse
-                    {Name = establishment.ReligiousCharacterName, Code = establishment.ReligiousCharacterCode},
-                ReligiousEthos = establishment.ReligiousEthosName,
-                Diocese = new NameAndCodeResponse {Name = establishment.DioceseName, Code = establishment.DioceseCode},
-                AdmissionsPolicy = new NameAndCodeResponse
-                    {Name = establishment.AdmissionsPolicyName, Code = establishment.AdmissionsPolicyCode},
-                SchoolCapacity = establishment.SchoolCapacity,
-                SpecialClasses = new NameAndCodeResponse
-                    {Name = establishment.SpecialClassesName, Code = establishment.SpecialClassesCode},
-                Census =
-                    new CensusResponse
-                    {
-                        CensusDate = establishment.CensusDate,
-                        NumberOfPupils = establishment.NumberOfPupils,
-                        NumberOfBoys = establishment.NumberOfBoys,
-                        NumberOfGirls = establishment.NumberOfGirls,
-                        PercentageFsm = establishment.PercentageFsm
-                    },
-                TrustSchoolFlag = new NameAndCodeResponse
-                    {Name = establishment.TrustSchoolFlagName, Code = establishment.TrustSchoolFlagCode},
-                Trusts = new NameAndCodeResponse {Name = establishment.TrustsName, Code = establishment.TrustsCode},
-                SchoolSponsorFlag = establishment.SchoolSponsorFlagName,
-                SchoolSponsors = establishment.SchoolSponsorsName,
-                FederationFlag = establishment.FederationFlagName,
-                Federations = new NameAndCodeResponse
-                    {Name = establishment.FederationsName, Code = establishment.FederationsCode},
-                Ukprn = establishment.Ukprn,
-                FeheiIdentifier = establishment.Feheidentifier,
-                FurtherEducationType = establishment.FurtherEducationTypeName,
-                OfstedLastInspection = establishment.OfstedLastInsp,
-                OfstedSpecialMeasures = new NameAndCodeResponse
-                    {Name = establishment.OfstedSpecialMeasuresName, Code = establishment.OfstedSpecialMeasuresCode},
-                LastChangedDate = establishment.LastChangedDate,
-                Address =
-                    new AddressResponse
-                    {
-                        Street = establishment.Street,
-                        Locality = establishment.Locality,
-                        AdditionalLine = establishment.Address3,
-                        Town = establishment.Town,
-                        County = establishment.CountyName,
-                        Postcode = establishment.Postcode
-                    },
-                SchoolWebsite = establishment.SchoolWebsite,
-                TelephoneNumber = establishment.TelephoneNum,
-                HeadteacherTitle = establishment.HeadTitleName,
-                HeadteacherFirstName = establishment.HeadFirstName,
-                HeadteacherLastName = establishment.HeadLastName,
-                HeadteacherPreferredJobTitle = establishment.HeadPreferredJobTitle,
-                InspectorateName = establishment.InspectorateNameName,
-                InspectorateReport = establishment.InspectorateReport,
-                DateOfLastInspectionVisit = establishment.DateOfLastInspectionVisit,
-                DateOfNextInspectionVisit = establishment.NextInspectionVisit,
-                TeenMoth = establishment.TeenMothName,
-                TeenMothPlaces = establishment.TeenMothPlaces,
-                CCF = establishment.CcfName,
-                SENPRU = establishment.SenpruName,
-                EBD = establishment.EbdName,
-                PlacesPRU = establishment.PlacesPru,
-                FTProv = establishment.FtprovName,
-                EdByOther = establishment.EdByOtherName,
-                Section14Approved = establishment.Section41ApprovedName,
-                SEN1 = establishment.Sen1Name,
-                SEN2 = establishment.Sen2Name,
-                SEN3 = establishment.Sen3Name,
-                SEN4 = establishment.Sen4Name,
-                SEN5 = establishment.Sen5Name,
-                SEN6 = establishment.Sen6Name,
-                SEN7 = establishment.Sen7Name,
-                SEN8 = establishment.Sen8Name,
-                SEN9 = establishment.Sen9Name,
-                SEN10 = establishment.Sen10Name,
-                SEN11 = establishment.Sen11Name,
-                SEN12 = establishment.Sen12Name,
-                SEN13 = establishment.Sen13Name,
-                TypeOfResourcedProvision = establishment.TypeOfResourcedProvisionName,
-                ResourcedProvisionOnRoll = establishment.ResourcedProvisionOnRoll,
-                ResourcedProvisionOnCapacity = establishment.ResourcedProvisionCapacity,
-                SenUnitOnRoll = establishment.SenUnitOnRoll,
-                SenUnitCapacity = establishment.SenUnitCapacity,
-                GOR = new NameAndCodeResponse {Name = establishment.GorName, Code = establishment.GorCode},
-                DistrictAdministrative =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.DistrictAdministrativeName, Code = establishment.DistrictAdministrativeCode
-                    },
-                AdministractiveWard = new NameAndCodeResponse
-                    {Name = establishment.AdministrativeWardName, Code = establishment.AdministrativeWardCode},
-                ParliamentaryConstituency =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.ParliamentaryConstituencyName,
-                        Code = establishment.ParliamentaryConstituencyCode
-                    },
-                UrbanRural =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.UrbanRuralName, Code = establishment.UrbanRuralCode
-                    },
-                GSSLACode = establishment.GsslacodeName,
-                Easting = establishment.Easting,
-                Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
-                MSOA = new NameAndCodeResponse {Name = establishment.MsoaName, Code = establishment.MsoaCode},
-                LSOA = new NameAndCodeResponse {Name = establishment.LsoaName, Code = establishment.LsoaCode},
-                SENStat = establishment.Senstat,
-                SENNoStat = establishment.SennoStat,
-                BoardingEstablishment = establishment.BoardingEstablishmentName,
-                PropsName = establishment.PropsName,
-                PreviousLocalAuthority = new NameAndCodeResponse
-                    {Name = establishment.PreviousLaName, Code = establishment.PreviousLaCode},
-                PreviousEstablishmentNumber = establishment.PreviousEstablishmentNumber,
-                OfstedRating = establishment.OfstedRatingName,
-                RSCRegion = establishment.RscregionName,
-                Country = establishment.CountryName,
-                UPRN = establishment.Uprn,
-                MISEstablishment = null,
-                MISFurtherEducationEstablishment = null,
-                SMARTData = null,
-                Financial = null,
-                Concerns = null
-            };
+            _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
 
-            var useCase = new GetEstablishmentByUkprn(establishmentGateway.Object);
-            var result = useCase.Execute(ukprn);
+            var expected = EstablishmentResponseFactory.Create(establishment, null, null);
+
+            var result = _useCase.Execute(UKPRN);
             
             result.Should().BeEquivalentTo(expected);
         }
@@ -208,259 +53,15 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsEstablishmentWithMisEstablishment_WhenMisEstablishmentDataIsFound()
         {
-            var ukprn = "mockukprn";
-            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = ukprn).Build();
+            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = UKPRN).Build();
             var misEstablishment = Builder<MisEstablishments>.CreateNew().With(m => m.Urn = establishment.Urn).Build();
-            var establishmentGateway = new Mock<IEstablishmentGateway>();
-            
-            establishmentGateway.Setup(gateway => gateway.GetByUkprn(ukprn)).Returns(establishment);
-            establishmentGateway.Setup(gateway => gateway.GetMisEstablishmentByUrn(establishment.Urn)).Returns(misEstablishment);
-            
-            var expected = new EstablishmentResponse
-            {
-                Urn = establishment.Urn.ToString(),
-                LocalAuthorityCode = establishment.LaCode,
-                LocalAuthorityName = establishment.LaName,
-                EstablishmentNumber = establishment.EstablishmentNumber,
-                EstablishmentName = establishment.EstablishmentName,
-                EstablishmentType = new NameAndCodeResponse
-                    {Name = establishment.TypeOfEstablishmentName, Code = establishment.TypeOfEstablishmentCode},
-                EstablishmentTypeGroup =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.EstablishmentTypeGroupName, Code = establishment.EstablishmentTypeGroupCode
-                    },
-                EstablishmentStatus = new NameAndCodeResponse
-                    {Name = establishment.EstablishmentStatusName, Code = establishment.EstablishmentStatusCode},
-                ReasonEstablishmentOpened = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentOpenedName,
-                    Code = establishment.ReasonEstablishmentOpenedCode
-                },
-                OpenDate = establishment.OpenDate,
-                ReasonEstablishmentClosed = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentClosedName,
-                    Code = establishment.ReasonEstablishmentClosedCode
-                },
-                CloseDate = establishment.CloseDate,
-                PhaseOfEducation = new NameAndCodeResponse
-                    {Name = establishment.PhaseOfEducationName, Code = establishment.PhaseOfEducationCode},
-                StatutoryLowAge = establishment.StatutoryLowAge,
-                StatutoryHighAge = establishment.StatutoryHighAge,
-                Boarders = new NameAndCodeResponse
-                    {Name = establishment.BoardersName, Code = establishment.BoardersCode},
-                NurseryProvision = establishment.NurseryProvisionName,
-                OfficialSixthForm =
-                    new NameAndCodeResponse
-                        {Name = establishment.OfficialSixthFormName, Code = establishment.OfficialSixthFormCode},
-                Gender = new NameAndCodeResponse {Name = establishment.GenderName, Code = establishment.GenderCode},
-                ReligiousCharacter = new NameAndCodeResponse
-                    {Name = establishment.ReligiousCharacterName, Code = establishment.ReligiousCharacterCode},
-                ReligiousEthos = establishment.ReligiousEthosName,
-                Diocese = new NameAndCodeResponse {Name = establishment.DioceseName, Code = establishment.DioceseCode},
-                AdmissionsPolicy = new NameAndCodeResponse
-                    {Name = establishment.AdmissionsPolicyName, Code = establishment.AdmissionsPolicyCode},
-                SchoolCapacity = establishment.SchoolCapacity,
-                SpecialClasses = new NameAndCodeResponse
-                    {Name = establishment.SpecialClassesName, Code = establishment.SpecialClassesCode},
-                Census =
-                    new CensusResponse
-                    {
-                        CensusDate = establishment.CensusDate,
-                        NumberOfPupils = establishment.NumberOfPupils,
-                        NumberOfBoys = establishment.NumberOfBoys,
-                        NumberOfGirls = establishment.NumberOfGirls,
-                        PercentageFsm = establishment.PercentageFsm
-                    },
-                TrustSchoolFlag = new NameAndCodeResponse
-                    {Name = establishment.TrustSchoolFlagName, Code = establishment.TrustSchoolFlagCode},
-                Trusts = new NameAndCodeResponse {Name = establishment.TrustsName, Code = establishment.TrustsCode},
-                SchoolSponsorFlag = establishment.SchoolSponsorFlagName,
-                SchoolSponsors = establishment.SchoolSponsorsName,
-                FederationFlag = establishment.FederationFlagName,
-                Federations = new NameAndCodeResponse
-                    {Name = establishment.FederationsName, Code = establishment.FederationsCode},
-                Ukprn = establishment.Ukprn,
-                FeheiIdentifier = establishment.Feheidentifier,
-                FurtherEducationType = establishment.FurtherEducationTypeName,
-                OfstedLastInspection = establishment.OfstedLastInsp,
-                OfstedSpecialMeasures = new NameAndCodeResponse
-                    {Name = establishment.OfstedSpecialMeasuresName, Code = establishment.OfstedSpecialMeasuresCode},
-                LastChangedDate = establishment.LastChangedDate,
-                Address =
-                    new AddressResponse
-                    {
-                        Street = establishment.Street,
-                        Locality = establishment.Locality,
-                        AdditionalLine = establishment.Address3,
-                        Town = establishment.Town,
-                        County = establishment.CountyName,
-                        Postcode = establishment.Postcode
-                    },
-                SchoolWebsite = establishment.SchoolWebsite,
-                TelephoneNumber = establishment.TelephoneNum,
-                HeadteacherTitle = establishment.HeadTitleName,
-                HeadteacherFirstName = establishment.HeadFirstName,
-                HeadteacherLastName = establishment.HeadLastName,
-                HeadteacherPreferredJobTitle = establishment.HeadPreferredJobTitle,
-                InspectorateName = establishment.InspectorateNameName,
-                InspectorateReport = establishment.InspectorateReport,
-                DateOfLastInspectionVisit = establishment.DateOfLastInspectionVisit,
-                DateOfNextInspectionVisit = establishment.NextInspectionVisit,
-                TeenMoth = establishment.TeenMothName,
-                TeenMothPlaces = establishment.TeenMothPlaces,
-                CCF = establishment.CcfName,
-                SENPRU = establishment.SenpruName,
-                EBD = establishment.EbdName,
-                PlacesPRU = establishment.PlacesPru,
-                FTProv = establishment.FtprovName,
-                EdByOther = establishment.EdByOtherName,
-                Section14Approved = establishment.Section41ApprovedName,
-                SEN1 = establishment.Sen1Name,
-                SEN2 = establishment.Sen2Name,
-                SEN3 = establishment.Sen3Name,
-                SEN4 = establishment.Sen4Name,
-                SEN5 = establishment.Sen5Name,
-                SEN6 = establishment.Sen6Name,
-                SEN7 = establishment.Sen7Name,
-                SEN8 = establishment.Sen8Name,
-                SEN9 = establishment.Sen9Name,
-                SEN10 = establishment.Sen10Name,
-                SEN11 = establishment.Sen11Name,
-                SEN12 = establishment.Sen12Name,
-                SEN13 = establishment.Sen13Name,
-                TypeOfResourcedProvision = establishment.TypeOfResourcedProvisionName,
-                ResourcedProvisionOnRoll = establishment.ResourcedProvisionOnRoll,
-                ResourcedProvisionOnCapacity = establishment.ResourcedProvisionCapacity,
-                SenUnitOnRoll = establishment.SenUnitOnRoll,
-                SenUnitCapacity = establishment.SenUnitCapacity,
-                GOR = new NameAndCodeResponse {Name = establishment.GorName, Code = establishment.GorCode},
-                DistrictAdministrative =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.DistrictAdministrativeName, Code = establishment.DistrictAdministrativeCode
-                    },
-                AdministractiveWard = new NameAndCodeResponse
-                    {Name = establishment.AdministrativeWardName, Code = establishment.AdministrativeWardCode},
-                ParliamentaryConstituency =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.ParliamentaryConstituencyName,
-                        Code = establishment.ParliamentaryConstituencyCode
-                    },
-                UrbanRural =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.UrbanRuralName, Code = establishment.UrbanRuralCode
-                    },
-                GSSLACode = establishment.GsslacodeName,
-                Easting = establishment.Easting,
-                Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
-                MSOA = new NameAndCodeResponse {Name = establishment.MsoaName, Code = establishment.MsoaCode},
-                LSOA = new NameAndCodeResponse {Name = establishment.LsoaName, Code = establishment.LsoaCode},
-                SENStat = establishment.Senstat,
-                SENNoStat = establishment.SennoStat,
-                BoardingEstablishment = establishment.BoardingEstablishmentName,
-                PropsName = establishment.PropsName,
-                PreviousLocalAuthority = new NameAndCodeResponse
-                    {Name = establishment.PreviousLaName, Code = establishment.PreviousLaCode},
-                PreviousEstablishmentNumber = establishment.PreviousEstablishmentNumber,
-                OfstedRating = establishment.OfstedRatingName,
-                RSCRegion = establishment.RscregionName,
-                Country = establishment.CountryName,
-                UPRN = establishment.Uprn,
-                MISEstablishment = new MISEstablishmentResponse
-                {
-                    SiteName = null,
-                    WebLink = misEstablishment.WebLink,
-                    LAESTAB = misEstablishment.Laestab.ToString(),
-                    SchoolName = misEstablishment.SchoolName,
-                    OfstedPhase = misEstablishment.OfstedPhase,
-                    TypeOfEducation = misEstablishment.TypeOfEducation,
-                    SchoolOpenDate = misEstablishment.SchoolOpenDate,
-                    SixthForm = misEstablishment.SixthForm,
-                    DesignatedReligiousCharacter = misEstablishment.DesignatedReligiousCharacter,
-                    ReligiousEthos = misEstablishment.ReligiousEthos,
-                    FaithGrouping = misEstablishment.FaithGrouping,
-                    OfstedRegion = misEstablishment.OfstedRegion,
-                    Region = misEstablishment.Region,
-                    LocalAuthority = misEstablishment.LocalAuthority,
-                    ParliamentaryConstituency = misEstablishment.ParliamentaryConstituency,
-                    Postcode = misEstablishment.Postcode,
-                    IncomeDeprivationAffectingChildrenIndexQuintile =
-                        misEstablishment.TheIncomeDeprivationAffectingChildrenIndexIdaciQuintile.ToString(),
-                    TotalNumberOfPupils = misEstablishment.TotalNumberOfPupils.ToString(),
-                    LatestSection8InspectionNumberSinceLastFullInspection =
-                        misEstablishment.LatestSection8InspectionNumberSinceLastFullInspection,
-                    Section8InspectionRelatedToCurrentSchoolUrn =
-                        misEstablishment.DoesTheSection8InspectionRelateToTheUrnOfTheCurrentSchool,
-                    UrnAtTimeOfSection8Inspection = misEstablishment.UrnAtTimeOfTheSection8Inspection.ToString(),
-                    SchoolNameAtTimeOfSection8Inspection = misEstablishment.SchoolNameAtTimeOfTheLatestSection8Inspection,
-                    SchoolTypeAtTimeOfSection8Inspection = misEstablishment.SchoolTypeAtTimeOfTheLatestSection8Inspection,
-                    NumberOfSection8InspectionsSinceLastFullInspection =
-                        misEstablishment.NumberOfSection8InspectionsSinceTheLastFullInspection.ToString(),
-                    DateOfLatestSection8Inspection = misEstablishment.DateOfLatestSection8Inspection,
-                    Section8InspectionPublicationDate = misEstablishment.Section8InspectionPublicationDate,
-                    LatestSection8InspectionConvertedToFullInspection =
-                        misEstablishment.DidTheLatestSection8InspectionConvertToAFullInspection,
-                    Section8InspectionOverallOutcome = misEstablishment.Section8InspectionOverallOutcome,
-                    InspectionNumberOfLatestFullInspection = misEstablishment.InspectionNumberOfLatestFullInspection,
-                    InspectionType = misEstablishment.InspectionType,
-                    InspectionTypeGrouping = misEstablishment.InspectionTypeGrouping,
-                    InspectionStartDate = misEstablishment.InspectionStartDate,
-                    InspectionEndDate = misEstablishment.InspectionEndDate,
-                    PublicationDate = misEstablishment.PublicationDate,
-                    LatestFullInspectionRelatesToCurrentSchoolUrn =
-                        misEstablishment.DoesTheLatestFullInspectionRelateToTheUrnOfTheCurrentSchool,
-                    SchoolUrnAtTimeOfLastFullInspection = misEstablishment.UrnAtTimeOfLatestFullInspection.ToString(),
-                    LAESTABAtTimeOfLastFullInspection = misEstablishment.LaestabAtTimeOfLatestFullInspection.ToString(),
-                    SchoolNameAtTimeOfLastFullInspection = misEstablishment.SchoolNameAtTimeOfLatestFullInspection,
-                    SchoolTypeAtTimeOfLastFullInspection = misEstablishment.SchoolTypeAtTimeOfLatestFullInspection,
-                    OverallEffectiveness = misEstablishment.OverallEffectiveness.ToString(),
-                    CategoryOfConcern = misEstablishment.CategoryOfConcern,
-                    QualityOfEducation = misEstablishment.QualityOfEducation.ToString(),
-                    BehaviourAndAttitudes = misEstablishment.BehaviourAndAttitudes.ToString(),
-                    PersonalDevelopment = misEstablishment.PersonalDevelopment.ToString(),
-                    EffectivenessOfLeadershipAndManagement =
-                        misEstablishment.EffectivenessOfLeadershipAndManagement.ToString(),
-                    SafeguardingIsEffective = misEstablishment.SafeguardingIsEffective,
-                    EarlyYearsProvision = misEstablishment.EarlyYearsProvisionWhereApplicable.ToString(),
-                    SixthFormProvision = misEstablishment.SixthFormProvisionWhereApplicable.ToString(),
-                    PreviousFullInspectionNumber = misEstablishment.PreviousFullInspectionNumber,
-                    PreviousInspectionStartDate = misEstablishment.PreviousInspectionStartDate,
-                    PreviousInspectionEndDate = misEstablishment.PreviousInspectionEndDate,
-                    PreviousPublicationDate = misEstablishment.PreviousPublicationDate,
-                    PreviousFullInspectionRelatesToUrnOfCurrentSchool =
-                        misEstablishment.DoesThePreviousFullInspectionRelateToTheUrnOfTheCurrentSchool,
-                    UrnAtTheTimeOfPreviousFullInspection = misEstablishment.UrnAtTimeOfPreviousFullInspection.ToString(),
-                    LAESTABAtTheTimeOfPreviousFullInspection =
-                        misEstablishment.LaestabAtTimeOfPreviousFullInspection.ToString(),
-                    SchoolNameAtTheTimeOfPreviousFullInspection =
-                        misEstablishment.SchoolNameAtTimeOfPreviousFullInspection,
-                    SchoolTypeAtTheTimeOfPreviousFullInspection =
-                        misEstablishment.SchoolTypeAtTimeOfPreviousFullInspection,
-                    PreviousFullInspectionOverallEffectiveness =
-                        misEstablishment.PreviousFullInspectionOverallEffectiveness,
-                    PreviousCategoryOfConcern = misEstablishment.PreviousCategoryOfConcern,
-                    PreviousQualityOfEducation = misEstablishment.PreviousQualityOfEducation.ToString(),
-                    PreviousBehaviourAndAttitudes = misEstablishment.PreviousBehaviourAndAttitudes.ToString(),
-                    PreviousPersonalDevelopment = misEstablishment.PreviousPersonalDevelopment.ToString(),
-                    PreviousEffectivenessOfLeadershipAndManagement =
-                        misEstablishment.PreviousEffectivenessOfLeadershipAndManagement.ToString(),
-                    PreviousIsSafeguardingEffective = misEstablishment.PreviousSafeguardingIsEffective,
-                    PreviousEarlyYearsProvision = misEstablishment.PreviousEarlyYearsProvisionWhereApplicable.ToString(),
-                    PreviousSixthFormProvision = misEstablishment.PreviousSixthFormProvisionWhereApplicable
-                },
-                MISFurtherEducationEstablishment = null,
-                SMARTData = null,
-                Financial = null,
-                Concerns = null
-            };
 
-            var useCase = new GetEstablishmentByUkprn(establishmentGateway.Object);
-            var result = useCase.Execute(ukprn);
+            _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
+            _establishmentGateway.Setup(gateway => gateway.GetMisEstablishmentByUrn(establishment.Urn)).Returns(misEstablishment);
+
+            var expected = EstablishmentResponseFactory.Create(establishment, misEstablishment, null);
+            
+            var result = _useCase.Execute(UKPRN);
             
             result.Should().BeEquivalentTo(expected);
         }
@@ -468,192 +69,39 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetEstablishmentByUkprn_ReturnsEstablishmentWithSmartData_WhenSmartDataIsFound()
         {
-            var ukprn = "mockukprn";
-            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = ukprn).Build();
+            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = UKPRN).Build();
             var smartData = Builder<SmartData>.CreateNew().With(s => s.Urn = establishment.Urn.ToString()).Build();
-            var establishmentGateway = new Mock<IEstablishmentGateway>();
-            
-            establishmentGateway.Setup(gateway => gateway.GetByUkprn(ukprn)).Returns(establishment);
-            establishmentGateway.Setup(gateway => gateway.GetSmartDataByUrn(establishment.Urn)).Returns(smartData);
-            
-            var expected = new EstablishmentResponse
-            {
-                Urn = establishment.Urn.ToString(),
-                LocalAuthorityCode = establishment.LaCode,
-                LocalAuthorityName = establishment.LaName,
-                EstablishmentNumber = establishment.EstablishmentNumber,
-                EstablishmentName = establishment.EstablishmentName,
-                EstablishmentType = new NameAndCodeResponse
-                    {Name = establishment.TypeOfEstablishmentName, Code = establishment.TypeOfEstablishmentCode},
-                EstablishmentTypeGroup =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.EstablishmentTypeGroupName, Code = establishment.EstablishmentTypeGroupCode
-                    },
-                EstablishmentStatus = new NameAndCodeResponse
-                    {Name = establishment.EstablishmentStatusName, Code = establishment.EstablishmentStatusCode},
-                ReasonEstablishmentOpened = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentOpenedName,
-                    Code = establishment.ReasonEstablishmentOpenedCode
-                },
-                OpenDate = establishment.OpenDate,
-                ReasonEstablishmentClosed = new NameAndCodeResponse
-                {
-                    Name = establishment.ReasonEstablishmentClosedName,
-                    Code = establishment.ReasonEstablishmentClosedCode
-                },
-                CloseDate = establishment.CloseDate,
-                PhaseOfEducation = new NameAndCodeResponse
-                    {Name = establishment.PhaseOfEducationName, Code = establishment.PhaseOfEducationCode},
-                StatutoryLowAge = establishment.StatutoryLowAge,
-                StatutoryHighAge = establishment.StatutoryHighAge,
-                Boarders = new NameAndCodeResponse
-                    {Name = establishment.BoardersName, Code = establishment.BoardersCode},
-                NurseryProvision = establishment.NurseryProvisionName,
-                OfficialSixthForm =
-                    new NameAndCodeResponse
-                        {Name = establishment.OfficialSixthFormName, Code = establishment.OfficialSixthFormCode},
-                Gender = new NameAndCodeResponse {Name = establishment.GenderName, Code = establishment.GenderCode},
-                ReligiousCharacter = new NameAndCodeResponse
-                    {Name = establishment.ReligiousCharacterName, Code = establishment.ReligiousCharacterCode},
-                ReligiousEthos = establishment.ReligiousEthosName,
-                Diocese = new NameAndCodeResponse {Name = establishment.DioceseName, Code = establishment.DioceseCode},
-                AdmissionsPolicy = new NameAndCodeResponse
-                    {Name = establishment.AdmissionsPolicyName, Code = establishment.AdmissionsPolicyCode},
-                SchoolCapacity = establishment.SchoolCapacity,
-                SpecialClasses = new NameAndCodeResponse
-                    {Name = establishment.SpecialClassesName, Code = establishment.SpecialClassesCode},
-                Census =
-                    new CensusResponse
-                    {
-                        CensusDate = establishment.CensusDate,
-                        NumberOfPupils = establishment.NumberOfPupils,
-                        NumberOfBoys = establishment.NumberOfBoys,
-                        NumberOfGirls = establishment.NumberOfGirls,
-                        PercentageFsm = establishment.PercentageFsm
-                    },
-                TrustSchoolFlag = new NameAndCodeResponse
-                    {Name = establishment.TrustSchoolFlagName, Code = establishment.TrustSchoolFlagCode},
-                Trusts = new NameAndCodeResponse {Name = establishment.TrustsName, Code = establishment.TrustsCode},
-                SchoolSponsorFlag = establishment.SchoolSponsorFlagName,
-                SchoolSponsors = establishment.SchoolSponsorsName,
-                FederationFlag = establishment.FederationFlagName,
-                Federations = new NameAndCodeResponse
-                    {Name = establishment.FederationsName, Code = establishment.FederationsCode},
-                Ukprn = establishment.Ukprn,
-                FeheiIdentifier = establishment.Feheidentifier,
-                FurtherEducationType = establishment.FurtherEducationTypeName,
-                OfstedLastInspection = establishment.OfstedLastInsp,
-                OfstedSpecialMeasures = new NameAndCodeResponse
-                    {Name = establishment.OfstedSpecialMeasuresName, Code = establishment.OfstedSpecialMeasuresCode},
-                LastChangedDate = establishment.LastChangedDate,
-                Address =
-                    new AddressResponse
-                    {
-                        Street = establishment.Street,
-                        Locality = establishment.Locality,
-                        AdditionalLine = establishment.Address3,
-                        Town = establishment.Town,
-                        County = establishment.CountyName,
-                        Postcode = establishment.Postcode
-                    },
-                SchoolWebsite = establishment.SchoolWebsite,
-                TelephoneNumber = establishment.TelephoneNum,
-                HeadteacherTitle = establishment.HeadTitleName,
-                HeadteacherFirstName = establishment.HeadFirstName,
-                HeadteacherLastName = establishment.HeadLastName,
-                HeadteacherPreferredJobTitle = establishment.HeadPreferredJobTitle,
-                InspectorateName = establishment.InspectorateNameName,
-                InspectorateReport = establishment.InspectorateReport,
-                DateOfLastInspectionVisit = establishment.DateOfLastInspectionVisit,
-                DateOfNextInspectionVisit = establishment.NextInspectionVisit,
-                TeenMoth = establishment.TeenMothName,
-                TeenMothPlaces = establishment.TeenMothPlaces,
-                CCF = establishment.CcfName,
-                SENPRU = establishment.SenpruName,
-                EBD = establishment.EbdName,
-                PlacesPRU = establishment.PlacesPru,
-                FTProv = establishment.FtprovName,
-                EdByOther = establishment.EdByOtherName,
-                Section14Approved = establishment.Section41ApprovedName,
-                SEN1 = establishment.Sen1Name,
-                SEN2 = establishment.Sen2Name,
-                SEN3 = establishment.Sen3Name,
-                SEN4 = establishment.Sen4Name,
-                SEN5 = establishment.Sen5Name,
-                SEN6 = establishment.Sen6Name,
-                SEN7 = establishment.Sen7Name,
-                SEN8 = establishment.Sen8Name,
-                SEN9 = establishment.Sen9Name,
-                SEN10 = establishment.Sen10Name,
-                SEN11 = establishment.Sen11Name,
-                SEN12 = establishment.Sen12Name,
-                SEN13 = establishment.Sen13Name,
-                TypeOfResourcedProvision = establishment.TypeOfResourcedProvisionName,
-                ResourcedProvisionOnRoll = establishment.ResourcedProvisionOnRoll,
-                ResourcedProvisionOnCapacity = establishment.ResourcedProvisionCapacity,
-                SenUnitOnRoll = establishment.SenUnitOnRoll,
-                SenUnitCapacity = establishment.SenUnitCapacity,
-                GOR = new NameAndCodeResponse {Name = establishment.GorName, Code = establishment.GorCode},
-                DistrictAdministrative =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.DistrictAdministrativeName, Code = establishment.DistrictAdministrativeCode
-                    },
-                AdministractiveWard = new NameAndCodeResponse
-                    {Name = establishment.AdministrativeWardName, Code = establishment.AdministrativeWardCode},
-                ParliamentaryConstituency =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.ParliamentaryConstituencyName,
-                        Code = establishment.ParliamentaryConstituencyCode
-                    },
-                UrbanRural =
-                    new NameAndCodeResponse
-                    {
-                        Name = establishment.UrbanRuralName, Code = establishment.UrbanRuralCode
-                    },
-                GSSLACode = establishment.GsslacodeName,
-                Easting = establishment.Easting,
-                Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
-                MSOA = new NameAndCodeResponse {Name = establishment.MsoaName, Code = establishment.MsoaCode},
-                LSOA = new NameAndCodeResponse {Name = establishment.LsoaName, Code = establishment.LsoaCode},
-                SENStat = establishment.Senstat,
-                SENNoStat = establishment.SennoStat,
-                BoardingEstablishment = establishment.BoardingEstablishmentName,
-                PropsName = establishment.PropsName,
-                PreviousLocalAuthority = new NameAndCodeResponse
-                    {Name = establishment.PreviousLaName, Code = establishment.PreviousLaCode},
-                PreviousEstablishmentNumber = establishment.PreviousEstablishmentNumber,
-                OfstedRating = establishment.OfstedRatingName,
-                RSCRegion = establishment.RscregionName,
-                Country = establishment.CountryName,
-                UPRN = establishment.Uprn,
-                MISEstablishment = null,
-                MISFurtherEducationEstablishment = null,
-                SMARTData = new SMARTDataResponse
-                    {
-                        ProbabilityOfDeclining = smartData.ProbabilityOfDeclining.ToString(),
-                        ProbabilityOfStayingTheSame = smartData.ProbabilityOfStayingTheSame.ToString(),
-                        ProbabilityOfImproving = smartData.ProbabilityOfImproving.ToString(),
-                        PredictedChangeInProgress8Score = smartData.PredictedChangeInProgress8Score,
-                        PredictedChanceOfChangeOccurring = smartData.PredictedChanceOfChangeOccuring.ToString(),
-                        TotalNumberOfRisks = smartData.TotalNumberOfRisks.ToString(),
-                        TotalRiskScore = smartData.TotalRiskScore.ToString(),
-                        RiskRatingNum = smartData.RiskRatingNum.ToString()
-                    },
-                Financial = null,
-                Concerns = null
-            };
 
-            var useCase = new GetEstablishmentByUkprn(establishmentGateway.Object);
-            var result = useCase.Execute(ukprn);
+            _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
+            _establishmentGateway.Setup(gateway => gateway.GetSmartDataByUrn(establishment.Urn)).Returns(smartData);
+
+            var expected = EstablishmentResponseFactory.Create(establishment, null, smartData);
+
+            var result = _useCase.Execute(UKPRN);
             
             result.Should().BeEquivalentTo(expected);
         }
 
-        
+        [Fact]
+        public void GetEstablishmentByUrn_ReturnsNull_WhenNoEstablishmentsAreFound()
+        {
+            _establishmentGateway.Setup(gateway => gateway.GetByUrn(It.IsAny<int>())).Returns(() => null);
+
+            _useCase.Execute(new GetEstablishmentByUrnRequest { URN = URN }).Should().BeNull();
+        }
+
+        [Fact]
+        public void GetEstablishmentByUrn_ReturnsEstablishment_WhenAnEstablishmentIsFound()
+        {
+            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = UKPRN).Build();
+
+            _establishmentGateway.Setup(gateway => gateway.GetByUrn(URN)).Returns(establishment);
+
+            var expected = EstablishmentResponseFactory.Create(establishment, null, null);
+
+            var result = _useCase.Execute(new GetEstablishmentByUrnRequest { URN = URN });
+
+            result.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/TramsDataApi/Controllers/EstablishmentsController.cs
+++ b/TramsDataApi/Controllers/EstablishmentsController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.UseCases;
 
@@ -9,9 +9,14 @@ namespace TramsDataApi.Controllers
     public class EstablishmentsController : ControllerBase
     {
         private readonly IGetEstablishmentByUkprn _getEstablishmentByUkprn;
-        public EstablishmentsController(IGetEstablishmentByUkprn getEstablishmentByUkprn)
+        private readonly IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse> _getEstablishmentByUrn;
+
+        public EstablishmentsController(
+            IGetEstablishmentByUkprn getEstablishmentByUkprn, 
+            IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse> getEstablishmentByUrn)
         {
             _getEstablishmentByUkprn = getEstablishmentByUkprn;
+            _getEstablishmentByUrn = getEstablishmentByUrn;
         }
 
         [HttpGet]
@@ -19,6 +24,20 @@ namespace TramsDataApi.Controllers
         public ActionResult<EstablishmentResponse> GetByUkprn(string ukprn)
         {
             var establishment = _getEstablishmentByUkprn.Execute(ukprn);
+
+            if (establishment == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(establishment);
+        }
+
+        [HttpGet]
+        [Route("establishment/urn/{urn}")]
+        public ActionResult<EstablishmentResponse> GetByUrn(int urn)
+        {
+            var establishment = _getEstablishmentByUrn.Execute(new GetEstablishmentByUrnRequest { URN = urn });
 
             if (establishment == null)
             {

--- a/TramsDataApi/Gateways/EstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/EstablishmentGateway.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
-using TramsDataApi.Factories;
-using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Gateways
 {
@@ -19,6 +16,11 @@ namespace TramsDataApi.Gateways
         public Establishment GetByUkprn(string ukprn)
         { 
             return _dbContext.Establishment.FirstOrDefault(e => e.Ukprn == ukprn);
+        }
+
+        public Establishment GetByUrn(int urn)
+        {
+            return _dbContext.Establishment.SingleOrDefault(e => e.Urn == urn);
         }
 
         public IList<Establishment> GetByTrustUid(string trustUid)

--- a/TramsDataApi/Gateways/IEstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/IEstablishmentGateway.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
-using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Gateways
 {
     public interface IEstablishmentGateway
     {
         public Establishment GetByUkprn(string ukprn);
+        public Establishment GetByUrn(int urn);
         public IList<Establishment> GetByTrustUid(string trustUid);
         public MisEstablishments GetMisEstablishmentByUrn(int establishmentUrn);
         public SmartData GetSmartDataByUrn(int establishmentUrn);

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -7,12 +7,10 @@ namespace TramsDataApi.Gateways
     public class TrustGateway : ITrustGateway
     {
         private readonly LegacyTramsDbContext _dbContext;
-        private readonly IEstablishmentGateway _establishmentGateway;
 
-        public TrustGateway(LegacyTramsDbContext dbContext, IEstablishmentGateway establishmentGateway)
+        public TrustGateway(LegacyTramsDbContext dbContext)
         {
             _dbContext = dbContext;
-            _establishmentGateway = establishmentGateway;
         }
 
         public Group GetGroupByUkprn(string ukprn)

--- a/TramsDataApi/RequestModels/GetEstablishmentByUrnRequest.cs
+++ b/TramsDataApi/RequestModels/GetEstablishmentByUrnRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace TramsDataApi.RequestModels
+{
+    public class GetEstablishmentByUrnRequest
+    {
+        public int URN { get; set; }
+    }
+}

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -39,7 +39,7 @@ namespace TramsDataApi
             services.AddScoped<ITrustGateway, TrustGateway>();
             services.AddScoped<IEstablishmentGateway, EstablishmentGateway>();
             services.AddScoped<IGetTrustByUkprn, GetTrustByUkprn>();
-            services.AddScoped<IGetEstablishmentByUkprn, GetEstablishmentByUkprn>();
+            services.AddScoped<IGetEstablishmentByUkprn, GetEstablishment>();
             services.AddScoped<IGetEstablishmentsByTrustUid, GetEstablishmentsByTrustUid>();
             services.AddScoped<ISearchTrusts, SearchTrusts>();
             services.AddScoped<ICreateAcademyTransferProject, CreateAcademyTransferProject>();

--- a/TramsDataApi/UseCases/GetEstablishment.cs
+++ b/TramsDataApi/UseCases/GetEstablishment.cs
@@ -6,13 +6,13 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
-    public class GetEstablishmentByUkprn : 
+    public class GetEstablishment : 
         IGetEstablishmentByUkprn,
         IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse>
     {
         private readonly IEstablishmentGateway _establishmentGateway;
 
-        public GetEstablishmentByUkprn(IEstablishmentGateway establishmentGateway)
+        public GetEstablishment(IEstablishmentGateway establishmentGateway)
         {
             _establishmentGateway = establishmentGateway;
         }

--- a/TramsDataApi/UseCases/GetEstablishmentByUkprn.cs
+++ b/TramsDataApi/UseCases/GetEstablishmentByUkprn.cs
@@ -1,10 +1,14 @@
+using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
-    public class GetEstablishmentByUkprn : IGetEstablishmentByUkprn
+    public class GetEstablishmentByUkprn : 
+        IGetEstablishmentByUkprn,
+        IUseCase<GetEstablishmentByUrnRequest, EstablishmentResponse>
     {
         private readonly IEstablishmentGateway _establishmentGateway;
 
@@ -16,6 +20,17 @@ namespace TramsDataApi.UseCases
         public EstablishmentResponse Execute(string ukprn)
         {
             var establishment = _establishmentGateway.GetByUkprn(ukprn);
+            return BuildResponse(establishment);
+        }
+
+        public EstablishmentResponse Execute(GetEstablishmentByUrnRequest request)
+        {
+            var establishment = _establishmentGateway.GetByUrn(request.URN);
+            return BuildResponse(establishment);
+        }
+
+        private EstablishmentResponse BuildResponse(Establishment establishment)
+        {
             if (establishment == null)
             {
                 return null;


### PR DESCRIPTION
The table for academy conversion projects only appears to have URNs and UKPRNs always seem to be null. In production some do have UKPRNS but it seems A2B can't rely on this so I've added a second route to get the establishment data using the URN