### PR TITLE
Map school budget information fields when updating

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -67,7 +67,7 @@ namespace TramsDataApi.Test.Factories
         }
 
         [Fact]
-        public void ReturnsUpdatedAcademyConversionProjectWithNullDates_WhenUpdatingIfdPipeline_IfUpdateAcademyConversionProjectRequestDecimalFieldsAreSetToDefaultValues()
+        public void ReturnsUpdatedAcademyConversionProjectWithFieldValues_WhenUpdatingIfdPipeline_IfUpdateAcademyConversionProjectRequestDecimalFieldsAreSetToDefaultValues()
         {
             var ifdPipeline = CreateIfdPipeline();
 
@@ -116,7 +116,7 @@ namespace TramsDataApi.Test.Factories
         }
 
         [Fact]
-        public void ReturnsUpdatedAcademyConversionProjectWithNullDates_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestDateAndDecimalFieldsAreSetToDefaulValues()
+        public void ReturnsUpdatedAcademyConversionProjectWithNullFieldValues_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestDateAndDecimalFieldsAreSetToDefaulValues()
         {
             var academyConversionProject = CreateAcademyConversionProject();
 

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -67,6 +67,23 @@ namespace TramsDataApi.Test.Factories
         }
 
         [Fact]
+        public void ReturnsUpdatedAcademyConversionProjectWithNullDates_WhenUpdatingIfdPipeline_IfUpdateAcademyConversionProjectRequestDecimalFieldsAreSetToDefaultValues()
+        {
+            var ifdPipeline = CreateIfdPipeline();
+
+            var updateRequest = new UpdateAcademyConversionProjectRequest
+            {
+                RevenueCarryForwardAtEndMarchCurrentYear = default(decimal),
+                ProjectedRevenueBalanceAtEndMarchNextYear = default(decimal),
+            };
+
+            var expected = JsonConvert.DeserializeObject<IfdPipeline>(JsonConvert.SerializeObject(ifdPipeline));
+            expected.ProjectTemplateInformationFyRevenueBalanceCarriedForward = null;
+            expected.ProjectTemplateInformationFy1RevenueBalanceCarriedForward = null;
+            AcademyConversionProjectFactory.Update(ifdPipeline, updateRequest).Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
         public void ReturnsOriginalAcademyConversionProject_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestIsNull()
         {
             var academyConversionProject = CreateAcademyConversionProject();
@@ -99,7 +116,7 @@ namespace TramsDataApi.Test.Factories
         }
 
         [Fact]
-        public void ReturnsUpdatedAcademyConversionProjectWithNullDates_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestDateFieldsAreSetToDefaultDateTime()
+        public void ReturnsUpdatedAcademyConversionProjectWithNullDates_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestDateAndDecimalFieldsAreSetToDefaulValues()
         {
             var academyConversionProject = CreateAcademyConversionProject();
 
@@ -107,11 +124,15 @@ namespace TramsDataApi.Test.Factories
             {
                 LocalAuthorityInformationTemplateSentDate = default(DateTime),
                 LocalAuthorityInformationTemplateReturnedDate = default(DateTime),
+                CapitalCarryForwardAtEndMarchCurrentYear = default(decimal),
+                CapitalCarryForwardAtEndMarchNextYear = default(decimal)
             };
 
             var expected = JsonConvert.DeserializeObject<AcademyConversionProject>(JsonConvert.SerializeObject(academyConversionProject));
             expected.LocalAuthorityInformationTemplateSentDate = null;
             expected.LocalAuthorityInformationTemplateReturnedDate = null;
+            expected.CapitalCarryForwardAtEndMarchCurrentYear = null;
+            expected.CapitalCarryForwardAtEndMarchNextYear = null;
             AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest).Should().BeEquivalentTo(expected);
         }
 
@@ -147,6 +168,8 @@ namespace TramsDataApi.Test.Factories
             expected.LocalAuthorityInformationTemplateSectionComplete = updateRequest.LocalAuthorityInformationTemplateSectionComplete;
             expected.RisksAndIssuesSectionComplete = updateRequest.RisksAndIssuesSectionComplete;
             expected.SchoolPerformanceAdditionalInformation = updateRequest.SchoolPerformanceAdditionalInformation;
