### PR TITLE
70670: MisEstablishment returning null for Further Education Establishments

### DIFF
--- a/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
@@ -13,9 +13,9 @@ namespace TramsDataApi.Test.Factories
         [AutoData]
         public void EstablishmentResponseFactory_CreatesEstablishmentResponse_FromAnEstablishment(Establishment establishment)
         {
-            var expected = BuildExpected(establishment, null, null);
+            var expected = BuildExpected(establishment, null, null, null);
 
-            var result = EstablishmentResponseFactory.Create(establishment, null, null);
+            var result = EstablishmentResponseFactory.Create(establishment, null, null, null);
 
             result.Should().BeEquivalentTo(expected);
         }
@@ -24,9 +24,9 @@ namespace TramsDataApi.Test.Factories
         [AutoData]
         public void EstablishmentResponseFactory_CreatesEstablishmentResponse_WithAMisEstablishment(Establishment establishment, MisEstablishments misEstablishments)
         {
-            var expected = BuildExpected(establishment, misEstablishments, null);
+            var expected = BuildExpected(establishment, misEstablishments, null, null);
 
-            var result = EstablishmentResponseFactory.Create(establishment, misEstablishments, null);
+            var result = EstablishmentResponseFactory.Create(establishment, misEstablishments, null, null);
 
             result.Should().BeEquivalentTo(expected);
         }
@@ -35,14 +35,28 @@ namespace TramsDataApi.Test.Factories
         [AutoData]
         public void EstablishmentResponseFactory_CreatesEstablishmentResponse_WithASmartData(Establishment establishment, SmartData smartData)
         {
-            var expected = BuildExpected(establishment, null, smartData);
+            var expected = BuildExpected(establishment, null, smartData, null);
 
-            var result = EstablishmentResponseFactory.Create(establishment, null, smartData);
+            var result = EstablishmentResponseFactory.Create(establishment, null, smartData, null);
 
             result.Should().BeEquivalentTo(expected);
         }
 
