### PR TITLE
Add fuzzy search

### DIFF
--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -430,7 +430,7 @@ namespace TramsDataApi.Test.Integration
         }
 
         [Fact]
-        public async Task ShouldReturnSubsetofTrust_WhenSearchingTrust_WithFuzzySearch_ByCompaniesHouse()
+        public async Task ShouldReturnSubsetofTrust_WhenSearchingTrust_WithFuzzySearch_ByCompaniesHouseNumber()
         {
             var companiesHousePartial = "cOmpanIesHouSEMoCk";
 

--- a/TramsDataApi.Test/TramsDataApiFactory.cs
+++ b/TramsDataApi.Test/TramsDataApiFactory.cs
@@ -15,6 +15,7 @@ namespace TramsDataApi.Test
         public TramsDataApiFactory(DbFixture dbFixture)
             => _dbFixture = dbFixture;
 
+
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseEnvironment("Test");

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -30,13 +30,11 @@ namespace TramsDataApi.Gateways
                 return _dbContext.Group.OrderBy(group => group.GroupUid).Skip((page - 1) * 10).Take(10).ToList();
             }
 
-            var groupToCheck = groupName?.ToLower();
-
             return _dbContext.Group
                 .Where(g => (
-                    g.GroupName.ToLower().Contains(groupToCheck) ||
-                    g.Ukprn == ukprn ||
-                    g.CompaniesHouseNumber == companiesHouseNumber
+                    g.GroupName.Contains(groupName) ||
+                    g.Ukprn.Contains(ukprn) ||
+                    g.CompaniesHouseNumber.Contains(companiesHouseNumber)
                 ))
                 .OrderBy(group => group.GroupUid)
                 .Skip((page - 1) * 10).Take(10).ToList();

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -29,10 +29,12 @@ namespace TramsDataApi.Gateways
             {
                 return _dbContext.Group.OrderBy(group => group.GroupUid).Skip((page - 1) * 10).Take(10).ToList();
             }
-            
+
+            var groupToCheck = groupName?.ToLower();
+
             return _dbContext.Group
                 .Where(g => (
-                    g.GroupName.ToLower().Contains(groupName.ToLower()) ||
+                    g.GroupName.ToLower().Contains(groupToCheck) ||
                     g.Ukprn == ukprn ||
                     g.CompaniesHouseNumber == companiesHouseNumber
                 ))

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -32,7 +32,7 @@ namespace TramsDataApi.Gateways
             
             return _dbContext.Group
                 .Where(g => (
-                    g.GroupName == groupName ||
+                    g.GroupName.ToLower().Contains(groupName.ToLower()) ||
                     g.Ukprn == ukprn ||
                     g.CompaniesHouseNumber == companiesHouseNumber
                 ))


### PR DESCRIPTION
**Add a Fuzzy Search feature to when searching Trusts by Group Name.**

1. Update the SearchGroups() method in the TrustGateway to include Contains()
2. Add new Integration Test to check for when searching by just a partial GroupName
3. Add new Integration Test to check for when searching by all parameters and a partial GroupName