+            expected.CapitalCarryForwardAtEndMarchCurrentYear = updateRequest.CapitalCarryForwardAtEndMarchCurrentYear;
+            expected.CapitalCarryForwardAtEndMarchNextYear = updateRequest.CapitalCarryForwardAtEndMarchNextYear;
             expected.SchoolBudgetInformationAdditionalInformation = updateRequest.SchoolBudgetInformationAdditionalInformation;
             expected.SchoolBudgetInformationSectionComplete = updateRequest.SchoolBudgetInformationSectionComplete;
             return expected;

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -126,6 +126,8 @@ namespace TramsDataApi.Test.Factories
             expected.ProjectTemplateInformationRationaleForProject = updateRequest.RationaleForProject;
             expected.ProjectTemplateInformationRationaleForSponsor = updateRequest.RationaleForTrust;
             expected.ProjectTemplateInformationRisksAndIssues = updateRequest.RisksAndIssues;
+            expected.ProjectTemplateInformationFyRevenueBalanceCarriedForward = updateRequest.RevenueCarryForwardAtEndMarchCurrentYear.ToString();
+            expected.ProjectTemplateInformationFy1RevenueBalanceCarriedForward = updateRequest.ProjectedRevenueBalanceAtEndMarchNextYear.ToString();
             return expected;
         }
 
@@ -145,6 +147,8 @@ namespace TramsDataApi.Test.Factories
             expected.LocalAuthorityInformationTemplateSectionComplete = updateRequest.LocalAuthorityInformationTemplateSectionComplete;
             expected.RisksAndIssuesSectionComplete = updateRequest.RisksAndIssuesSectionComplete;
             expected.SchoolPerformanceAdditionalInformation = updateRequest.SchoolPerformanceAdditionalInformation;
+            expected.SchoolBudgetInformationAdditionalInformation = updateRequest.SchoolBudgetInformationAdditionalInformation;
+            expected.SchoolBudgetInformationSectionComplete = updateRequest.SchoolBudgetInformationSectionComplete;
             return expected;
         }
     }

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -73,10 +73,60 @@ namespace TramsDataApi.Test.Factories
                 RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
                 RisksAndIssuesSectionComplete = academyConversionProject.RisksAndIssuesSectionComplete,
                 SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation,
-                RevenueCarryForwardAtEndMarchCurrentYear = academyConversionProject.RevenueCarryForwardAtEndMarchCurrentYear,
-                ProjectedRevenueBalanceAtEndMarchNextYear = academyConversionProject.ProjectedRevenueBalanceAtEndMarchNextYear,
+                RevenueCarryForwardAtEndMarchCurrentYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward),
+                ProjectedRevenueBalanceAtEndMarchNextYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward),
+                CapitalCarryForwardAtEndMarchCurrentYear = academyConversionProject.CapitalCarryForwardAtEndMarchCurrentYear,
+                CapitalCarryForwardAtEndMarchNextYear = academyConversionProject.CapitalCarryForwardAtEndMarchNextYear,
                 SchoolBudgetInformationAdditionalInformation = academyConversionProject.SchoolBudgetInformationAdditionalInformation,
                 SchoolBudgetInformationSectionComplete = academyConversionProject.SchoolBudgetInformationSectionComplete