-        private EstablishmentResponse BuildExpected(Establishment establishment, MisEstablishments misEstablishments, SmartData smartData)
+        [Theory]
+        [AutoData]
+        public void EstablishmentResponseFactory_CreatesEstablishmentResponse_WithAFurtherEducationEstablishment(Establishment establishment, FurtherEducationEstablishments furtherEducationEstablishments)
+        {
+            var expected = BuildExpected(establishment, null, null, furtherEducationEstablishments);
+
+            var result = EstablishmentResponseFactory.Create(establishment, null, null, furtherEducationEstablishments);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        private EstablishmentResponse BuildExpected(Establishment establishment, 
+            MisEstablishments misEstablishments, 
+            SmartData smartData, 
+            FurtherEducationEstablishments furtherEducationEstablishments)
         {
             var expected = new EstablishmentResponse
             {
@@ -307,6 +321,47 @@ namespace TramsDataApi.Test.Factories
                     TotalNumberOfRisks = smartData.TotalNumberOfRisks.ToString(),
                     TotalRiskScore = smartData.TotalRiskScore.ToString(),
                     RiskRatingNum = smartData.RiskRatingNum.ToString()
+                };
+            }
+
+            if(furtherEducationEstablishments != null)
+            {
+                expected.MISFurtherEducationEstablishment = new MISFEAResponse
+                {
+                    Provider = new ProviderResponse
+                    {
+                        Urn = furtherEducationEstablishments.ProviderUrn,
+                        Name = furtherEducationEstablishments.ProviderName,
+                        Type = furtherEducationEstablishments.ProviderType,
+                        Group = furtherEducationEstablishments.ProviderGroup,
+                        Ukprn = furtherEducationEstablishments.ProviderUkprn
+                    },
+                    LocalAuthority = furtherEducationEstablishments.LocalAuthority,
+                    Region = furtherEducationEstablishments.Region,
+                    OfstedRegion = furtherEducationEstablishments.OfstedRegion,
+                    DateOfLatestShortInspection = furtherEducationEstablishments.DateOfLatestShortInspection,
+                    NumberOfShortInspectionsSinceLastFullInspection = furtherEducationEstablishments.NumberOfShortInspectionsSinceLastFullInspection.ToString(),
+                    NumberOfShortInspectionsSinceLastFullInspectionRAW = furtherEducationEstablishments.NumberOfShortInspectionsSinceLastFullInspectionRaw,
+                    InspectionNumber = furtherEducationEstablishments.InspectionNumber,
+                    FirstDayOfInspection = furtherEducationEstablishments.FirstDayOfInspection,
+                    LastDayOfInspection = furtherEducationEstablishments.LastDayOfInspection,
+                    InspectionType = furtherEducationEstablishments.InspectionType,
+                    DatePublished = furtherEducationEstablishments.DatePublished,
+                    OverallEffectiveness = furtherEducationEstablishments.OverallEffectiveness.ToString(),
+                    OverallEffectivenessRAW = furtherEducationEstablishments.OverallEffectivenessRaw,
+                    QualityOfEducation = furtherEducationEstablishments.QualityOfEducation.ToString(),
+                    QualityOfEducationRAW = furtherEducationEstablishments.QualityOfEducationRaw,
+                    BehaviourAndAttitudes = furtherEducationEstablishments.BehaviourAndAttitudes.ToString(),
+                    BehaviourAndAttitudesRAW = furtherEducationEstablishments.BehaviourAndAttitudesRaw,
+                    PersonalDevelopment = furtherEducationEstablishments.PersonalDevelopment.ToString(),
+                    PersonalDevelopmentRAW = furtherEducationEstablishments.PersonalDevelopmentRaw,
+                    EffectivenessOfLeadershipAndManagement = furtherEducationEstablishments.EffectivenessOfLeadershipAndManagement.ToString(),
+                    EffectivenessOfLeadershipAndManagementRAW = furtherEducationEstablishments.EffectivenessOfLeadershipAndManagementRaw,
+                    IsSafeguardingEffective = furtherEducationEstablishments.IsSafeguardingEffective,
+                    PreviousInspectionNumber = furtherEducationEstablishments.PreviousInspectionNumber,
+                    PreviousLastDayOfInspection = furtherEducationEstablishments.PreviousLastDayOfInspection,
+                    PreviousOverallEffectiveness = furtherEducationEstablishments.PreviousOverallEffectiveness.ToString(),
+                    PreviousOverallEffectivenessRAW = furtherEducationEstablishments.PreviousOverallEffectivenessRaw,
                 };
             }
 

--- a/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
@@ -229,14 +229,16 @@ namespace TramsDataApi.Test.Integration
                 .With(e => e.Urn = urn)
                 .Build();
             var misEstablishment = Builder<MisEstablishments>.CreateNew().With(m => m.Urn = establishment.Urn).Build();
+            var furtherEducationEstablishment = Builder<FurtherEducationEstablishments>.CreateNew().With(f => f.ProviderUrn = establishment.Urn).Build();
             var smartData = Generators.GenerateSmartData(establishment.Urn);
 
             _legacyDbContext.Establishment.Add(establishment);
             _legacyDbContext.MisEstablishments.Add(misEstablishment);
             _legacyDbContext.SmartData.Add(smartData);
+            _legacyDbContext.FurtherEducationEstablishments.Add(furtherEducationEstablishment);
             _legacyDbContext.SaveChanges();
 
-            return EstablishmentResponseFactory.Create(establishment, misEstablishment, smartData);
+            return EstablishmentResponseFactory.Create(establishment, misEstablishment, smartData, furtherEducationEstablishment);
         }
 
         public void Dispose()

