### PR TITLE
Make RddOrEsfaIntervention nullable for AT Requests

### DIFF
--- a/TramsDataApi/RequestModels/AcademyTransferProjectFeaturesRequest.cs
+++ b/TramsDataApi/RequestModels/AcademyTransferProjectFeaturesRequest.cs
@@ -3,7 +3,7 @@ namespace TramsDataApi.RequestModels
     public class AcademyTransferProjectFeaturesRequest
     {
         public string WhoInitiatedTheTransfer { get; set; }
-        public bool RddOrEsfaIntervention { get; set; }
+        public bool? RddOrEsfaIntervention { get; set; }
         public string RddOrEsfaInterventionDetail { get; set; }
         public string TypeOfTransfer { get; set; }
         public string OtherTransferTypeDescription { get; set; }


### PR DESCRIPTION
## What has changed

AT Projects -> Features -> RddOrEsfaIntervention has been made nullable

## Why has this changed?

When integrating with the API, I found that doing a project update required this to be set to `false` otherwise it would return bad request.

Setting this to false however means that it looks like our users have inputted this data (it's a Yes/No radio button), which means that it falsely marks the section as "in progress" with the user having selected "No"

This update just makes the field nullable to avoid this needing to be set

