### PR TITLE
KS4 additional info

### DIFF
--- a/TramsDataApi.ApplyToBecome/SyncAcademyConversionProject.cs
+++ b/TramsDataApi.ApplyToBecome/SyncAcademyConversionProject.cs
@@ -95,9 +95,6 @@ namespace TramsDataApi.ApplyToBecome
         public int? YearTwoProjectedPupilNumbers { get; set; }
         public int? YearThreeProjectedCapacity { get; set; }
         public int? YearThreeProjectedPupilNumbers { get; set; }
-        public string SchoolPupilForecastsAdditionalInformation { get; set; }
 
-        //key stage performance
-        public string KeyStagePerformanceTablesAdditionalInformation { get; set; }
     }
 }

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -123,7 +123,8 @@ namespace TramsDataApi.Test.Factories
             expected.YearTwoProjectedPupilNumbers = updateRequest.YearTwoProjectedPupilNumbers;
             expected.YearThreeProjectedCapacity = updateRequest.YearThreeProjectedCapacity;
             expected.YearThreeProjectedPupilNumbers = updateRequest.YearThreeProjectedPupilNumbers;
-            expected.KeyStagePerformanceTablesAdditionalInformation = updateRequest.KeyStagePerformanceTablesAdditionalInformation;
+            expected.KeyStage2PerformanceAdditionalInformation = updateRequest.KeyStage2PerformanceAdditionalInformation;
+            expected.KeyStage4PerformanceAdditionalInformation = updateRequest.KeyStage4PerformanceAdditionalInformation;
 
             return expected;
         }

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectResponseFactoryTests.cs
@@ -115,7 +115,8 @@ namespace TramsDataApi.Test.Factories
                 YearTwoProjectedPupilNumbers = academyConversionProject.YearTwoProjectedPupilNumbers,
                 YearThreeProjectedCapacity = academyConversionProject.YearThreeProjectedCapacity,
                 YearThreeProjectedPupilNumbers = academyConversionProject.YearThreeProjectedPupilNumbers,
-                KeyStagePerformanceTablesAdditionalInformation = academyConversionProject.KeyStagePerformanceTablesAdditionalInformation
+                KeyStage2PerformanceAdditionalInformation = academyConversionProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation = academyConversionProject.KeyStage4PerformanceAdditionalInformation
             };
             if (trust != null)
             {

--- a/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
@@ -157,6 +157,7 @@ namespace TramsDataApi.Test.Integration
             academyConversionProject.SchoolBudgetInformationSectionComplete.Should().Be(updateRequest.SchoolBudgetInformationSectionComplete);
             academyConversionProject.SchoolPupilForecastsAdditionalInformation.Should().Be(updateRequest.SchoolPupilForecastsAdditionalInformation);
             academyConversionProject.KeyStage2PerformanceAdditionalInformation.Should().Be(updateRequest.KeyStage2PerformanceAdditionalInformation);
+            academyConversionProject.KeyStage4PerformanceAdditionalInformation.Should().Be(updateRequest.KeyStage4PerformanceAdditionalInformation);
             academyConversionProject.RecommendationForProject.Should().Be(updateRequest.RecommendationForProject);
             academyConversionProject.Author.Should().Be(updateRequest.Author);
             academyConversionProject.ClearedBy.Should().Be(updateRequest.ClearedBy);

--- a/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
@@ -156,7 +156,7 @@ namespace TramsDataApi.Test.Integration
             academyConversionProject.SchoolBudgetInformationAdditionalInformation.Should().Be(updateRequest.SchoolBudgetInformationAdditionalInformation);
             academyConversionProject.SchoolBudgetInformationSectionComplete.Should().Be(updateRequest.SchoolBudgetInformationSectionComplete);
             academyConversionProject.SchoolPupilForecastsAdditionalInformation.Should().Be(updateRequest.SchoolPupilForecastsAdditionalInformation);
-            academyConversionProject.KeyStagePerformanceTablesAdditionalInformation.Should().Be(updateRequest.KeyStagePerformanceTablesAdditionalInformation);
+            academyConversionProject.KeyStage2PerformanceAdditionalInformation.Should().Be(updateRequest.KeyStage2PerformanceAdditionalInformation);
             academyConversionProject.RecommendationForProject.Should().Be(updateRequest.RecommendationForProject);
             academyConversionProject.Author.Should().Be(updateRequest.Author);
             academyConversionProject.ClearedBy.Should().Be(updateRequest.ClearedBy);

--- a/TramsDataApi/DatabaseModels/AcademyConversionProject.cs
+++ b/TramsDataApi/DatabaseModels/AcademyConversionProject.cs
@@ -99,6 +99,7 @@ namespace TramsDataApi.DatabaseModels
         public string SchoolPupilForecastsAdditionalInformation { get; set; }
 
         // key stage performance
-        public string KeyStagePerformanceTablesAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
     }
 }