--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -247,7 +247,7 @@ namespace TramsDataApi.Test.Integration
             
              var establishmentResponses = new List<EstablishmentResponse>
              {
-                 EstablishmentResponseFactory.Create(testEstablishment, misEstablishment, smartData)
+                 EstablishmentResponseFactory.Create(testEstablishment, misEstablishment, smartData, null)
              };
 
             var httpRequestMessage = new HttpRequestMessage

--- a/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetEstablishmentByUkprnTests.cs
@@ -43,7 +43,7 @@ namespace TramsDataApi.Test.UseCases
 
             _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
 
-            var expected = EstablishmentResponseFactory.Create(establishment, null, null);
+            var expected = EstablishmentResponseFactory.Create(establishment, null, null, null);
 
             var result = _useCase.Execute(UKPRN);
             
@@ -59,7 +59,7 @@ namespace TramsDataApi.Test.UseCases
             _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
             _establishmentGateway.Setup(gateway => gateway.GetMisEstablishmentByUrn(establishment.Urn)).Returns(misEstablishment);
 
-            var expected = EstablishmentResponseFactory.Create(establishment, misEstablishment, null);
+            var expected = EstablishmentResponseFactory.Create(establishment, misEstablishment, null, null);
             
             var result = _useCase.Execute(UKPRN);
             
@@ -75,10 +75,26 @@ namespace TramsDataApi.Test.UseCases
             _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
             _establishmentGateway.Setup(gateway => gateway.GetSmartDataByUrn(establishment.Urn)).Returns(smartData);
 
-            var expected = EstablishmentResponseFactory.Create(establishment, null, smartData);
+            var expected = EstablishmentResponseFactory.Create(establishment, null, smartData, null);
 
             var result = _useCase.Execute(UKPRN);
             
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void GetEstablishmentByUkprn_ReturnsEstablishmentWithFurtherEducationEstablishment_WhenFurtherEducationEstablishmentIsFound()
+        {
+            var establishment = Builder<Establishment>.CreateNew().With(e => e.Ukprn = UKPRN).Build();
+            var furtherEducationEstablishment = Builder<FurtherEducationEstablishments>.CreateNew().With(s => s.ProviderUrn = establishment.Urn).Build();
+
+            _establishmentGateway.Setup(gateway => gateway.GetByUkprn(UKPRN)).Returns(establishment);
+            _establishmentGateway.Setup(gateway => gateway.GetFurtherEducationEstablishmentByUrn(establishment.Urn)).Returns(furtherEducationEstablishment);
+
+            var expected = EstablishmentResponseFactory.Create(establishment, null, null, furtherEducationEstablishment);
+
+            var result = _useCase.Execute(UKPRN);
+
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -97,7 +113,7 @@ namespace TramsDataApi.Test.UseCases
 
             _establishmentGateway.Setup(gateway => gateway.GetByUrn(URN)).Returns(establishment);
 
-            var expected = EstablishmentResponseFactory.Create(establishment, null, null);
+            var expected = EstablishmentResponseFactory.Create(establishment, null, null, null);
 
             var result = _useCase.Execute(new GetEstablishmentByUrnRequest { URN = URN });
 

--- a/TramsDataApi.Test/UseCases/GetEstablishmentsByTrustUidTests.cs
+++ b/TramsDataApi.Test/UseCases/GetEstablishmentsByTrustUidTests.cs
@@ -34,7 +34,7 @@ namespace TramsDataApi.Test.UseCases
 
             establishmentsGateway.Setup(gateway => gateway.GetByTrustUid(trustUid)).Returns(establishments);
 
-            var expected = establishments.Select(e => EstablishmentResponseFactory.Create(e, null, null)).ToList();
+            var expected = establishments.Select(e => EstablishmentResponseFactory.Create(e, null, null, null)).ToList();
             var useCase = new GetEstablishmentsByTrustUid(establishmentsGateway.Object);
             var result = useCase.Execute(trustUid);
 
@@ -61,7 +61,7 @@ namespace TramsDataApi.Test.UseCases
 
             }
 
