### PR TITLE
Add pagination to index trusts

### DIFF
--- a/TramsDataApi.Test/Controllers/TrustsControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/TrustsControllerTests.cs
@@ -73,7 +73,7 @@ namespace TramsDataApi.Test.Controllers
             var companiesHouseNumber = "Mockcompanieshousenumber";
 
             var searchTrusts = new Mock<ISearchTrusts>();
-            searchTrusts.Setup(s => s.Execute(groupName, ukprn, companiesHouseNumber))
+            searchTrusts.Setup(s => s.Execute(groupName, ukprn, companiesHouseNumber, 1))
                 .Returns(new List<TrustSummaryResponse>());
 
             var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
@@ -95,7 +95,7 @@ namespace TramsDataApi.Test.Controllers
                 .Build();
             
             var searchTrusts = new Mock<ISearchTrusts>();
-            searchTrusts.Setup(s => s.Execute(groupName, null, companiesHouseNumber))
+            searchTrusts.Setup(s => s.Execute(groupName, null, companiesHouseNumber, 1))
                 .Returns(expectedTrustSummaries);
 
             var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
@@ -116,7 +116,7 @@ namespace TramsDataApi.Test.Controllers
                 .Build();
             
             var searchTrusts = new Mock<ISearchTrusts>();
-            searchTrusts.Setup(s => s.Execute(null, ukprn, null))
+            searchTrusts.Setup(s => s.Execute(null, ukprn, null, 1))
                 .Returns(expectedTrustSummaries);
 
             var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);
@@ -131,7 +131,7 @@ namespace TramsDataApi.Test.Controllers
             var expectedTrustSummaries = Builder<TrustSummaryResponse>.CreateListOfSize(5).Build();
             
             var searchTrusts = new Mock<ISearchTrusts>();
-            searchTrusts.Setup(s => s.Execute(null, null, null))
+            searchTrusts.Setup(s => s.Execute(null, null, null, 1))
                 .Returns(expectedTrustSummaries);
 
             var controller = new TrustsController(new Mock<IGetTrustByUkprn>().Object, searchTrusts.Object);

--- a/TramsDataApi.Test/UseCases/SearchTrustsTests.cs
+++ b/TramsDataApi.Test/UseCases/SearchTrustsTests.cs
@@ -23,11 +23,11 @@ namespace TramsDataApi.Test.UseCases
             var companiesHouseNumber = "companiesHouseNumber";
             
             var gateway = new Mock<ITrustGateway>();
-            gateway.Setup(g => g.SearchGroups(groupName, ukprn, companiesHouseNumber))
+            gateway.Setup(g => g.SearchGroups(groupName, ukprn, companiesHouseNumber, 1))
                 .Returns(new List<Group>());
 
             var useCase = new SearchTrusts(gateway.Object, new Mock<IEstablishmentGateway>().Object);
-            var result = useCase.Execute(groupName, ukprn, companiesHouseNumber);
+            var result = useCase.Execute(groupName, ukprn, companiesHouseNumber, 1);
 
             result.Should().BeEquivalentTo(new List<TrustSummaryResponse>());
         }
@@ -45,7 +45,7 @@ namespace TramsDataApi.Test.UseCases
             var trustsGateway = new Mock<ITrustGateway>();
             var establishmentsGateway = new Mock<IEstablishmentGateway>();
             
-            trustsGateway.Setup(g => g.SearchGroups(groupName, null, null))
+            trustsGateway.Setup(g => g.SearchGroups(groupName, null, null, 1))
                 .Returns(expectedTrusts);
             
             establishmentsGateway.Setup(g => g.GetByTrustUid(It.IsAny<string>()))
@@ -56,7 +56,7 @@ namespace TramsDataApi.Test.UseCases
                 .ToList();
             
             var searchTrusts = new SearchTrusts(trustsGateway.Object, establishmentsGateway.Object);
-            var result = searchTrusts.Execute(groupName, null, null);
+            var result = searchTrusts.Execute(groupName, null, null, 1);
 
             result.Should().BeEquivalentTo(expected);
         }
@@ -78,7 +78,7 @@ namespace TramsDataApi.Test.UseCases
             var trustGateway = new Mock<ITrustGateway>();
             var establishmentGateway = new Mock<IEstablishmentGateway>();
 
-            trustGateway.Setup(g => g.SearchGroups(null, ukprn, null))
+            trustGateway.Setup(g => g.SearchGroups(null, ukprn, null, 1))
                 .Returns(new List<Group> {expectedTrust});
             establishmentGateway.Setup(g => g.GetByTrustUid(expectedTrust.GroupUid))
                 .Returns(expectedEstablishments);
@@ -89,7 +89,7 @@ namespace TramsDataApi.Test.UseCases
             };
 
             var searchTrusts = new SearchTrusts(trustGateway.Object, establishmentGateway.Object);