--- a/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
@@ -76,8 +76,10 @@ namespace TramsDataApi.Factories
                 updateRequest.YearThreeProjectedCapacity ?? project.YearThreeProjectedCapacity;
             project.YearThreeProjectedPupilNumbers =
                 updateRequest.YearThreeProjectedPupilNumbers ?? project.YearThreeProjectedPupilNumbers;
-            project.KeyStagePerformanceTablesAdditionalInformation = updateRequest.KeyStagePerformanceTablesAdditionalInformation ??
-                project.KeyStagePerformanceTablesAdditionalInformation;
+            project.KeyStage2PerformanceAdditionalInformation = updateRequest.KeyStage2PerformanceAdditionalInformation ??
+                project.KeyStage2PerformanceAdditionalInformation;
+            project.KeyStage4PerformanceAdditionalInformation = updateRequest.KeyStage4PerformanceAdditionalInformation ??
+                project.KeyStage4PerformanceAdditionalInformation;
             project.PreviousHeadTeacherBoardDateQuestion = updateRequest.PreviousHeadTeacherBoardDateQuestion ??
                 project.PreviousHeadTeacherBoardDateQuestion;
             project.PreviousHeadTeacherBoardDate = updateRequest.PreviousHeadTeacherBoardDate == default(DateTime) ? null

--- a/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectResponseFactory.cs
@@ -61,7 +61,8 @@ namespace TramsDataApi.Factories
 				YearTwoProjectedPupilNumbers = academyConversionProject.YearTwoProjectedPupilNumbers,
 				YearThreeProjectedCapacity = academyConversionProject.YearThreeProjectedCapacity,
 				YearThreeProjectedPupilNumbers = academyConversionProject.YearThreeProjectedPupilNumbers,
-				KeyStagePerformanceTablesAdditionalInformation = academyConversionProject.KeyStagePerformanceTablesAdditionalInformation
+				KeyStage2PerformanceAdditionalInformation = academyConversionProject.KeyStage2PerformanceAdditionalInformation,
+				KeyStage4PerformanceAdditionalInformation = academyConversionProject.KeyStage4PerformanceAdditionalInformation
 			};
 
 			if (trust != null)

--- a/TramsDataApi/Migrations/TramsDb/20210810072617_AddKS4AdditionalInfoToACP.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20210810072617_AddKS4AdditionalInfoToACP.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210810072617_AddKS4AdditionalInfoToACP")]
+    partial class AddKS4AdditionalInfoToACP
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20210810072617_AddKS4AdditionalInfoToACP.cs
+++ b/TramsDataApi/Migrations/TramsDb/20210810072617_AddKS4AdditionalInfoToACP.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class AddKS4AdditionalInfoToACP : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeyStagePerformanceTablesAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject");
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject");
+
+            migrationBuilder.DropColumn(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject");
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStagePerformanceTablesAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyConversionProject",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
+++ b/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
@@ -67,6 +67,7 @@ namespace TramsDataApi.RequestModels.AcademyConversionProject
         public int? YearThreeProjectedPupilNumbers { get; set; }
 
         // key stage performance tables
-        public string KeyStagePerformanceTablesAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
+++ b/TramsDataApi/ResponseModels/AcademyConversionProject/AcademyConversionProjectResponse.cs
@@ -82,6 +82,7 @@ namespace TramsDataApi.ResponseModels.AcademyConversionProject
         public string SchoolPupilForecastsAdditionalInformation { get; set; }
 
         // key stage performance tables
-        public string KeyStagePerformanceTablesAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
     }
 }


### PR DESCRIPTION
- Rename KS2 additional info field in ACP db table to be more specific
- Add KS4 additional info field to ACP table
- Map KS4 additional info field when retrieving and updating ACP