### PR TITLE
Add keystage 5 response data and update tests

### DIFF
--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -90,6 +90,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = 50.00M)
                 .With(epd => epd.SipProgress8score = 50.00M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 50.00M)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 40.54M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 51.44M)
                 .Build();
 
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -127,6 +129,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8)
                 .With(epd => epd.SipMathsprogressscore = 4)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 77.76M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 53.78M)
                 .Build();
             
             var laAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -164,6 +168,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8)
                 .With(epd => epd.SipMathsprogressscore = 4)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 76.99M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 12.87M)
                 .Build();
                 
             var globalOptionMetadata = Builder<GlobalOptionSetMetadata>.CreateNew()
@@ -280,13 +286,17 @@ namespace TramsDataApi.Test.Integration
 
             var expectedKs4Response = new List<KeyStage4PerformanceResponse> {KeyStage4PerformanceResponseFactory
                 .Create(educationPerformanceData, nationalAverageEducationPerformanceData, laAverageEducationPerformanceData)};
+            
+            var expectedKs5Response = new List<KeyStage5PerformanceResponse> {KeyStage5PerformanceResponseFactory
+                .Create(educationPerformanceData, nationalAverageEducationPerformanceData, laAverageEducationPerformanceData)};
 
             var expected = new EducationalPerformanceResponse
             {
                 SchoolName = account.Name,
                 KeyStage1 = expectedKs1Response,
                 KeyStage2 = expectedKs2Response,
-                KeyStage4 = expectedKs4Response
+                KeyStage4 = expectedKs4Response,
+                KeyStage5 = expectedKs5Response
             };
             
             var response = await _client.GetAsync($"/educationPerformance/{accountUrn}");
@@ -303,7 +313,7 @@ namespace TramsDataApi.Test.Integration
         }
         
         [Fact]
-        public async Task CanGetEducationPerformanceDataWithKeyStage4Data()
+        public async Task CanGetEducationPerformanceDataWithKeyStage4And5Data()
         {
 
             var accountGuid = Guid.NewGuid();
@@ -352,6 +362,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = 100.49M)
                 .With(epd => epd.SipProgress8score = 99.17M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 37.78M)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 40.54M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 51.44M)
                 .Build();
 
             var nationalEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -389,6 +401,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8.00M)
                 .With(epd => epd.SipMathsprogressscore = 4.00M)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 66.33M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 71.55M)
                 .Build();
             
             var nationalEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -481,6 +495,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8.00M)
                 .With(epd => epd.SipMathsprogressscore = 4.00M)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
+                .With(epd => epd.SipAcademiclevelaveragepspe = 77.22M)
+                .With(epd => epd.SipAppliedgeneralaveragepspe = 67.87M)
                 .Build();
 
             var educationPerformanceDataList = new List<SipEducationalperformancedata>
@@ -688,12 +704,24 @@ namespace TramsDataApi.Test.Integration
                 LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence
             };
 
+            var expectedKeyStage5Response = new KeyStage5PerformanceResponse
+            {
+                Year = educationPerformanceData.SipName,
+                AcademicQualificationAverage = educationPerformanceData.SipAcademiclevelaveragepspe,
+                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedgeneralaveragepspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformance1.SipAcademiclevelaveragepspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance1.SipAppliedgeneralaveragepspe,
+                LAAcademicQualificationAverage = laEducationPerformance2.SipAcademiclevelaveragepspe,
+                LAAppliedGeneralQualificationAverage = laEducationPerformance2.SipAppliedgeneralaveragepspe
+            };
+
             var expected = new EducationalPerformanceResponse
             {
                 SchoolName = account.Name,
                 KeyStage1 = new List<KeyStage1PerformanceResponse>(),
                 KeyStage2 = new List<KeyStage2PerformanceResponse> { expectedKeyStage2Response },
-                KeyStage4 = new List<KeyStage4PerformanceResponse> { expectedKeyStage4Response }
+                KeyStage4 = new List<KeyStage4PerformanceResponse> { expectedKeyStage4Response },
+                KeyStage5 = new List<KeyStage5PerformanceResponse> { expectedKeyStage5Response }
             };
             
             var response = await _client.GetAsync($"/educationPerformance/{accountUrn}");