-            var result = searchTrusts.Execute(null, ukprn, null);
+            var result = searchTrusts.Execute(null, ukprn, null, 1);
             result.Should().BeEquivalentTo(expected);
         }
     }

--- a/TramsDataApi/Controllers/TrustsController.cs
+++ b/TramsDataApi/Controllers/TrustsController.cs
@@ -37,9 +37,9 @@ namespace TramsDataApi.Controllers
 
         [HttpGet]
         [Route("trusts")]
-        public ActionResult<List<TrustSummaryResponse>> SearchTrusts(string groupName, string ukprn, string companiesHouseNumber)
+        public ActionResult<List<TrustSummaryResponse>> SearchTrusts(string groupName, string ukprn, string companiesHouseNumber, int page = 1)
         {
-            var trusts = _searchTrusts.Execute(groupName, ukprn, companiesHouseNumber);
+            var trusts = _searchTrusts.Execute(groupName, ukprn, companiesHouseNumber, page);
             return Ok(trusts);
         }
     }

--- a/TramsDataApi/Gateways/ITrustGateway.cs
+++ b/TramsDataApi/Gateways/ITrustGateway.cs
@@ -9,6 +9,6 @@ namespace TramsDataApi.Gateways
         public Group GetGroupByUkprn(string ukprn);
         public Trust GetIfdTrustByGroupId(string groupId);
 
-        public IList<Group> SearchGroups(string groupName, string ukprn, string companiesHouseNumber);
+        public IList<Group> SearchGroups(string groupName, string ukprn, string companiesHouseNumber, int page);
     }
 }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -27,7 +27,7 @@ namespace TramsDataApi.Gateways
         {
             if (groupName == null && ukprn == null && companiesHouseNumber == null)
             {
-                return _dbContext.Group.Skip((page - 1) * 10).Take(10).ToList();
+                return _dbContext.Group.OrderBy(group => group.GroupUid).Skip((page - 1) * 10).Take(10).ToList();
             }
             
             return _dbContext.Group
@@ -36,6 +36,7 @@ namespace TramsDataApi.Gateways
                     g.Ukprn == ukprn ||
                     g.CompaniesHouseNumber == companiesHouseNumber
                 ))
+                .OrderBy(group => group.GroupUid)
                 .Skip((page - 1) * 10).Take(10).ToList();
         }
     }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -23,11 +23,11 @@ namespace TramsDataApi.Gateways
             return _dbContext.Trust.FirstOrDefault(t => t.TrustRef == groupId);
         }
 
-        public IList<Group> SearchGroups(string groupName, string ukprn, string companiesHouseNumber)
+        public IList<Group> SearchGroups(string groupName, string ukprn, string companiesHouseNumber, int page)
         {
             if (groupName == null && ukprn == null && companiesHouseNumber == null)
             {
-                return _dbContext.Group.ToList();
+                return _dbContext.Group.Skip((page - 1) * 10).Take(10).ToList();
             }
             
             return _dbContext.Group
@@ -36,7 +36,7 @@ namespace TramsDataApi.Gateways
                     g.Ukprn == ukprn ||
                     g.CompaniesHouseNumber == companiesHouseNumber
                 ))
-                .ToList();
+                .Skip((page - 1) * 10).Take(10).ToList();
         }
     }
 }

--- a/TramsDataApi/UseCases/ISearchTrusts.cs
+++ b/TramsDataApi/UseCases/ISearchTrusts.cs
@@ -7,6 +7,6 @@ namespace TramsDataApi.UseCases
 {
     public interface ISearchTrusts
     {
-        public IList<TrustSummaryResponse> Execute(string groupName, string urn, string companiesHouseNumber);
+        public IList<TrustSummaryResponse> Execute(string groupName, string urn, string companiesHouseNumber, int page);
     }
 }

--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -17,9 +17,9 @@ namespace TramsDataApi.UseCases
             _establishmentGateway = establishmentGateway;
         }
         
-        public IList<TrustSummaryResponse> Execute(string groupName, string ukprn, string companiesHouseNumber)
+        public IList<TrustSummaryResponse> Execute(string groupName, string ukprn, string companiesHouseNumber, int page)
         {
-            return _trustGateway.SearchGroups(groupName, ukprn, companiesHouseNumber)
+            return _trustGateway.SearchGroups(groupName, ukprn, companiesHouseNumber, page)
                 .Select(g => TrustSummaryResponseFactory.Create(g, _establishmentGateway.GetByTrustUid(g.GroupUid)))
                 .ToList();
         }


### PR DESCRIPTION
This PR adds simple pagination to the index trusts endpoint.

Also I have make the index trust gateway return trusts ordered by GroupUID. 
This is mainly for testability as GroupUID is stored in the DB as a string and ordering wont work nicely without some tomfoolery. 