### PR TITLE
Add rationale fields to academy conversion project response

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -1,0 +1,62 @@
+using System;
+using AutoFixture;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.ResponseModels.AcademyConversionProject;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class AcademyConversionProjectResponseFactoryTests
+    {
+        [Fact]
+        public void ReturnsAnAcademyConversionProjectResponse_WhenGivenAnAcademyConversionProject()
+        {
+            var fixture = new Fixture();
+            var academyConversionProject = new IfdPipeline
+            {
+                Sk = fixture.Create<int>(),
+                GeneralDetailsUrn = fixture.Create<string>(),
+                GeneralDetailsProjectName = fixture.Create<string>(),
+                GeneralDetailsLocalAuthority = fixture.Create<string>(),
+                TrustSponsorManagementCoSponsor1 = fixture.Create<string>(),
+                TrustSponsorManagementCoSponsor1SponsorName = fixture.Create<string>(),
+                InterestDateOfInterest = new DateTime(),
+                ApprovalProcessApplicationDate = new DateTime(),
+                ProjectTemplateInformationRationaleForProject = fixture.Create<string>(),
+                ProjectTemplateInformationRationaleForSponsor = fixture.Create<string>()
+            };
+
+            var expectedResponse = new AcademyConversionProjectResponse
+            {
+                Id = (int)academyConversionProject.Sk,
+                School = new SchoolResponse
+                {
+                    Id = academyConversionProject.GeneralDetailsUrn,
+                    Name = academyConversionProject.GeneralDetailsProjectName,
+                    URN = academyConversionProject.GeneralDetailsUrn,
+                    LocalAuthority = academyConversionProject.GeneralDetailsLocalAuthority
+                },
+                Trust = new TrustResponse
+                {
+                    Id = academyConversionProject.TrustSponsorManagementCoSponsor1,
+                    Name = academyConversionProject.TrustSponsorManagementCoSponsor1SponsorName
+                },
+                ApplicationReceivedDate = academyConversionProject.InterestDateOfInterest,
+                AssignedDate = academyConversionProject.ApprovalProcessApplicationDate,
+                Phase = ProjectPhase.PreHTB,
+                ProjectDocuments = new DocumentDetailsResponse[0],
+                RationaleResponse = new RationaleResponse
+                {
+                    ProjectRationale = academyConversionProject.ProjectTemplateInformationRationaleForProject,
+                    TrustRationale = academyConversionProject.ProjectTemplateInformationRationaleForSponsor
+                }
+            };
+
+            var academyConversionProjectResponse = AcademyConversionProjectResponseFactory.Create(academyConversionProject);
+
+            academyConversionProjectResponse.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -47,7 +47,7 @@ namespace TramsDataApi.Test.Factories
                 AssignedDate = academyConversionProject.ApprovalProcessApplicationDate,
                 Phase = ProjectPhase.PreHTB,
                 ProjectDocuments = new DocumentDetailsResponse[0],
-                RationaleResponse = new RationaleResponse
+                Rationale = new RationaleResponse
                 {
                     ProjectRationale = academyConversionProject.ProjectTemplateInformationRationaleForProject,
                     TrustRationale = academyConversionProject.ProjectTemplateInformationRationaleForSponsor

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -22,8 +22,8 @@ namespace TramsDataApi.Test.Factories
                 GeneralDetailsLocalAuthority = fixture.Create<string>(),
                 TrustSponsorManagementCoSponsor1 = fixture.Create<string>(),
                 TrustSponsorManagementCoSponsor1SponsorName = fixture.Create<string>(),
-                InterestDateOfInterest = new DateTime(),
-                ApprovalProcessApplicationDate = new DateTime(),
+                InterestDateOfInterest = DateTime.Now,
+                ApprovalProcessApplicationDate = DateTime.Now.AddMonths(2),
                 ProjectTemplateInformationRationaleForProject = fixture.Create<string>(),
                 ProjectTemplateInformationRationaleForSponsor = fixture.Create<string>()
             };

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -26,7 +26,7 @@ namespace TramsDataApi.Factories
 				AssignedDate = ifdPipeline.ApprovalProcessApplicationDate,
 				Phase = ProjectPhase.PreHTB,
 				ProjectDocuments = new DocumentDetailsResponse[0],
-				RationaleResponse = new RationaleResponse
+				Rationale = new RationaleResponse
 				{
 					ProjectRationale = ifdPipeline.ProjectTemplateInformationRationaleForProject,
 					TrustRationale = ifdPipeline.ProjectTemplateInformationRationaleForSponsor

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -25,7 +25,12 @@ namespace TramsDataApi.Factories
 				ApplicationReceivedDate = ifdPipeline.InterestDateOfInterest,
 				AssignedDate = ifdPipeline.ApprovalProcessApplicationDate,
 				Phase = ProjectPhase.PreHTB,
-				ProjectDocuments = new DocumentDetailsResponse[0]
+				ProjectDocuments = new DocumentDetailsResponse[0],
+				RationaleResponse = new RationaleResponse
+				{
+					ProjectRationale = ifdPipeline.ProjectTemplateInformationRationaleForProject,
+					TrustRationale = ifdPipeline.ProjectTemplateInformationRationaleForSponsor
+				}
 			};
 		}
     }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
@@ -12,6 +12,6 @@ namespace TramsDataApi.ResponseModels.AcademyConversionProject
 		public DateTime? AssignedDate { get; set; }
 		public ProjectPhase Phase { get; set; }
 		public IEnumerable<DocumentDetailsResponse> ProjectDocuments { get; set; }
-		public RationaleResponse RationaleResponse { get; set; }
+		public RationaleResponse Rationale { get; set; }
 	}
 }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
@@ -12,5 +12,6 @@ namespace TramsDataApi.ResponseModels.AcademyConversionProject
 		public DateTime? AssignedDate { get; set; }
 		public ProjectPhase Phase { get; set; }
 		public IEnumerable<DocumentDetailsResponse> ProjectDocuments { get; set; }
+		public RationaleResponse RationaleResponse { get; set; }
 	}
 }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/DocumentDetailsResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/DocumentDetailsResponse.cs
@@ -5,6 +5,5 @@
 		public string Name { get; set; }
 		public string Type { get; set; }
 		public string Size { get; set; }
-
 	}
 }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/RationaleResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/RationaleResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace TramsDataApi.ResponseModels.AcademyConversionProject
+{
+	public class RationaleResponse
+	{
+		public string ProjectRationale { get; set; }
+		public string TrustRationale { get; set; }
+	}
+}

--- a/TramsDataApi/appsettings.Development.json
+++ b/TramsDataApi/appsettings.Development.json
@@ -5,5 +5,10 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "AllowedHosts": "*",
+  "ApiKey": "app-key",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,1433;Database=sip;User=sa;Password=StrongPassword905"
   }
 }


### PR DESCRIPTION
Add a `Rationale` property to the `AcademyConversionProjectResponse`, where this property is of type `RationaleResponse` - an object containing two properties for the `ProjectRationale` (rationale for the project) and `TrustRationale` (rationale for the trust or sponsor) respectively.

This change is necessary because the rationale details are needed for the a2b internal service.