### PR TITLE
Only return single and multi academy trusts

### DIFF
--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -338,8 +338,6 @@ namespace TramsDataApi.Test.Integration
             var groupName = "Mygroupname";
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -397,8 +395,6 @@ namespace TramsDataApi.Test.Integration
 
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -450,8 +446,6 @@ namespace TramsDataApi.Test.Integration
 
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -503,8 +497,6 @@ namespace TramsDataApi.Test.Integration
 
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -555,8 +547,6 @@ namespace TramsDataApi.Test.Integration
             var companiesHouseNumber = "MyCompaniesHouseNumber";
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -609,8 +599,6 @@ namespace TramsDataApi.Test.Integration
             var ukprn = "mockurn";
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -658,8 +646,6 @@ namespace TramsDataApi.Test.Integration
             
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -711,8 +697,6 @@ namespace TramsDataApi.Test.Integration
 
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -765,8 +749,6 @@ namespace TramsDataApi.Test.Integration
             
             var groups = Builder<Group>.CreateListOfSize(15)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -818,8 +800,6 @@ namespace TramsDataApi.Test.Integration
         {
             var groups = Builder<Group>.CreateListOfSize(30)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")
@@ -861,8 +841,6 @@ namespace TramsDataApi.Test.Integration
         {
             var groups = Builder<Group>.CreateListOfSize(30)
                 .TheFirst(2)
-                .With(g => g.GroupType = "Trust")
-                .TheNext(2)
                 .With(g => g.GroupType = "Single-academy trust")
                 .TheRest()
                 .With(g => g.GroupType = "Multi-academy trust")

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -47,9 +47,12 @@ namespace TramsDataApi.Gateways
             return _dbContext.Group
                 .Where(g => (
                     (g.GroupName.Contains(groupName) ||
-                    g.Ukprn.Contains(ukprn) ||
-                    g.CompaniesHouseNumber.Contains(companiesHouseNumber))
-                    && g.GroupType.Contains("trust")
+                     g.Ukprn.Contains(ukprn) ||
+                     g.CompaniesHouseNumber.Contains(companiesHouseNumber))
+                    && (
+                        g.GroupType == "Single-academy trust" ||
+                        g.GroupType == "Multi-academy trust"
+                    )
                 ))
                 .OrderBy(group => group.GroupUid)
                 .Skip((page - 1) * 10).Take(10).ToList();


### PR DESCRIPTION
## Context

"Trusts" in get information about schools don't refer to the same things as Single/Multi academy trusts, and so when searching for trusts with matches of just the "Trust" type you get results that dont have UKPRNs or Group IDs, which are invalid.

## Changes

- Updates the group-type check to single/multi academy trusts

