### PR TITLE
Update rationale property names in academy conversion response

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -49,8 +49,8 @@ namespace TramsDataApi.Test.Factories
                 ProjectDocuments = new DocumentDetailsResponse[0],
                 Rationale = new RationaleResponse
                 {
-                    ProjectRationale = academyConversionProject.ProjectTemplateInformationRationaleForProject,
-                    TrustRationale = academyConversionProject.ProjectTemplateInformationRationaleForSponsor
+                    RationaleForProject = academyConversionProject.ProjectTemplateInformationRationaleForProject,
+                    RationaleForTrust = academyConversionProject.ProjectTemplateInformationRationaleForSponsor
                 }
             };
 

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -28,8 +28,8 @@ namespace TramsDataApi.Factories
 				ProjectDocuments = new DocumentDetailsResponse[0],
 				Rationale = new RationaleResponse
 				{
-					ProjectRationale = ifdPipeline.ProjectTemplateInformationRationaleForProject,
-					TrustRationale = ifdPipeline.ProjectTemplateInformationRationaleForSponsor
+					RationaleForProject = ifdPipeline.ProjectTemplateInformationRationaleForProject,
+					RationaleForTrust = ifdPipeline.ProjectTemplateInformationRationaleForSponsor
 				}
 			};
 		}

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/RationaleResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/RationaleResponse.cs
@@ -2,7 +2,7 @@
 {
 	public class RationaleResponse
 	{
-		public string ProjectRationale { get; set; }
-		public string TrustRationale { get; set; }
+		public string RationaleForProject { get; set; }
+		public string RationaleForTrust { get; set; }
 	}
 }


### PR DESCRIPTION
These changes are needed to align the academy conversion rationale response properties with changes made to the rationale property names in the object that the api response deserialises to in the A2B service.