### PR TITLE
Add check for account's local authority when getting education performance data

### DIFF
--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -43,6 +43,7 @@ namespace TramsDataApi.Test.Integration
                 .With(a => a.Name = "Gillshill Primary School")
                 .With(a => a.SipUrn = accountUrn)
                 .With(a => a.Id = accountGuid)
+                .With(a => a.SipLocalAuthorityNumber = 123)
                 .Build();
 
             var phonics = Builder<SipPhonics>.CreateListOfSize(3)
@@ -58,6 +59,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.Id = Guid.NewGuid())
                 .With(epd => epd.SipParentaccountid = accountGuid)
                 .With(epd => epd.SipName = "2016-2017")
+                .With(epd => epd.SipLocalauthoritycode = null)
                 .With(epd => epd.SipMeetingexpectedstandardinrwm = 20)
                 .With(epd => epd.SipMeetingexpectedstandardinrwmdisadv = 10)
                 .With(epd => epd.SipMeetinghigherstandardinrwm = 12)
@@ -97,6 +99,7 @@ namespace TramsDataApi.Test.Integration
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
                 .With(epd => epd.SipParentaccountid = null)
+                .With(epd => epd.SipLocalauthoritycode = null)
                 .With(epd => epd.SipPerformancetype = 123)
                 .With(epd => epd.SipName = "2016-2017")
                 .With(epd => epd.SipAttainment8score = 100.23M)
@@ -135,6 +138,7 @@ namespace TramsDataApi.Test.Integration
             
             var laAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
+                .With(epd => epd.SipLocalauthoritycode = "123")
                 .With(epd => epd.SipParentaccountid = null)
                 .With(epd => epd.SipPerformancetype = 234)
                 .With(epd => epd.SipName = "2016-2017")
@@ -323,12 +327,14 @@ namespace TramsDataApi.Test.Integration
                 .With(a => a.Name = "Gillshill Primary School")
                 .With(a => a.SipUrn = accountUrn)
                 .With(a => a.Id = accountGuid)
+                .With(a => a.SipLocalAuthorityNumber = 456)
                 .Build();
 
             
             var educationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
                 .With(epd => epd.SipParentaccountid = accountGuid)
+                .With(epd => epd.SipLocalauthoritycode = null)
                 .With(epd => epd.SipName = "2016-2017")
                 .With(epd => epd.SipMeetingexpectedstandardinrwm = 20.00M)
                 .With(epd => epd.SipMeetingexpectedstandardinrwmdisadv = 10.00M)
@@ -368,6 +374,7 @@ namespace TramsDataApi.Test.Integration
 
             var nationalEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
+                .With(epd => epd.SipLocalauthoritycode = null)
                 .With(epd => epd.SipParentaccountid = null)
                 .With(epd => epd.SipPerformancetype = 123)
                 .With(epd => epd.SipName = "2016-2017")
@@ -407,6 +414,7 @@ namespace TramsDataApi.Test.Integration
             
             var nationalEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
+                .With(epd => epd.SipLocalauthoritycode = null)
                 .With(epd => epd.SipParentaccountid = null)
                 .With(epd => epd.SipPerformancetype = 123)
                 .With(epd => epd.SipName = "2017-2018")
@@ -434,6 +442,7 @@ namespace TramsDataApi.Test.Integration
             
             var laEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
+                .With(epd => epd.SipLocalauthoritycode = "456")
                 .With(epd => epd.SipParentaccountid = null)
                 .With(epd => epd.SipPerformancetype = 234)
                 .With(epd => epd.SipName = "2017-2018")
@@ -462,6 +471,7 @@ namespace TramsDataApi.Test.Integration
             
             var laEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
                 .With(epd => epd.Id = Guid.NewGuid())
+                .With(epd => epd.SipLocalauthoritycode = "456")
                 .With(epd => epd.SipParentaccountid = null)
                 .With(epd => epd.SipPerformancetype = 234)
                 .With(epd => epd.SipName = "2016-2017")

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -235,7 +235,7 @@ namespace TramsDataApi.Test.UseCases
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetPhonicsByUrn(urn)).Returns(() => phonics);
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetEducationalPerformanceForAccount(account)).Returns(() => new List<SipEducationalperformancedata> {educationPerformanceData});
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetNationalEducationalPerformanceData()).Returns(nationalEducationPerformanceDataList);
-            mockEducationPerformanceGateway.Setup(gateway => gateway.GetLocalAuthorityEducationalPerformanceData()).Returns(localAuthorityPerformanceDataList);
+            mockEducationPerformanceGateway.Setup(gateway => gateway.GetLocalAuthorityEducationalPerformanceData(account)).Returns(localAuthorityPerformanceDataList);
 
             
             var expectedKs1 = phonics.Select(ph => new KeyStage1PerformanceResponse

--- a/TramsDataApi/DatabaseModels/Account.cs
+++ b/TramsDataApi/DatabaseModels/Account.cs
@@ -7,5 +7,6 @@ namespace TramsDataApi.DatabaseModels
             public Guid Id { get; set; }
             public string SipUrn { get; set; }
             public string Name { get; set; }
+            public int SipLocalAuthorityNumber { get; set; }
         }
 }

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -154,6 +154,10 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.SipAcademicLevelAveragePspe)
                     .HasColumnName("sip_academiclevelaveragepspe")
                     .HasColumnType("decimal(38, 2)");