+            };
+
+            var academyConversionProjectResponse = AcademyConversionProjectResponseFactory.Create(ifdPipeline, academyConversionProject);
+
+            academyConversionProjectResponse.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public void ReturnsAnAcademyConversionProjectResponse_WhenGivenIfdPipelineAndAcademyConversionProjectWithNullSchoolBudgetValues()
+        {
+            var fixture = new Fixture();
+            var ifdPipeline = fixture.Build<IfdPipeline>()
+                .With(x => x.GeneralDetailsUrn, "12345")
+                .With(x => x.ProjectTemplateInformationFyRevenueBalanceCarriedForward, (string)null)
+                .With(x => x.ProjectTemplateInformationFy1RevenueBalanceCarriedForward, (string)null)
+                .Create();
+
+            var academyConversionProject = fixture.Build<AcademyConversionProject>()
+                .With(x => x.CapitalCarryForwardAtEndMarchCurrentYear, (decimal?)null)
+                .With(x => x.CapitalCarryForwardAtEndMarchNextYear, (decimal?)null)
+                .Create();
+
+            var expectedResponse = new AcademyConversionProjectResponse
+            {
+                Id = (int)ifdPipeline.Sk,
+                Urn = int.Parse(ifdPipeline.GeneralDetailsUrn),
+                SchoolName = ifdPipeline.GeneralDetailsProjectName,
+                LocalAuthority = ifdPipeline.GeneralDetailsLocalAuthority,
+                ApplicationReceivedDate = ifdPipeline.InterestDateOfInterest,
+                AssignedDate = ifdPipeline.ApprovalProcessApplicationDate,
+                ProjectStatus = "Pre HTB",
+                RationaleForProject = ifdPipeline.ProjectTemplateInformationRationaleForProject,
+                RationaleForTrust = ifdPipeline.ProjectTemplateInformationRationaleForSponsor,
+                RationaleSectionComplete = academyConversionProject.RationaleSectionComplete,
+                LocalAuthorityInformationTemplateSentDate = academyConversionProject.LocalAuthorityInformationTemplateSentDate,
+                LocalAuthorityInformationTemplateReturnedDate = academyConversionProject.LocalAuthorityInformationTemplateReturnedDate,
+                LocalAuthorityInformationTemplateComments = academyConversionProject.LocalAuthorityInformationTemplateComments,
+                LocalAuthorityInformationTemplateLink = academyConversionProject.LocalAuthorityInformationTemplateLink,
+                LocalAuthorityInformationTemplateSectionComplete = academyConversionProject.LocalAuthorityInformationTemplateSectionComplete,
+                RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
+                RisksAndIssuesSectionComplete = academyConversionProject.RisksAndIssuesSectionComplete,
+                SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation,
+                RevenueCarryForwardAtEndMarchCurrentYear = null,
+                ProjectedRevenueBalanceAtEndMarchNextYear = null,
+                CapitalCarryForwardAtEndMarchCurrentYear = null,
+                CapitalCarryForwardAtEndMarchNextYear = null,
+                SchoolBudgetInformationAdditionalInformation = academyConversionProject.SchoolBudgetInformationAdditionalInformation,
+                SchoolBudgetInformationSectionComplete = academyConversionProject.SchoolBudgetInformationSectionComplete,
             };
 
             var academyConversionProjectResponse = AcademyConversionProjectResponseFactory.Create(ifdPipeline, academyConversionProject);

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -13,7 +13,11 @@ namespace TramsDataApi.Test.Factories
         public void ReturnsAnAcademyConversionProjectResponse_WhenGivenIfdPipeline()
         {
             var fixture = new Fixture();
-            var ifdPipeline = fixture.Build<IfdPipeline>().With(x => x.GeneralDetailsUrn, "12345").Create();
+            var ifdPipeline = fixture.Build<IfdPipeline>()
+                .With(x => x.GeneralDetailsUrn, "12345")
+                .With(x => x.ProjectTemplateInformationFyRevenueBalanceCarriedForward, fixture.Create<decimal>().ToString)
+                .With(x => x.ProjectTemplateInformationFy1RevenueBalanceCarriedForward, fixture.Create<decimal>().ToString)
+                .Create();
 
             var expectedResponse = new AcademyConversionProjectResponse
             {
@@ -28,7 +32,10 @@ namespace TramsDataApi.Test.Factories
                 RationaleForTrust = ifdPipeline.ProjectTemplateInformationRationaleForSponsor,
                 RationaleSectionComplete = null,
                 RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
-                RisksAndIssuesSectionComplete = null
+                RisksAndIssuesSectionComplete = null,
+                RevenueCarryForwardAtEndMarchCurrentYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward),
+                ProjectedRevenueBalanceAtEndMarchNextYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward)
+
             };
 
             var academyConversionProjectResponse = AcademyConversionProjectResponseFactory.Create(ifdPipeline);
