### PR TITLE
Updated searching to return values based on all matches

### DIFF
--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -481,16 +481,20 @@ namespace TramsDataApi.Test.Integration
                 .With(e => e.Ukprn = _randomGenerator.Int().ToString())
                 .Build();
 
-            groups[0].Ukprn = ukprn;
             groups[0].CompaniesHouseNumber = companiesHouseNumber;
-            groups[0].GroupName = groupName;
+
+            groups[1].Ukprn = ukprn;
+            
+            groups[3].GroupName = groupName;
             
             _legacyDbContext.Group.AddRange(groups);
             _legacyDbContext.SaveChanges();
 
             var expected = new List<TrustSummaryResponse>
             {
-                TrustSummaryResponseFactory.Create(groups[0], new List<Establishment>())
+                TrustSummaryResponseFactory.Create(groups[0], new List<Establishment>()),
+                TrustSummaryResponseFactory.Create(groups[1], new List<Establishment>()),
+                TrustSummaryResponseFactory.Create(groups[3], new List<Establishment>()),
             };
 
             var httpRequestMessage = new HttpRequestMessage

--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -15,7 +15,6 @@ using TramsDataApi.Factories;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.Test.Utils;
 using Xunit;
-using Xunit.Sdk;
 
 namespace TramsDataApi.Test.Integration
 {
@@ -482,9 +481,7 @@ namespace TramsDataApi.Test.Integration
                 .Build();
 
             groups[0].CompaniesHouseNumber = companiesHouseNumber;
-
             groups[1].Ukprn = ukprn;
-            
             groups[3].GroupName = groupName;
             
             _legacyDbContext.Group.AddRange(groups);

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -27,8 +27,8 @@ namespace TramsDataApi.Gateways
         {
             return _dbContext.Group
                 .Where(g => (
-                    (groupName == null || g.GroupName == groupName) &&
-                    (ukprn == null || g.Ukprn == ukprn) &&
+                    (groupName == null || g.GroupName == groupName) ||
+                    (ukprn == null || g.Ukprn == ukprn) ||
                     (companiesHouseNumber == null || g.CompaniesHouseNumber == companiesHouseNumber)
                 ))
                 .ToList();

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -25,11 +25,16 @@ namespace TramsDataApi.Gateways
 
         public IList<Group> SearchGroups(string groupName, string ukprn, string companiesHouseNumber)
         {
+            if (groupName == null && ukprn == null && companiesHouseNumber == null)
+            {
+                return _dbContext.Group.ToList();
+            }
+            
             return _dbContext.Group
                 .Where(g => (
-                    (groupName == null || g.GroupName == groupName) ||
-                    (ukprn == null || g.Ukprn == ukprn) ||
-                    (companiesHouseNumber == null || g.CompaniesHouseNumber == companiesHouseNumber)
+                    g.GroupName == groupName ||
+                    g.Ukprn == ukprn ||
+                    g.CompaniesHouseNumber == companiesHouseNumber
                 ))
                 .ToList();
         }


### PR DESCRIPTION
Previously the search trusts would do a strict `AND` search with the given fields; only trusts with matching `ukprn` AND `companiesHouseNumber` AND `groupName` would be returned. This replaces that with an OR search, so as long as any one of those fields are matched, the Trust will be returned.