+                    
+                entity.Property(e => e.SipLocalauthoritycode)
+                    .HasColumnName("sip_localauthoritycode")
+                    .HasMaxLength(100);
             });
         }
     }

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.cs
@@ -2174,6 +2174,9 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.SipUrn)
                     .HasColumnName("sip_urn")
                     .HasMaxLength(100);
+
+                entity.Property(e => e.SipLocalAuthorityNumber)
+                    .HasColumnName("sip_localauthoritynumber");
             });
             
             modelBuilder.Entity<GlobalOptionSetMetadata>(entity =>

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -42,9 +42,9 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipProgress8mathsdisadvantaged { get; set; }
         public decimal? SipProgress8ebacc { get; set; }
         public decimal? SipProgress8ebaccdisadvantaged { get; set; }
-        
         public int? SipPerformancetype { get; set; }
         public decimal? SipAppliedGeneralAveragePspe { get; set; }
         public decimal? SipAcademicLevelAveragePspe { get; set; }
+        public string SipLocalauthoritycode { get; set; }
     }
 }

--- a/TramsDataApi/Gateways/EducationPerformanceGateway.cs
+++ b/TramsDataApi/Gateways/EducationPerformanceGateway.cs
@@ -47,7 +47,7 @@ namespace TramsDataApi.Gateways
             return results;
         }
         
-        public IList<SipEducationalperformancedata> GetLocalAuthorityEducationalPerformanceData()
+        public IList<SipEducationalperformancedata> GetLocalAuthorityEducationalPerformanceData(Account account)
         {
             var results = _dbContext.SipEducationalperformancedata
                 .Join(_dbContext.GlobalOptionSetMetadata,
@@ -56,6 +56,7 @@ namespace TramsDataApi.Gateways
                     (gpd, gom) => new {performanceData = gpd, globalMetaData = gom})
                 .Where(data => data.globalMetaData.OptionSetName == "sip_performancetype")
                 .Where(data => data.globalMetaData.LocalizedLabel == "Authority")
+                .Where(data => data.performanceData.SipLocalauthoritycode == account.SipLocalAuthorityNumber.ToString())
                 .Select(data => data.performanceData).ToList();
 
             return results;

--- a/TramsDataApi/Gateways/IEducationPerformanceGateway.cs
+++ b/TramsDataApi/Gateways/IEducationPerformanceGateway.cs
@@ -10,6 +10,6 @@ namespace TramsDataApi.Gateways
         public IList<SipPhonics> GetPhonicsByUrn(string urn);
         public IList<SipEducationalperformancedata> GetEducationalPerformanceForAccount(Account account);
         public IList<SipEducationalperformancedata> GetNationalEducationalPerformanceData();
-        public IList<SipEducationalperformancedata> GetLocalAuthorityEducationalPerformanceData();
+        public IList<SipEducationalperformancedata> GetLocalAuthorityEducationalPerformanceData(Account account);
     }
 }

--- a/TramsDataApi/UseCases/GetKeyStagePerformanceByUrn.cs
+++ b/TramsDataApi/UseCases/GetKeyStagePerformanceByUrn.cs
@@ -35,7 +35,7 @@ namespace TramsDataApi.UseCases
             
             var nationalAverageEducationPerformances = GroupAverageEducationPerformances(groupedNationalAverages);
             
-            var groupedLAAverages = _educationPerformanceGateway.GetLocalAuthorityEducationalPerformanceData().GroupBy(epd => epd.SipName);
+            var groupedLAAverages = _educationPerformanceGateway.GetLocalAuthorityEducationalPerformanceData(academy).GroupBy(epd => epd.SipName);
 
             var localAuthorityAverageEducationPerformances = GroupAverageEducationPerformances(groupedLAAverages);
 


### PR DESCRIPTION
This PR adds a check to ensure that the Local authority performance data is for the Local Authority for the requested academy.