@@ -40,7 +47,10 @@ namespace TramsDataApi.Test.Factories
         public void ReturnsAnAcademyConversionProjectResponse_WhenGivenIfdPipelineAndAcademyConversionProject()
         {
             var fixture = new Fixture();
-            var ifdPipeline = fixture.Build<IfdPipeline>().With(x => x.GeneralDetailsUrn, "12345").Create();
+            var ifdPipeline = fixture.Build<IfdPipeline>().With(x => x.GeneralDetailsUrn, "12345")
+                .With(x => x.ProjectTemplateInformationFyRevenueBalanceCarriedForward, fixture.Create<decimal>().ToString)
+                .With(x => x.ProjectTemplateInformationFy1RevenueBalanceCarriedForward, fixture.Create<decimal>().ToString)
+                .Create();
             var academyConversionProject = fixture.Create<AcademyConversionProject>();
 
             var expectedResponse = new AcademyConversionProjectResponse
@@ -62,7 +72,11 @@ namespace TramsDataApi.Test.Factories
                 LocalAuthorityInformationTemplateSectionComplete = academyConversionProject.LocalAuthorityInformationTemplateSectionComplete,
                 RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
                 RisksAndIssuesSectionComplete = academyConversionProject.RisksAndIssuesSectionComplete,
-                SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation
+                SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation,
+                RevenueCarryForwardAtEndMarchCurrentYear = academyConversionProject.RevenueCarryForwardAtEndMarchCurrentYear,
+                ProjectedRevenueBalanceAtEndMarchNextYear = academyConversionProject.ProjectedRevenueBalanceAtEndMarchNextYear,
+                SchoolBudgetInformationAdditionalInformation = academyConversionProject.SchoolBudgetInformationAdditionalInformation,
+                SchoolBudgetInformationSectionComplete = academyConversionProject.SchoolBudgetInformationSectionComplete
             };
 
             var academyConversionProjectResponse = AcademyConversionProjectResponseFactory.Create(ifdPipeline, academyConversionProject);

--- a/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
@@ -16,8 +16,10 @@ namespace TramsDataApi.Factories
             project.ProjectTemplateInformationRationaleForProject = updateRequest.RationaleForProject ?? project.ProjectTemplateInformationRationaleForProject;
             project.ProjectTemplateInformationRationaleForSponsor = updateRequest.RationaleForTrust ?? project.ProjectTemplateInformationRationaleForSponsor;
             project.ProjectTemplateInformationRisksAndIssues = updateRequest.RisksAndIssues ?? project.ProjectTemplateInformationRisksAndIssues;
-            project.ProjectTemplateInformationFyRevenueBalanceCarriedForward = updateRequest.RevenueCarryForwardAtEndMarchCurrentYear?.ToString() ?? project.ProjectTemplateInformationFyRevenueBalanceCarriedForward;
-            project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward = updateRequest.ProjectedRevenueBalanceAtEndMarchNextYear?.ToString() ?? project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward;
+            project.ProjectTemplateInformationFyRevenueBalanceCarriedForward = updateRequest.RevenueCarryForwardAtEndMarchCurrentYear == default(decimal) ? null :
+                updateRequest.RevenueCarryForwardAtEndMarchCurrentYear?.ToString() ?? project.ProjectTemplateInformationFyRevenueBalanceCarriedForward;
+            project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward = updateRequest.ProjectedRevenueBalanceAtEndMarchNextYear == default(decimal) ? null :
+                updateRequest.ProjectedRevenueBalanceAtEndMarchNextYear?.ToString() ?? project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward;
 
             return project;
         }
@@ -45,6 +47,10 @@ namespace TramsDataApi.Factories
             project.RisksAndIssuesSectionComplete = updateRequest.RisksAndIssuesSectionComplete ?? project.RisksAndIssuesSectionComplete;
             project.SchoolPerformanceAdditionalInformation = updateRequest.SchoolPerformanceAdditionalInformation ??
                 project.SchoolPerformanceAdditionalInformation;
+            project.CapitalCarryForwardAtEndMarchCurrentYear = updateRequest.CapitalCarryForwardAtEndMarchCurrentYear == default(decimal) ? null :
+                updateRequest.CapitalCarryForwardAtEndMarchCurrentYear ?? project.CapitalCarryForwardAtEndMarchCurrentYear;
+            project.CapitalCarryForwardAtEndMarchNextYear = updateRequest.CapitalCarryForwardAtEndMarchNextYear == default(decimal) ? null :
+                updateRequest.CapitalCarryForwardAtEndMarchNextYear ?? project.CapitalCarryForwardAtEndMarchNextYear;
             project.SchoolBudgetInformationAdditionalInformation = updateRequest.SchoolBudgetInformationAdditionalInformation ??
                 project.SchoolBudgetInformationAdditionalInformation;
             project.SchoolBudgetInformationSectionComplete = updateRequest.SchoolBudgetInformationSectionComplete ?? project.SchoolBudgetInformationSectionComplete;