-            var expected = establishments.Select((e, i) => EstablishmentResponseFactory.Create(e, misEstablishments[i], null)).ToList();
+            var expected = establishments.Select((e, i) => EstablishmentResponseFactory.Create(e, misEstablishments[i], null, null)).ToList();
 ;
             var useCase = new GetEstablishmentsByTrustUid(establishmentsGateway.Object);
             var result = useCase.Execute(trustUid);
@@ -88,7 +88,34 @@ namespace TramsDataApi.Test.UseCases
                 establishmentsGateway.Setup(gateway => gateway.GetSmartDataByUrn(establishments[i].Urn)).Returns(smartDataList[i]);
             }
 
-            var expected = establishments.Select((e, i) => EstablishmentResponseFactory.Create(e, null, smartDataList[i])).ToList();
+            var expected = establishments.Select((e, i) => EstablishmentResponseFactory.Create(e, null, smartDataList[i], null)).ToList();
+            var useCase = new GetEstablishmentsByTrustUid(establishmentsGateway.Object);
+            var result = useCase.Execute(trustUid);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void GetEstablishmentsByTrustUid_ReturnsListOfEstablishmentResponseWithFurtherEducationEstablishment_WhenFurtherEducationEstablishmentIsFound()
+        {
+            var trustUid = "trustuid";
+            var establishmentsGateway = new Mock<IEstablishmentGateway>();
+            var establishments = Builder<Establishment>.CreateListOfSize(10).All()
+                .With(e => e.TrustsCode = trustUid).Build();
+
+            var furtherEducationEstablishments = Builder<FurtherEducationEstablishments>.CreateListOfSize(establishments.Count)
+                .All()
+                .With((m, i) => m.ProviderUrn = establishments[i].Urn)
+                .Build();
+
+            establishmentsGateway.Setup(gateway => gateway.GetByTrustUid(trustUid)).Returns(establishments);
+            for (var i = 0; i < establishments.Count; i++)
+            {
+                establishmentsGateway.Setup(gateway => gateway.GetFurtherEducationEstablishmentByUrn(establishments[i].Urn)).Returns(furtherEducationEstablishments[i]);
+            }
+
+            var expected = establishments.Select((e, i) => EstablishmentResponseFactory.Create(e, null, null, furtherEducationEstablishments[i])).ToList();
+
             var useCase = new GetEstablishmentsByTrustUid(establishmentsGateway.Object);
             var result = useCase.Execute(trustUid);
 

--- a/TramsDataApi/Factories/EstablishmentResponseFactory.cs
+++ b/TramsDataApi/Factories/EstablishmentResponseFactory.cs
@@ -5,7 +5,7 @@ namespace TramsDataApi.Factories
 {
     public class EstablishmentResponseFactory
     {
-        public static EstablishmentResponse Create(Establishment establishment, MisEstablishments misEstablishment, SmartData smartData)
+        public static EstablishmentResponse Create(Establishment establishment, MisEstablishments misEstablishment, SmartData smartData, FurtherEducationEstablishments furtherEducationEstablishments)
         {
             if (establishment == null)
             {
@@ -168,7 +168,7 @@ namespace TramsDataApi.Factories
                 Country = establishment.CountryName,
                 UPRN = establishment.Uprn,
                 MISEstablishment = MISEstablishmentResponseFactory.Create(misEstablishment),
-                MISFurtherEducationEstablishment = null,
+                MISFurtherEducationEstablishment = FurtherEducationEstablishmentResponseFactory.Create(furtherEducationEstablishments),
                 SMARTData = SmartDataResponseFactory.Create(smartData),
                 Financial = null,
                 Concerns = null

--- a/TramsDataApi/Factories/FurtherEducationEstablishmentResponseFactory.cs
+++ b/TramsDataApi/Factories/FurtherEducationEstablishmentResponseFactory.cs
@@ -1,0 +1,54 @@
+﻿using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.Factories
+{
+    public class FurtherEducationEstablishmentResponseFactory
+    {
+        public static MISFEAResponse Create(FurtherEducationEstablishments furtherEducationEstablishments)
+        {
+            if (furtherEducationEstablishments == null)
+            {
+                return null;
+            }
+
+            return new MISFEAResponse
+            {
+                Provider = new ProviderResponse
+                {
+                    Urn = furtherEducationEstablishments.ProviderUrn,
+                    Name = furtherEducationEstablishments.ProviderName,
+                    Type = furtherEducationEstablishments.ProviderType,
+                    Group = furtherEducationEstablishments.ProviderGroup,
+                    Ukprn = furtherEducationEstablishments.ProviderUkprn
+                },
+                LocalAuthority = furtherEducationEstablishments.LocalAuthority,
+                Region = furtherEducationEstablishments.Region,
+                OfstedRegion = furtherEducationEstablishments.OfstedRegion,
+                DateOfLatestShortInspection = furtherEducationEstablishments.DateOfLatestShortInspection,
+                NumberOfShortInspectionsSinceLastFullInspection = furtherEducationEstablishments.NumberOfShortInspectionsSinceLastFullInspection.ToString(),
+                NumberOfShortInspectionsSinceLastFullInspectionRAW = furtherEducationEstablishments.NumberOfShortInspectionsSinceLastFullInspectionRaw,
+                InspectionNumber = furtherEducationEstablishments.InspectionNumber,
+                FirstDayOfInspection = furtherEducationEstablishments.FirstDayOfInspection,
+                LastDayOfInspection = furtherEducationEstablishments.LastDayOfInspection,
+                InspectionType = furtherEducationEstablishments.InspectionType,
+                DatePublished = furtherEducationEstablishments.DatePublished,
+                OverallEffectiveness = furtherEducationEstablishments.OverallEffectiveness.ToString(),
+                OverallEffectivenessRAW = furtherEducationEstablishments.OverallEffectivenessRaw,
+                QualityOfEducation = furtherEducationEstablishments.QualityOfEducation.ToString(),
+                QualityOfEducationRAW = furtherEducationEstablishments.QualityOfEducationRaw,
+                BehaviourAndAttitudes = furtherEducationEstablishments.BehaviourAndAttitudes.ToString(),
+                BehaviourAndAttitudesRAW = furtherEducationEstablishments.BehaviourAndAttitudesRaw,
+                PersonalDevelopment = furtherEducationEstablishments.PersonalDevelopment.ToString(),
+                PersonalDevelopmentRAW = furtherEducationEstablishments.PersonalDevelopmentRaw,
+                EffectivenessOfLeadershipAndManagement = furtherEducationEstablishments.EffectivenessOfLeadershipAndManagement.ToString(),
+                EffectivenessOfLeadershipAndManagementRAW = furtherEducationEstablishments.EffectivenessOfLeadershipAndManagementRaw,
+                IsSafeguardingEffective = furtherEducationEstablishments.IsSafeguardingEffective,
+                PreviousInspectionNumber = furtherEducationEstablishments.PreviousInspectionNumber,
+                PreviousLastDayOfInspection = furtherEducationEstablishments.PreviousLastDayOfInspection,
+                PreviousOverallEffectiveness = furtherEducationEstablishments.PreviousOverallEffectiveness.ToString(),
+                PreviousOverallEffectivenessRAW = furtherEducationEstablishments.PreviousOverallEffectivenessRaw,
+            };
+        }
+    }
+}

--- a/TramsDataApi/Gateways/EstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/EstablishmentGateway.cs
@@ -34,6 +34,11 @@ namespace TramsDataApi.Gateways
             return _dbContext.MisEstablishments.FirstOrDefault(m => m.Urn == establishmentUrn);
         }
 
+        public FurtherEducationEstablishments GetFurtherEducationEstablishmentByUrn(int establishmentUrn)
+        {
+            return _dbContext.FurtherEducationEstablishments.FirstOrDefault(m => m.ProviderUrn == establishmentUrn);
+        }
+
         public SmartData GetSmartDataByUrn(int establishmentUrn)
         {
             return _dbContext.SmartData.FirstOrDefault(s => s.Urn == establishmentUrn.ToString());

--- a/TramsDataApi/Gateways/IEstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/IEstablishmentGateway.cs
@@ -14,5 +14,6 @@ namespace TramsDataApi.Gateways
         public SmartData GetSmartDataByUrn(int establishmentUrn);
 
         public IList<Establishment> SearchEstablishments(int? urn, string ukprn, string name);
+        public FurtherEducationEstablishments GetFurtherEducationEstablishmentByUrn(int establishmentUrn);
     }
 }

--- a/TramsDataApi/ResponseModels/ProviderResponse.cs
+++ b/TramsDataApi/ResponseModels/ProviderResponse.cs
@@ -1,5 +1,11 @@
 namespace TramsDataApi.ResponseModels
 {
     public class ProviderResponse
-    {}
+    {
+        public int Urn { get; set; }
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public string Group { get; set; }
+        public int? Ukprn { get; set; }
+    }
 }

--- a/TramsDataApi/UseCases/GetEstablishment.cs
+++ b/TramsDataApi/UseCases/GetEstablishment.cs
@@ -36,9 +36,14 @@ namespace TramsDataApi.UseCases
                 return null;
             }
             var misEstablishmentData = _establishmentGateway.GetMisEstablishmentByUrn(establishment.Urn);
+            var furtherEstablishmentData = _establishmentGateway.GetFurtherEducationEstablishmentByUrn(establishment.Urn);
             var smartData = _establishmentGateway.GetSmartDataByUrn(establishment.Urn);
 
-            return EstablishmentResponseFactory.Create(establishment, misEstablishmentData, smartData);
+            return EstablishmentResponseFactory.Create(establishment, 
+                misEstablishmentData, 
+                smartData,
+                furtherEstablishmentData
+                );
         }
     }
 }