@@ -706,8 +734,8 @@ namespace TramsDataApi.Test.Integration
             _legacyDbContext.Account.RemoveRange(_legacyDbContext.Account);
             _legacyDbContext.SipEducationalperformancedata.RemoveRange(_legacyDbContext.SipEducationalperformancedata);
             _legacyDbContext.GlobalOptionSetMetadata.RemoveRange(_legacyDbContext.GlobalOptionSetMetadata);
-
         }
+        
 
         public void Dispose()
         {

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -90,8 +90,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = 50.00M)
                 .With(epd => epd.SipProgress8score = 50.00M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 50.00M)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 40.54M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 51.44M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
                 .Build();
 
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -129,8 +129,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8)
                 .With(epd => epd.SipMathsprogressscore = 4)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 77.76M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 53.78M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 77.76M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 53.78M)
                 .Build();
             
             var laAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -168,8 +168,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8)
                 .With(epd => epd.SipMathsprogressscore = 4)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 76.99M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 12.87M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 76.99M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 12.87M)
                 .Build();
                 
             var globalOptionMetadata = Builder<GlobalOptionSetMetadata>.CreateNew()
@@ -362,8 +362,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = 100.49M)
                 .With(epd => epd.SipProgress8score = 99.17M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 37.78M)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 40.54M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 51.44M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
                 .Build();
 
             var nationalEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -401,8 +401,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8.00M)
                 .With(epd => epd.SipMathsprogressscore = 4.00M)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 66.33M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 71.55M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 66.33M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 71.55M)
                 .Build();
             
             var nationalEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -495,8 +495,8 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipWritingprogressscoredisadv = 8.00M)
                 .With(epd => epd.SipMathsprogressscore = 4.00M)
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
-                .With(epd => epd.SipAcademiclevelaveragepspe = 77.22M)
-                .With(epd => epd.SipAppliedgeneralaveragepspe = 67.87M)
+                .With(epd => epd.SipAcademicLevelAveragePspe = 77.22M)
+                .With(epd => epd.SipAppliedGeneralAveragePspe = 67.87M)
                 .Build();
 
             var educationPerformanceDataList = new List<SipEducationalperformancedata>
@@ -707,12 +707,12 @@ namespace TramsDataApi.Test.Integration
             var expectedKeyStage5Response = new KeyStage5PerformanceResponse
             {
                 Year = educationPerformanceData.SipName,
-                AcademicQualificationAverage = educationPerformanceData.SipAcademiclevelaveragepspe,
-                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedgeneralaveragepspe,
-                NationalAcademicQualificationAverage = nationalEducationPerformance1.SipAcademiclevelaveragepspe,
-                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance1.SipAppliedgeneralaveragepspe,
-                LAAcademicQualificationAverage = laEducationPerformance2.SipAcademiclevelaveragepspe,
-                LAAppliedGeneralQualificationAverage = laEducationPerformance2.SipAppliedgeneralaveragepspe
+                AcademicQualificationAverage = educationPerformanceData.SipAcademicLevelAveragePspe,
+                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedGeneralAveragePspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformance1.SipAcademicLevelAveragePspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance1.SipAppliedGeneralAveragePspe,
+                LAAcademicQualificationAverage = laEducationPerformance2.SipAcademicLevelAveragePspe,
+                LAAppliedGeneralQualificationAverage = laEducationPerformance2.SipAppliedGeneralAveragePspe
             };
 
             var expected = new EducationalPerformanceResponse

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -477,12 +477,12 @@ namespace TramsDataApi.Test.UseCases
             var expectedKS5 = new KeyStage5PerformanceResponse
             {
                 Year = educationPerformanceData.SipName,
-                AcademicQualificationAverage = educationPerformanceData.SipAcademiclevelaveragepspe,
-                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedgeneralaveragepspe,
-                NationalAcademicQualificationAverage = nationalEducationPerformanceData2.SipAcademiclevelaveragepspe,
-                NationalAppliedGeneralQualificationAverage = nationalEducationPerformanceData2.SipAppliedgeneralaveragepspe,
-                LAAcademicQualificationAverage = localAuthorityEducationPerformance?.SipAcademiclevelaveragepspe,
-                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance?.SipAppliedgeneralaveragepspe
+                AcademicQualificationAverage = educationPerformanceData.SipAcademicLevelAveragePspe,
+                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedGeneralAveragePspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformanceData2.SipAcademicLevelAveragePspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformanceData2.SipAppliedGeneralAveragePspe,
+                LAAcademicQualificationAverage = localAuthorityEducationPerformance?.SipAcademicLevelAveragePspe,
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance?.SipAppliedGeneralAveragePspe
             };
             
             var expected = new EducationalPerformanceResponse

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -473,13 +473,25 @@ namespace TramsDataApi.Test.UseCases
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
             };