--- a/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
@@ -16,6 +16,8 @@ namespace TramsDataApi.Factories
             project.ProjectTemplateInformationRationaleForProject = updateRequest.RationaleForProject ?? project.ProjectTemplateInformationRationaleForProject;
             project.ProjectTemplateInformationRationaleForSponsor = updateRequest.RationaleForTrust ?? project.ProjectTemplateInformationRationaleForSponsor;
             project.ProjectTemplateInformationRisksAndIssues = updateRequest.RisksAndIssues ?? project.ProjectTemplateInformationRisksAndIssues;
+            project.ProjectTemplateInformationFyRevenueBalanceCarriedForward = updateRequest.RevenueCarryForwardAtEndMarchCurrentYear?.ToString() ?? project.ProjectTemplateInformationFyRevenueBalanceCarriedForward;
+            project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward = updateRequest.ProjectedRevenueBalanceAtEndMarchNextYear?.ToString() ?? project.ProjectTemplateInformationFy1RevenueBalanceCarriedForward;
 
             return project;
         }
@@ -34,16 +36,18 @@ namespace TramsDataApi.Factories
             project.LocalAuthorityInformationTemplateReturnedDate =
                 updateRequest.LocalAuthorityInformationTemplateReturnedDate == default(DateTime) ?
                     null : updateRequest.LocalAuthorityInformationTemplateReturnedDate ?? project.LocalAuthorityInformationTemplateReturnedDate;
-            project.LocalAuthorityInformationTemplateComments =
-                updateRequest.LocalAuthorityInformationTemplateComments ??
+            project.LocalAuthorityInformationTemplateComments = updateRequest.LocalAuthorityInformationTemplateComments ??
                 project.LocalAuthorityInformationTemplateComments;
             project.LocalAuthorityInformationTemplateLink = updateRequest.LocalAuthorityInformationTemplateLink ??
                 project.LocalAuthorityInformationTemplateLink;
-            project.LocalAuthorityInformationTemplateSectionComplete =
-                updateRequest.LocalAuthorityInformationTemplateSectionComplete ??
+            project.LocalAuthorityInformationTemplateSectionComplete = updateRequest.LocalAuthorityInformationTemplateSectionComplete ??
                 project.LocalAuthorityInformationTemplateSectionComplete;
             project.RisksAndIssuesSectionComplete = updateRequest.RisksAndIssuesSectionComplete ?? project.RisksAndIssuesSectionComplete;
-            project.SchoolPerformanceAdditionalInformation = updateRequest.SchoolPerformanceAdditionalInformation ?? project.SchoolPerformanceAdditionalInformation;
+            project.SchoolPerformanceAdditionalInformation = updateRequest.SchoolPerformanceAdditionalInformation ??
+                project.SchoolPerformanceAdditionalInformation;
+            project.SchoolBudgetInformationAdditionalInformation = updateRequest.SchoolBudgetInformationAdditionalInformation ??
+                project.SchoolBudgetInformationAdditionalInformation;
+            project.SchoolBudgetInformationSectionComplete = updateRequest.SchoolBudgetInformationSectionComplete ?? project.SchoolBudgetInformationSectionComplete;
 
             return project;
         }

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -19,8 +19,10 @@ namespace TramsDataApi.Factories
 				RationaleForProject = ifdPipeline.ProjectTemplateInformationRationaleForProject,
 				RationaleForTrust = ifdPipeline.ProjectTemplateInformationRationaleForSponsor,
 				RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
-				RevenueCarryForwardAtEndMarchCurrentYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward),
-				ProjectedRevenueBalanceAtEndMarchNextYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward)
+				RevenueCarryForwardAtEndMarchCurrentYear = !string.IsNullOrEmpty(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward) ?
+				    decimal.Parse(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward) : (decimal?)null,
+				ProjectedRevenueBalanceAtEndMarchNextYear = !string.IsNullOrEmpty(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward) ?
+					decimal.Parse(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward) : (decimal?)null
 			};
 
 			if (academyConversionProject != null)