--- a/TramsDataApi/UseCases/GetEstablishmentsByTrustUid.cs
+++ b/TramsDataApi/UseCases/GetEstablishmentsByTrustUid.cs
@@ -19,7 +19,7 @@ namespace TramsDataApi.UseCases
         {
             return _establishmentGateway.GetByTrustUid(trustUid)
                 .Select(e =>
-                    EstablishmentResponseFactory.Create(e, _establishmentGateway.GetMisEstablishmentByUrn(e.Urn), _establishmentGateway.GetSmartDataByUrn(e.Urn))
+                    EstablishmentResponseFactory.Create(e, _establishmentGateway.GetMisEstablishmentByUrn(e.Urn), _establishmentGateway.GetSmartDataByUrn(e.Urn), _establishmentGateway.GetFurtherEducationEstablishmentByUrn(e.Urn))
                     )
                 .ToList();
         }


### PR DESCRIPTION
**Issue**
When attempting to get data from a Further Education Establishment, the `MisEstablishment` field comes back as null because a Further Education Establishment does not exist in the `Mis.Establishments` table. However, they do exist in the `Mis.FurtherEducationEstablishments` table.

At present the `MISFurtherEducationEstablishment` property in the response is set to null. Instead it needs to make its own call to the database to bring back a more appropriate result.

**Solution**
Build out a new vertical slice that interacts with the `Mis.FurtherEducationEstablishments` table and utilize the existing `FurtherEducationEstablishments` DatabaseModel and the existing `MISFEAResponse`. 

**Approach**
1. Update the existing EstablishmentResponseFactory to take a `FurtherEducationEstablishments` argument
2. Then create a new `FurtherEducationEstablishmentResponseFactory` to return a `MISFEAResponse` to the `EstablishmentResponse.MISFurtherEducationEstablishment` property
3. Create a new method in `EstablishmentGateway` called `GetFurtherEducationEstablishmentByUrn(int establishmentUrn)` to get the Further Education Establishment info from the database