+
+            var expectedKS5 = new KeyStage5PerformanceResponse
+            {
+                Year = educationPerformanceData.SipName,
+                AcademicQualificationAverage = educationPerformanceData.SipAcademiclevelaveragepspe,
+                AppliedGeneralQualificationAverage = educationPerformanceData.SipAppliedgeneralaveragepspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformanceData2.SipAcademiclevelaveragepspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformanceData2.SipAppliedgeneralaveragepspe,
+                LAAcademicQualificationAverage = localAuthorityEducationPerformance?.SipAcademiclevelaveragepspe,
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance?.SipAppliedgeneralaveragepspe
+            };
             
             var expected = new EducationalPerformanceResponse
             {
                 SchoolName = account.Name,
                 KeyStage1 = expectedKs1,
                 KeyStage2 = new List<KeyStage2PerformanceResponse>{ expectedKs2 },
-                KeyStage4 = new List<KeyStage4PerformanceResponse>{ expectedKs4 }
+                KeyStage4 = new List<KeyStage4PerformanceResponse>{ expectedKs4 },
+                KeyStage5 = new List<KeyStage5PerformanceResponse>{ expectedKS5 }
             };
             
             var useCase = new GetKeyStagePerformanceByUrn(mockEducationPerformanceGateway.Object);

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -147,11 +147,11 @@ namespace TramsDataApi.DatabaseModels
                     
                 entity.Property(e => e.SipPerformancetype).HasColumnName("sip_performancetype");
                 
-                entity.Property(e => e.SipAppliedgeneralaveragepspe)
+                entity.Property(e => e.SipAppliedGeneralAveragePspe)
                     .HasColumnName("sip_appliedgeneralaveragepspe")
                     .HasColumnType("decimal(38, 2)");
                 
-                entity.Property(e => e.SipAcademiclevelaveragepspe)
+                entity.Property(e => e.SipAcademicLevelAveragePspe)
                     .HasColumnName("sip_academiclevelaveragepspe")
                     .HasColumnType("decimal(38, 2)");
             });

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -146,6 +146,14 @@ namespace TramsDataApi.DatabaseModels
                     .HasColumnType("decimal(38, 2)");
                     
                 entity.Property(e => e.SipPerformancetype).HasColumnName("sip_performancetype");
+                
+                entity.Property(e => e.SipAppliedgeneralaveragepspe)
+                    .HasColumnName("sip_appliedgeneralaveragepspe")
+                    .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipAcademiclevelaveragepspe)
+                    .HasColumnName("sip_academiclevelaveragepspe")
+                    .HasColumnType("decimal(38, 2)");
             });
         }
     }

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -44,5 +44,7 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipProgress8ebaccdisadvantaged { get; set; }
         
         public int? SipPerformancetype { get; set; }
+        public decimal? SipAppliedgeneralaveragepspe { get; set; }
+        public decimal? SipAcademiclevelaveragepspe { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -44,7 +44,7 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipProgress8ebaccdisadvantaged { get; set; }
         
         public int? SipPerformancetype { get; set; }
-        public decimal? SipAppliedgeneralaveragepspe { get; set; }
-        public decimal? SipAcademiclevelaveragepspe { get; set; }
+        public decimal? SipAppliedGeneralAveragePspe { get; set; }
+        public decimal? SipAcademicLevelAveragePspe { get; set; }
     }
 }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