@@ -33,14 +35,10 @@ namespace TramsDataApi.Factories
 				response.LocalAuthorityInformationTemplateSectionComplete = academyConversionProject.LocalAuthorityInformationTemplateSectionComplete;
 				response.RisksAndIssuesSectionComplete = academyConversionProject.RisksAndIssuesSectionComplete;
 				response.SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation;
-				response.RevenueCarryForwardAtEndMarchCurrentYear =
-					academyConversionProject.RevenueCarryForwardAtEndMarchCurrentYear;
-				response.ProjectedRevenueBalanceAtEndMarchNextYear =
-					academyConversionProject.ProjectedRevenueBalanceAtEndMarchNextYear;
-				response.SchoolBudgetInformationAdditionalInformation =
-					academyConversionProject.SchoolBudgetInformationAdditionalInformation;
-				response.SchoolBudgetInformationSectionComplete =
-					academyConversionProject.SchoolBudgetInformationSectionComplete;
+				response.CapitalCarryForwardAtEndMarchCurrentYear = academyConversionProject.CapitalCarryForwardAtEndMarchCurrentYear;
+				response.CapitalCarryForwardAtEndMarchNextYear = academyConversionProject.CapitalCarryForwardAtEndMarchNextYear;
+				response.SchoolBudgetInformationAdditionalInformation = academyConversionProject.SchoolBudgetInformationAdditionalInformation;
+				response.SchoolBudgetInformationSectionComplete = academyConversionProject.SchoolBudgetInformationSectionComplete;
             }
 
 			return response;

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -19,6 +19,8 @@ namespace TramsDataApi.Factories
 				RationaleForProject = ifdPipeline.ProjectTemplateInformationRationaleForProject,
 				RationaleForTrust = ifdPipeline.ProjectTemplateInformationRationaleForSponsor,
 				RisksAndIssues = ifdPipeline.ProjectTemplateInformationRisksAndIssues,
+				RevenueCarryForwardAtEndMarchCurrentYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFyRevenueBalanceCarriedForward),
+				ProjectedRevenueBalanceAtEndMarchNextYear = decimal.Parse(ifdPipeline.ProjectTemplateInformationFy1RevenueBalanceCarriedForward)
 			};
 
 			if (academyConversionProject != null)
@@ -31,7 +33,15 @@ namespace TramsDataApi.Factories
 				response.LocalAuthorityInformationTemplateSectionComplete = academyConversionProject.LocalAuthorityInformationTemplateSectionComplete;
 				response.RisksAndIssuesSectionComplete = academyConversionProject.RisksAndIssuesSectionComplete;
 				response.SchoolPerformanceAdditionalInformation = academyConversionProject.SchoolPerformanceAdditionalInformation;
-			}
+				response.RevenueCarryForwardAtEndMarchCurrentYear =
+					academyConversionProject.RevenueCarryForwardAtEndMarchCurrentYear;
+				response.ProjectedRevenueBalanceAtEndMarchNextYear =
+					academyConversionProject.ProjectedRevenueBalanceAtEndMarchNextYear;
+				response.SchoolBudgetInformationAdditionalInformation =
+					academyConversionProject.SchoolBudgetInformationAdditionalInformation;
+				response.SchoolBudgetInformationSectionComplete =
+					academyConversionProject.SchoolBudgetInformationSectionComplete;
+            }
 
 			return response;
 		}


### PR DESCRIPTION
- Map the `RevenueCarryForwardAtEndMarchCurrentYear` and `ProjectedRevenueBalanceAtEndMarchNextYear` to their corresponding fields in the `IfdPipeline` table when retrieving and updating.
- Map the `CapitalCarryForwardAtEndMarchCurrentYear`, `CapitalCarryForwardAtEndMarchNextYear`, `SchoolBudgetAdditionalInformation` and `SchoolBudgetInformationSectionComplete` fields to their corresponding fields in the `AcademyConversionProject` table as they don't have existing corresponding fields in the sip database.
- Set School budget decimal fields to null if they're set to `default(decimal)` when updating.