### PR TITLE
Ensure project note date is set correctly regardless of where code is hosted

### DIFF
--- a/TramsDataApi.Test/Integration/AcademyConversionProjectNotesIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectNotesIntegrationTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using TimeZoneConverter;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.RequestModels.AcademyConversionProject;
 using TramsDataApi.ResponseModels.AcademyConversionProject;
@@ -142,7 +143,8 @@ namespace TramsDataApi.Test.Integration
             projectNoteInDb.Subject.Should().Be(addProjectNoteRequest.Subject);
             projectNoteInDb.Note.Should().Be(addProjectNoteRequest.Note);
             projectNoteInDb.Author.Should().Be(addProjectNoteRequest.Author);
-            projectNoteInDb.Date.Should().BeCloseTo(DateTime.Now, 1000);
+            var timeZoneInfo = TZConvert.GetTimeZoneInfo("GMT Standard Time");
+            projectNoteInDb.Date.Should().BeCloseTo(TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.UtcNow, timeZoneInfo.Id), 1000);
         }
 
         [Fact]

--- a/TramsDataApi/TramsDataApi.csproj
+++ b/TramsDataApi/TramsDataApi.csproj
@@ -16,6 +16,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.14" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+        <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TramsDataApi/UseCases/AddAcademyConversionProjectNote.cs
+++ b/TramsDataApi/UseCases/AddAcademyConversionProjectNote.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using TimeZoneConverter;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
 using TramsDataApi.RequestModels.AcademyConversionProject;
@@ -21,12 +22,14 @@ namespace TramsDataApi.UseCases
             if(!_tramsDbContext.AcademyConversionProjects.Any(p => p.Id == id))
                 return null;
 
+            var timeZoneInfo = TZConvert.GetTimeZoneInfo("GMT Standard Time");
+
             var projectNote = new AcademyConversionProjectNote
             {
                 Subject = request.Subject,
                 Note = request.Note,
                 Author = request.Author,
-                Date = DateTime.Now,
+                Date = TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.UtcNow, timeZoneInfo.Id),
                 AcademyConversionProjectId = id
             };
 


### PR DESCRIPTION
There was a bug with the project note date (the date at which the project note is created) whereby on the dev environment the `Date` field value was displaying as one-hour behind but was displaying correctly when running locally.

I assume this is because the server where the code is hosted thinks `DateTime.Now` is equivalent to GMT time, whereas my machine thinks `DateTime.Now` is equivalent to GMT + 1 (BST). 

Therefore I've changed it so that when the project note date is created, the UTC time is got and then converted to london's local time. 
This requires the time zone id, however, different operating systems use different values for the id of the same time zone (e.g. linux uses `Europe/London` and windows uses `GMT Standard Time` - the latter of which I find misleading because, despite the name, it does take into account BST). 
To handle this I have added the lightweight library `TimeZoneConverter` that will get the correct time zone id for the operating system - for example I could pass either `Europe/London` or `GMT Standard Time` to the `GetTimeZoneInfo` and it will return the correct time zone id for the current operating system.