@@ -43,8 +43,8 @@ namespace TramsDataApi.Factories
                     SipProgress8ebacc = nationalEducationPerformance1.SipProgress8ebacc ?? nationalEducationPerformance2.SipProgress8ebacc,
                     SipProgress8ebaccdisadvantaged = nationalEducationPerformance1.SipProgress8ebaccdisadvantaged ?? nationalEducationPerformance2.SipProgress8ebaccdisadvantaged,
                     SipPerformancetype = nationalEducationPerformance1.SipPerformancetype ?? nationalEducationPerformance2.SipPerformancetype,
-                    SipAcademiclevelaveragepspe = nationalEducationPerformance1.SipAcademiclevelaveragepspe ?? nationalEducationPerformance2.SipAcademiclevelaveragepspe,
-                    SipAppliedgeneralaveragepspe = nationalEducationPerformance1.SipAppliedgeneralaveragepspe ?? nationalEducationPerformance2.SipAppliedgeneralaveragepspe
+                    SipAcademicLevelAveragePspe = nationalEducationPerformance1.SipAcademicLevelAveragePspe ?? nationalEducationPerformance2.SipAcademicLevelAveragePspe,
+                    SipAppliedGeneralAveragePspe = nationalEducationPerformance1.SipAppliedGeneralAveragePspe ?? nationalEducationPerformance2.SipAppliedGeneralAveragePspe
                 };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
@@ -42,7 +42,9 @@ namespace TramsDataApi.Factories
                     SipProgress8mathsdisadvantaged = nationalEducationPerformance1.SipProgress8mathsdisadvantaged ?? nationalEducationPerformance2.SipProgress8mathsdisadvantaged,
                     SipProgress8ebacc = nationalEducationPerformance1.SipProgress8ebacc ?? nationalEducationPerformance2.SipProgress8ebacc,
                     SipProgress8ebaccdisadvantaged = nationalEducationPerformance1.SipProgress8ebaccdisadvantaged ?? nationalEducationPerformance2.SipProgress8ebaccdisadvantaged,
-                    SipPerformancetype = nationalEducationPerformance1.SipPerformancetype ?? nationalEducationPerformance2.SipPerformancetype
+                    SipPerformancetype = nationalEducationPerformance1.SipPerformancetype ?? nationalEducationPerformance2.SipPerformancetype,
+                    SipAcademiclevelaveragepspe = nationalEducationPerformance1.SipAcademiclevelaveragepspe ?? nationalEducationPerformance2.SipAcademiclevelaveragepspe,
+                    SipAppliedgeneralaveragepspe = nationalEducationPerformance1.SipAppliedgeneralaveragepspe ?? nationalEducationPerformance2.SipAppliedgeneralaveragepspe
                 };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
@@ -12,12 +12,12 @@ namespace TramsDataApi.Factories
             return new KeyStage5PerformanceResponse
             {
                 Year = educationalPerformanceData.SipName,
-                AcademicQualificationAverage = educationalPerformanceData.SipAcademiclevelaveragepspe,
-                AppliedGeneralQualificationAverage = educationalPerformanceData.SipAppliedgeneralaveragepspe,
-                NationalAcademicQualificationAverage = nationalEducationPerformance.SipAcademiclevelaveragepspe,
-                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance.SipAppliedgeneralaveragepspe,
-                LAAcademicQualificationAverage = localAuthorityEducationPerformance.SipAcademiclevelaveragepspe,
-                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance.SipAppliedgeneralaveragepspe
+                AcademicQualificationAverage = educationalPerformanceData.SipAcademicLevelAveragePspe,
+                AppliedGeneralQualificationAverage = educationalPerformanceData.SipAppliedGeneralAveragePspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformance.SipAcademicLevelAveragePspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance.SipAppliedGeneralAveragePspe,
+                LAAcademicQualificationAverage = localAuthorityEducationPerformance.SipAcademicLevelAveragePspe,
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance.SipAppliedGeneralAveragePspe
             };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
