### PR TITLE
Map previous head teacher board fields when updating and retrieving ACP

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -62,7 +62,8 @@ namespace TramsDataApi.Test.Factories
                 LocalAuthorityInformationTemplateSentDate = default(DateTime),
                 LocalAuthorityInformationTemplateReturnedDate = default(DateTime),
                 CapitalCarryForwardAtEndMarchCurrentYear = default(decimal),
-                CapitalCarryForwardAtEndMarchNextYear = default(decimal)
+                CapitalCarryForwardAtEndMarchNextYear = default(decimal),
+                PreviousHeadTeacherBoardDate = default(DateTime)
             };
 
             var expected = JsonConvert.DeserializeObject<AcademyConversionProject>(JsonConvert.SerializeObject(academyConversionProject));
@@ -70,6 +71,7 @@ namespace TramsDataApi.Test.Factories
             expected.LocalAuthorityInformationTemplateReturnedDate = null;
             expected.CapitalCarryForwardAtEndMarchCurrentYear = null;
             expected.CapitalCarryForwardAtEndMarchNextYear = null;
+            expected.PreviousHeadTeacherBoardDate = null;
             AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest).Should().BeEquivalentTo(expected);
         }
 
@@ -102,6 +104,8 @@ namespace TramsDataApi.Test.Factories
             expected.LocalAuthorityInformationTemplateSectionComplete = updateRequest.LocalAuthorityInformationTemplateSectionComplete;
             expected.RecommendationForProject = updateRequest.RecommendationForProject;
             expected.AcademyOrderRequired = updateRequest.AcademyOrderRequired;
+            expected.PreviousHeadTeacherBoardDateQuestion = updateRequest.PreviousHeadTeacherBoardDateQuestion;
+            expected.PreviousHeadTeacherBoardDate = updateRequest.PreviousHeadTeacherBoardDate;
             expected.SchoolAndTrustInformationSectionComplete = updateRequest.SchoolAndTrustInformationSectionComplete;
             expected.DistanceFromSchoolToTrustHeadquarters = updateRequest.DistanceFromSchoolToTrustHeadquarters;
             expected.DistanceFromSchoolToTrustHeadquartersAdditionalInformation = updateRequest.DistanceFromSchoolToTrustHeadquartersAdditionalInformation;

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -41,7 +41,7 @@ namespace TramsDataApi.Test.Factories
         }
 
         [Fact]
-        public void ReturnsAnAcademyConversionProjectResponse_WhenGivenAcademyConversionProjectWithNullSchoolBudgetAndPupilForecaseValues()
+        public void ReturnsAnAcademyConversionProjectResponse_WhenGivenAcademyConversionProjectWithNullSchoolBudgetAndPupilForecastValues()
         {
               var academyConversionProject = _fixture.Build<AcademyConversionProject>()
                 .Without(x => x.CapitalCarryForwardAtEndMarchCurrentYear)
@@ -92,6 +92,8 @@ namespace TramsDataApi.Test.Factories
                 AcademyOrderRequired = academyConversionProject.AcademyOrderRequired,
                 DistanceFromSchoolToTrustHeadquarters = academyConversionProject.DistanceFromSchoolToTrustHeadquarters,
                 DistanceFromSchoolToTrustHeadquartersAdditionalInformation = academyConversionProject.DistanceFromSchoolToTrustHeadquartersAdditionalInformation,
+                PreviousHeadTeacherBoardDateQuestion = academyConversionProject.PreviousHeadTeacherBoardDateQuestion,
+                PreviousHeadTeacherBoardDate = academyConversionProject.PreviousHeadTeacherBoardDate,
                 SchoolAndTrustInformationSectionComplete = academyConversionProject.SchoolAndTrustInformationSectionComplete,
                 GeneralInformationSectionComplete = academyConversionProject.GeneralInformationSectionComplete,
                 RationaleSectionComplete = academyConversionProject.RationaleSectionComplete,

--- a/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
@@ -157,6 +157,14 @@ namespace TramsDataApi.Test.Integration
             academyConversionProject.SchoolBudgetInformationSectionComplete.Should().Be(updateRequest.SchoolBudgetInformationSectionComplete);
             academyConversionProject.SchoolPupilForecastsAdditionalInformation.Should().Be(updateRequest.SchoolPupilForecastsAdditionalInformation);
             academyConversionProject.KeyStagePerformanceTablesAdditionalInformation.Should().Be(updateRequest.KeyStagePerformanceTablesAdditionalInformation);
+            academyConversionProject.RecommendationForProject.Should().Be(updateRequest.RecommendationForProject);
+            academyConversionProject.Author.Should().Be(updateRequest.Author);
+            academyConversionProject.ClearedBy.Should().Be(updateRequest.ClearedBy);
+            academyConversionProject.HeadTeacherBoardDate.Should().Be(updateRequest.HeadTeacherBoardDate);
+            academyConversionProject.PreviousHeadTeacherBoardDateQuestion.Should().Be(updateRequest.PreviousHeadTeacherBoardDateQuestion);
+            academyConversionProject.PreviousHeadTeacherBoardDate.Should().Be(updateRequest.PreviousHeadTeacherBoardDate);
+            academyConversionProject.ProposedAcademyOpeningDate.Should().Be(updateRequest.ProposedAcademyOpeningDate);
+            academyConversionProject.SchoolAndTrustInformationSectionComplete.Should().Be(updateRequest.SchoolAndTrustInformationSectionComplete);
         }
 
         private AcademyConversionProjectResponse CreateExpectedApiResponse(Trust trust, AcademyConversionProject academyConversionProject, UpdateAcademyConversionProjectRequest updateRequest)