@@ -1,0 +1,24 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels.EducationalPerformance;
+
+namespace TramsDataApi.Factories
+{
+    public class KeyStage5PerformanceResponseFactory
+    {
+        public static KeyStage5PerformanceResponse Create(SipEducationalperformancedata educationalPerformanceData,
+            SipEducationalperformancedata nationalEducationPerformance,
+            SipEducationalperformancedata localAuthorityEducationPerformance)
+        {
+            return new KeyStage5PerformanceResponse
+            {
+                Year = educationalPerformanceData.SipName,
+                AcademicQualificationAverage = educationalPerformanceData.SipAcademiclevelaveragepspe,
+                AppliedGeneralQualificationAverage = educationalPerformanceData.SipAppliedgeneralaveragepspe,
+                NationalAcademicQualificationAverage = nationalEducationPerformance.SipAcademiclevelaveragepspe,
+                NationalAppliedGeneralQualificationAverage = nationalEducationPerformance.SipAppliedgeneralaveragepspe,
+                LAAcademicQualificationAverage = localAuthorityEducationPerformance.SipAcademiclevelaveragepspe,
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance.SipAppliedgeneralaveragepspe
+            };
+        }
+    }
+}

--- a/TramsDataApi/ResponseModels/EducationalPerformance/EducationalPerformanceResponse.cs
+++ b/TramsDataApi/ResponseModels/EducationalPerformance/EducationalPerformanceResponse.cs
@@ -8,5 +8,7 @@ namespace TramsDataApi.ResponseModels.EducationalPerformance
         public List<KeyStage1PerformanceResponse> KeyStage1 { get; set; }
         public List<KeyStage2PerformanceResponse> KeyStage2 { get; set; }
         public List<KeyStage4PerformanceResponse> KeyStage4 { get; set; }
+        
+        public List<KeyStage5PerformanceResponse> KeyStage5 { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage5PerformanceResponse.cs
+++ b/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage5PerformanceResponse.cs
@@ -1,0 +1,13 @@
+namespace TramsDataApi.ResponseModels.EducationalPerformance
+{
+    public class KeyStage5PerformanceResponse
+    {
+        public string Year { get; set; }
+        public decimal? AcademicQualificationAverage { get; set; }
+        public decimal? AppliedGeneralQualificationAverage { get; set; }
+        public decimal? NationalAcademicQualificationAverage { get; set; }
+        public decimal? NationalAppliedGeneralQualificationAverage { get; set; }
+        public decimal? LAAcademicQualificationAverage { get; set; }
+        public decimal? LAAppliedGeneralQualificationAverage { get; set; }
+    }
+}

--- a/TramsDataApi/UseCases/GetKeyStagePerformanceByUrn.cs
+++ b/TramsDataApi/UseCases/GetKeyStagePerformanceByUrn.cs
@@ -58,12 +58,24 @@ namespace TramsDataApi.UseCases
                         )
                 ).ToList();
             
+            var ks5Response = educationPerformance
+                .Select(epd => KeyStage5PerformanceResponseFactory
+                    .Create(epd, 
+                        nationalAverageEducationPerformances
+                            .FirstOrDefault(
+                                national => national.SipName == epd.SipName), 
+                        localAuthorityAverageEducationPerformances
+                            .FirstOrDefault(la => la.SipName == epd.SipName)
+                    )
+                ).ToList();
+            
             return new EducationalPerformanceResponse
             {
                 SchoolName = academy.Name,
                 KeyStage1 = ks1Responses,
                 KeyStage2 = ks2Response,
-                KeyStage4 = ks4Response
+                KeyStage4 = ks4Response,
+                KeyStage5 = ks5Response
             };
         }
         private List<SipEducationalperformancedata> GroupAverageEducationPerformances(IEnumerable<IGrouping<string, SipEducationalperformancedata>> enumerable)


### PR DESCRIPTION
This PR adds the keystage 5 data that we currently store in TRAMS db.