--- a/TramsDataApi/DatabaseModels/AcademyConversionProject.cs
+++ b/TramsDataApi/DatabaseModels/AcademyConversionProject.cs
@@ -33,6 +33,7 @@ namespace TramsDataApi.DatabaseModels
         public string ClearedBy { get; set; }
         public string AcademyOrderRequired { get; set; }
         public DateTime? PreviousHeadTeacherBoardDate { get; set; }
+        public string PreviousHeadTeacherBoardDateQuestion { get; set; }
         public string PreviousHeadTeacherBoardLink { get; set; }
         public string TrustReferenceNumber { get; set; }
         public string NameOfTrust { get; set; }

--- a/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
@@ -78,6 +78,10 @@ namespace TramsDataApi.Factories
                 updateRequest.YearThreeProjectedPupilNumbers ?? project.YearThreeProjectedPupilNumbers;
             project.KeyStagePerformanceTablesAdditionalInformation = updateRequest.KeyStagePerformanceTablesAdditionalInformation ??
                 project.KeyStagePerformanceTablesAdditionalInformation;
+            project.PreviousHeadTeacherBoardDateQuestion = updateRequest.PreviousHeadTeacherBoardDateQuestion ??
+                project.PreviousHeadTeacherBoardDateQuestion;
+            project.PreviousHeadTeacherBoardDate = updateRequest.PreviousHeadTeacherBoardDate == default(DateTime) ? null
+                : updateRequest.PreviousHeadTeacherBoardDate ?? project.PreviousHeadTeacherBoardDate;
 
             return project;
         }

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -42,6 +42,8 @@ namespace TramsDataApi.Factories
 				LocalAuthorityInformationTemplateSectionComplete = academyConversionProject.LocalAuthorityInformationTemplateSectionComplete,
 				RecommendationForProject = academyConversionProject.RecommendationForProject,
 				AcademyOrderRequired = academyConversionProject.AcademyOrderRequired,
+				PreviousHeadTeacherBoardDateQuestion = academyConversionProject.PreviousHeadTeacherBoardDateQuestion,
+				PreviousHeadTeacherBoardDate = academyConversionProject.PreviousHeadTeacherBoardDate,
 				SchoolAndTrustInformationSectionComplete = academyConversionProject.SchoolAndTrustInformationSectionComplete,
 				DistanceFromSchoolToTrustHeadquarters = academyConversionProject.DistanceFromSchoolToTrustHeadquarters,
 				DistanceFromSchoolToTrustHeadquartersAdditionalInformation = academyConversionProject.DistanceFromSchoolToTrustHeadquartersAdditionalInformation,

--- a/TramsDataApi/Migrations/TramsDb/20210722160223_AddPrevHtbDateQuestionFieldToACP.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20210722160223_AddPrevHtbDateQuestionFieldToACP.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210722160223_AddPrevHtbDateQuestionFieldToACP")]
+    partial class AddPrevHtbDateQuestionFieldToACP
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20210722160223_AddPrevHtbDateQuestionFieldToACP.cs
+++ b/TramsDataApi/Migrations/TramsDb/20210722160223_AddPrevHtbDateQuestionFieldToACP.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class AddPrevHtbDateQuestionFieldToACP : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousHeadTeacherBoardDateQuestion",
+                schema: "sdd",
+                table: "AcademyConversionProject",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreviousHeadTeacherBoardDateQuestion",
+                schema: "sdd",
+                table: "AcademyConversionProject");
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
+++ b/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
@@ -25,6 +25,8 @@ namespace TramsDataApi.RequestModels.AcademyConversionProject
         public string AcademyOrderRequired { get; set; }
         public DateTime? ProposedAcademyOpeningDate { get; set; }
         public bool? SchoolAndTrustInformationSectionComplete { get; set; }
+        public string PreviousHeadTeacherBoardDateQuestion { get; set; }
+        public DateTime? PreviousHeadTeacherBoardDate { get; set; }
 
         //general info
         public string PublishedAdmissionNumber { get; set; }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
@@ -29,6 +29,7 @@ namespace TramsDataApi.ResponseModels.AcademyConversionProject
         public string Version { get; set; }
         public string ClearedBy { get; set; }
         public string AcademyOrderRequired { get; set; }
+        public string PreviousHeadTeacherBoardDateQuestion { get; set; }
         public DateTime? PreviousHeadTeacherBoardDate { get; set; }
         public string PreviousHeadTeacherBoardLink { get; set; }
         public string TrustReferenceNumber { get; set; }


### PR DESCRIPTION
- Add new field `PreviousHeadTeacherBoardDateQuestion` to `AcademyConversionProject` table
- Map `PreviousHeadTeacherBoard` field in ACP update route
- Map `PreviousHeadTeacherBoardDateQuestion` field in ACP get and patch routes