### PR TITLE
Add entering ebacc ks4 data

### DIFF
--- a/TramsDataApi.Test/Factories/KeyStage4ResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/KeyStage4ResponseFactoryTests.cs
@@ -113,6 +113,7 @@ namespace TramsDataApi.Test.Factories
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
+                Enteringebacc = educationPerformanceData.SipEnteringebacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformance?.SipAttainment8score.ToString(),
@@ -161,6 +162,7 @@ namespace TramsDataApi.Test.Factories
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformance?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformance?.SipProgress8upperconfidence,
+                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringebaccengland,
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),
@@ -208,7 +210,8 @@ namespace TramsDataApi.Test.Factories
                     Disadvantaged = localAuthorityEducationPerformance?.SipProgress8ebaccdisadvantaged.ToString()
                 },
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
-                LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence
+                LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
+                LAEnteringEbacc = localAuthorityEducationPerformance?.SipAenteringebacclocalauthorityaverage
             };
 
             var result = KeyStage4PerformanceResponseFactory.Create(educationPerformanceData, nationalEducationPerformance, localAuthorityEducationPerformance);
@@ -305,6 +308,7 @@ namespace TramsDataApi.Test.Factories
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
+                Enteringebacc = educationPerformanceData.SipEnteringebacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = null,
@@ -352,6 +356,7 @@ namespace TramsDataApi.Test.Factories
                 },
                 NationalAverageP8LowerConfidence = null,
                 NationalAverageP8UpperConfidence = null,
+                
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = null,

--- a/TramsDataApi.Test/Factories/KeyStage4ResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/KeyStage4ResponseFactoryTests.cs
@@ -113,7 +113,7 @@ namespace TramsDataApi.Test.Factories
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
-                Enteringebacc = educationPerformanceData.SipEnteringebacc,
+                Enteringebacc = educationPerformanceData.SipEnteringEbacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformance?.SipAttainment8score.ToString(),
@@ -162,7 +162,7 @@ namespace TramsDataApi.Test.Factories
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformance?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformance?.SipProgress8upperconfidence,
-                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringebaccengland,
+                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringEbaccEngland,
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),
@@ -211,7 +211,7 @@ namespace TramsDataApi.Test.Factories
                 },
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
-                LAEnteringEbacc = localAuthorityEducationPerformance?.SipAenteringebacclocalauthorityaverage
+                LAEnteringEbacc = localAuthorityEducationPerformance?.SipEnteringEbaccLocalAuthorityAverage
             };
 
             var result = KeyStage4PerformanceResponseFactory.Create(educationPerformanceData, nationalEducationPerformance, localAuthorityEducationPerformance);
@@ -308,7 +308,7 @@ namespace TramsDataApi.Test.Factories
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
-                Enteringebacc = educationPerformanceData.SipEnteringebacc,
+                Enteringebacc = educationPerformanceData.SipEnteringEbacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = null,

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -373,6 +373,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8scoredisadvantaged = 37.78M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
+                .With(epd => epd.SipEnteringEbacc = 20.98M)
                 .Build();
 
             var nationalEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -413,6 +414,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 66.33M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 71.55M)
+                .With(epd => epd.SipEnteringEbaccEngland = 80.98M)
                 .Build();
             
             var nationalEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -470,6 +472,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8score = 105.77M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 67.98M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 67.98M)
+                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = 77.98M)
                 .Build();
             
             var laEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -94,7 +94,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8scoredisadvantaged = 50.00M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
-                .With(epd => epd.SipEnteringebacc = 51.44M)
+                .With(epd => epd.SipEnteringEbacc = 51.44M)
                 .Build();
 
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -135,7 +135,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 77.76M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 53.78M)
-                .With(epd => epd.SipEnteringebaccengland = 20.77M )
+                .With(epd => epd.SipEnteringEbaccEngland = 20.77M )
                 .Build();
             
             var laAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -176,7 +176,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 76.99M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 12.87M)
-                .With(epd => epd.SipAenteringebacclocalauthorityaverage = 44.87M)
+                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = 44.87M)
                 .Build();
                 
             var globalOptionMetadata = Builder<GlobalOptionSetMetadata>.CreateNew()
@@ -596,7 +596,7 @@ namespace TramsDataApi.Test.Integration
                     Disadvantaged = String.Format("{0:0.00}",
                         educationPerformanceData.SipProgress8scoredisadvantaged.ToString())
                 },
-                Enteringebacc = educationPerformanceData.SipEnteringebacc,
+                Enteringebacc = educationPerformanceData.SipEnteringEbacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = String.Format("{0:0.00}", nationalEducationPerformance1.SipAttainment8score),

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -721,7 +721,7 @@ namespace TramsDataApi.Test.Integration
                 },
                 LAAverageP8LowerConfidence = laEducationPerformance2.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence,
-                LAEnteringEbacc = laEducationPerformance1.SipEnteringEbaccEngland
+                LAEnteringEbacc = laEducationPerformance1.SipEnteringEbaccLocalAuthorityAverage
             };
 
             var expectedKeyStage5Response = new KeyStage5PerformanceResponse

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -719,7 +719,7 @@ namespace TramsDataApi.Test.Integration
                 },
                 LAAverageP8LowerConfidence = laEducationPerformance2.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence,
-                LAEnteringEbacc = laEducationPerformance2.SipEnteringEbaccEngland
+                LAEnteringEbacc = laEducationPerformance1.SipEnteringEbaccEngland
             };
 
             var expectedKeyStage5Response = new KeyStage5PerformanceResponse

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -656,7 +656,7 @@ namespace TramsDataApi.Test.Integration
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformance1.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformance1.SipProgress8upperconfidence,
-                
+                NationalEnteringEbacc = nationalEducationPerformance1.SipEnteringEbaccEngland,
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = String.Format("{0:0.00}", laEducationPerformance2.SipAttainment8score),
@@ -715,7 +715,8 @@ namespace TramsDataApi.Test.Integration
                         laEducationPerformance2.SipProgress8ebaccdisadvantaged.ToString())
                 },
                 LAAverageP8LowerConfidence = laEducationPerformance2.SipProgress8lowerconfidence,
-                LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence
+                LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence,
+                LAEnteringEbacc = laEducationPerformance2.SipEnteringEbaccEngland
             };
 
             var expectedKeyStage5Response = new KeyStage5PerformanceResponse

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -94,6 +94,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8scoredisadvantaged = 50.00M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
+                .With(epd => epd.SipEnteringebacc = 51.44M)
                 .Build();
 
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -134,6 +135,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 77.76M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 53.78M)
+                .With(epd => epd.SipEnteringebaccengland = 20.77M )
                 .Build();
             
             var laAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -174,6 +176,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 76.99M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 12.87M)
+                .With(epd => epd.SipAenteringebacclocalauthorityaverage = 44.87M)
                 .Build();
                 
             var globalOptionMetadata = Builder<GlobalOptionSetMetadata>.CreateNew()
@@ -593,6 +596,7 @@ namespace TramsDataApi.Test.Integration
                     Disadvantaged = String.Format("{0:0.00}",
                         educationPerformanceData.SipProgress8scoredisadvantaged.ToString())
                 },
+                Enteringebacc = educationPerformanceData.SipEnteringebacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = String.Format("{0:0.00}", nationalEducationPerformance1.SipAttainment8score),

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -473,7 +473,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8score = 105.77M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 67.98M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 67.98M)
-                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = 77.98M)
+               
                 .Build();
             
             var laEducationPerformance2 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -514,7 +514,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 77.22M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 67.87M)
-                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = null)
+                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = 77.98M)
                 .Build();
 
             var educationPerformanceDataList = new List<SipEducationalperformancedata>
@@ -721,7 +721,7 @@ namespace TramsDataApi.Test.Integration
                 },
                 LAAverageP8LowerConfidence = laEducationPerformance2.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = laEducationPerformance2.SipProgress8upperconfidence,
-                LAEnteringEbacc = laEducationPerformance1.SipEnteringEbaccLocalAuthorityAverage
+                LAEnteringEbacc = laEducationPerformance2.SipEnteringEbaccLocalAuthorityAverage
             };
 
             var expectedKeyStage5Response = new KeyStage5PerformanceResponse

--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -443,6 +443,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = 22.79M)
                 .With(epd => epd.SipProgress8score = 105.77M)
                 .With(epd => epd.SipProgress8scoredisadvantaged = 67.98M)
+                .With(epd => epd.SipEnteringEbaccEngland = null)
                 .Build();
             
             var laEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -513,6 +514,7 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipMathsprogressscoredisadv = 9.00M)
                 .With(epd => epd.SipAcademicLevelAveragePspe = 77.22M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 67.87M)
+                .With(epd => epd.SipEnteringEbaccLocalAuthorityAverage = null)
                 .Build();
 
             var educationPerformanceDataList = new List<SipEducationalperformancedata>

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -376,7 +376,7 @@ namespace TramsDataApi.Test.UseCases
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
-                Enteringebacc = educationPerformanceData.SipEnteringebacc,
+                Enteringebacc = educationPerformanceData.SipEnteringEbacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformanceData3?.SipAttainment8score.ToString(),

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -225,6 +225,7 @@ namespace TramsDataApi.Test.UseCases
                 .With(nepd => nepd.SipProgress8mathsdisadvantaged = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebacc = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebaccdisadvantaged = _randomGenerator.Int())
+                .With(nepd => nepd.SipEnteringEbaccLocalAuthorityAverage = _randomGenerator.Int())
                 .Build();
 
              var localAuthorityPerformanceDataList = new List<SipEducationalperformancedata>

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -376,6 +376,7 @@ namespace TramsDataApi.Test.UseCases
                     NotDisadvantaged = educationPerformanceData.SipProgress8score.ToString(),
                     Disadvantaged = educationPerformanceData.SipProgress8scoredisadvantaged.ToString()
                 },
+                Enteringebacc = educationPerformanceData.SipEnteringebacc,
                 NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformanceData3?.SipAttainment8score.ToString(),

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -81,6 +81,7 @@ namespace TramsDataApi.Test.UseCases
                 .With(epd => epd.SipProgress8mathsdisadvantaged = _randomGenerator.Int())
                 .With(epd => epd.SipProgress8ebacc = _randomGenerator.Int())
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = _randomGenerator.Int())
+                .With(epd => epd.SipEnteringEbacc = _randomGenerator.Int())
                 .Build();
 
             var nationalEducationPerformanceData1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -149,6 +150,7 @@ namespace TramsDataApi.Test.UseCases
                 .With(nepd => nepd.SipProgress8mathsdisadvantaged = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebacc = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebaccdisadvantaged = _randomGenerator.Int())
+                .With(nepd => nepd.SipEnteringEbaccEngland= _randomGenerator.Int())
                 .Build();
             
             var nationalEducationPerformanceData3 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -234,7 +236,9 @@ namespace TramsDataApi.Test.UseCases
             var mockEducationPerformanceGateway = new Mock<IEducationPerformanceGateway>();
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetAccountByUrn(urn)).Returns(() => account);
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetPhonicsByUrn(urn)).Returns(() => phonics);
-            mockEducationPerformanceGateway.Setup(gateway => gateway.GetEducationalPerformanceForAccount(account)).Returns(() => new List<SipEducationalperformancedata> {educationPerformanceData});
+            mockEducationPerformanceGateway.Setup(gateway => gateway.GetEducationalPerformanceForAccount(account)).Returns(
+                () => new List<SipEducationalperformancedata> {educationPerformanceData}
+                );
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetNationalEducationalPerformanceData()).Returns(nationalEducationPerformanceDataList);
             mockEducationPerformanceGateway.Setup(gateway => gateway.GetLocalAuthorityEducationalPerformanceData(account)).Returns(localAuthorityPerformanceDataList);
 
@@ -426,7 +430,7 @@ namespace TramsDataApi.Test.UseCases
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformanceData2?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformanceData2?.SipProgress8upperconfidence,
-                NationalEnteringEbacc = nationalEducationPerformanceData1?.SipEnteringEbaccEngland,
+                NationalEnteringEbacc = nationalEducationPerformanceData2?.SipEnteringEbaccEngland,
                  LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -185,6 +185,7 @@ namespace TramsDataApi.Test.UseCases
                 .With(nepd => nepd.SipProgress8mathsdisadvantaged = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebacc = _randomGenerator.Int())
                 .With(nepd => nepd.SipProgress8ebaccdisadvantaged = _randomGenerator.Int())
+                .With(nepd => nepd.SipEnteringEbaccEngland= null )
                 .Build();
 
             var nationalEducationPerformanceDataList = new List<SipEducationalperformancedata>

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -425,6 +425,7 @@ namespace TramsDataApi.Test.UseCases
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformanceData2?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformanceData2?.SipProgress8upperconfidence,
+                NationalEnteringEbacc = nationalEducationPerformanceData1?.SipEnteringEbaccEngland,
                  LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),
@@ -473,6 +474,8 @@ namespace TramsDataApi.Test.UseCases
                 },
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
+                LAEnteringEbacc = localAuthorityEducationPerformance?.SipEnteringEbaccLocalAuthorityAverage
+
             };
 
             var expectedKS5 = new KeyStage5PerformanceResponse

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -158,6 +158,18 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.SipLocalauthoritycode)
                     .HasColumnName("sip_localauthoritycode")
                     .HasMaxLength(100);
+                
+                entity.Property(e => e.SipEnteringebacc)
+                    .HasColumnName("sip_enteringebacc")
+                    .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipEnteringebaccengland)
+                    .HasColumnName("sip_enteringebaccengland")
+                    .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipAenteringebacclocalauthorityaverage)
+                    .HasColumnName("sip_aenteringebacclocalauthorityaverage")
+                    .HasColumnType("decimal(38, 2)");
             });
         }
     }

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -159,15 +159,15 @@ namespace TramsDataApi.DatabaseModels
                     .HasColumnName("sip_localauthoritycode")
                     .HasMaxLength(100);
                 
-                entity.Property(e => e.SipEnteringebacc)
+                entity.Property(e => e.SipEnteringEbacc)
                     .HasColumnName("sip_enteringebacc")
                     .HasColumnType("decimal(38, 2)");
                 
-                entity.Property(e => e.SipEnteringebaccengland)
+                entity.Property(e => e.SipEnteringEbaccEngland)
                     .HasColumnName("sip_enteringebaccengland")
                     .HasColumnType("decimal(38, 2)");
                 
-                entity.Property(e => e.SipAenteringebacclocalauthorityaverage)
+                entity.Property(e => e.SipEnteringEbaccLocalAuthorityAverage)
                     .HasColumnName("sip_aenteringebacclocalauthorityaverage")
                     .HasColumnType("decimal(38, 2)");
             });

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -46,8 +46,8 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipAppliedGeneralAveragePspe { get; set; }
         public decimal? SipAcademicLevelAveragePspe { get; set; }
         public string SipLocalauthoritycode { get; set; }
-        public decimal? SipEnteringebacc { get; set; }
-        public decimal? SipEnteringebaccengland { get; set; }
-        public decimal? SipAenteringebacclocalauthorityaverage { get; set; }
+        public decimal? SipEnteringEbacc { get; set; }
+        public decimal? SipEnteringEbaccEngland { get; set; }
+        public decimal? SipEnteringEbaccLocalAuthorityAverage { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -46,5 +46,8 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipAppliedGeneralAveragePspe { get; set; }
         public decimal? SipAcademicLevelAveragePspe { get; set; }
         public string SipLocalauthoritycode { get; set; }
+        public decimal? SipEnteringebacc { get; set; }
+        public decimal? SipEnteringebaccengland { get; set; }
+        public decimal? SipAenteringebacclocalauthorityaverage { get; set; }
     }
 }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
@@ -44,7 +44,10 @@ namespace TramsDataApi.Factories
                     SipProgress8ebaccdisadvantaged = nationalEducationPerformance1.SipProgress8ebaccdisadvantaged ?? nationalEducationPerformance2.SipProgress8ebaccdisadvantaged,
                     SipPerformancetype = nationalEducationPerformance1.SipPerformancetype ?? nationalEducationPerformance2.SipPerformancetype,
                     SipAcademicLevelAveragePspe = nationalEducationPerformance1.SipAcademicLevelAveragePspe ?? nationalEducationPerformance2.SipAcademicLevelAveragePspe,
-                    SipAppliedGeneralAveragePspe = nationalEducationPerformance1.SipAppliedGeneralAveragePspe ?? nationalEducationPerformance2.SipAppliedGeneralAveragePspe
+                    SipAppliedGeneralAveragePspe = nationalEducationPerformance1.SipAppliedGeneralAveragePspe ?? nationalEducationPerformance2.SipAppliedGeneralAveragePspe,
+                    SipEnteringEbacc = nationalEducationPerformance1.SipEnteringEbacc ?? nationalEducationPerformance2.SipEnteringEbacc,
+                    SipEnteringEbaccLocalAuthorityAverage = nationalEducationPerformance1.SipEnteringEbaccLocalAuthorityAverage ?? nationalEducationPerformance2.SipEnteringEbaccLocalAuthorityAverage,
+                    SipEnteringEbaccEngland = nationalEducationPerformance1.SipEnteringEbaccEngland ?? nationalEducationPerformance2.SipEnteringEbaccEngland
                 };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage4PerformanceResponseFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage4PerformanceResponseFactory.cs
@@ -66,7 +66,7 @@ namespace TramsDataApi.Factories
                      NotDisadvantaged = educationalPerformanceData.SipProgress8score.ToString(),
                      Disadvantaged = educationalPerformanceData.SipProgress8scoredisadvantaged.ToString()
                  },
-                 Enteringebacc = educationalPerformanceData.SipEnteringebacc,
+                 Enteringebacc = educationalPerformanceData.SipEnteringEbacc,
                  NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformance?.SipAttainment8score.ToString(),
@@ -115,7 +115,7 @@ namespace TramsDataApi.Factories
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformance?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformance?.SipProgress8upperconfidence,
-                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringebaccengland,
+                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringEbaccEngland,
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),
@@ -164,7 +164,7 @@ namespace TramsDataApi.Factories
                 },
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
                 LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
-                LAEnteringEbacc = localAuthorityEducationPerformance?.SipAenteringebacclocalauthorityaverage
+                LAEnteringEbacc = localAuthorityEducationPerformance?.SipEnteringEbaccLocalAuthorityAverage
             };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage4PerformanceResponseFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage4PerformanceResponseFactory.cs
@@ -66,6 +66,7 @@ namespace TramsDataApi.Factories
                      NotDisadvantaged = educationalPerformanceData.SipProgress8score.ToString(),
                      Disadvantaged = educationalPerformanceData.SipProgress8scoredisadvantaged.ToString()
                  },
+                 Enteringebacc = educationalPerformanceData.SipEnteringebacc,
                  NationalAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = nationalEducationPerformance?.SipAttainment8score.ToString(),
@@ -114,6 +115,7 @@ namespace TramsDataApi.Factories
                 },
                 NationalAverageP8LowerConfidence = nationalEducationPerformance?.SipProgress8lowerconfidence,
                 NationalAverageP8UpperConfidence = nationalEducationPerformance?.SipProgress8upperconfidence,
+                NationalEnteringEbacc = nationalEducationPerformance?.SipEnteringebaccengland,
                 LAAverageA8Score = new DisadvantagedPupilsResponse
                 {
                     NotDisadvantaged = localAuthorityEducationPerformance?.SipAttainment8score.ToString(),
@@ -161,7 +163,8 @@ namespace TramsDataApi.Factories
                     Disadvantaged = localAuthorityEducationPerformance?.SipProgress8ebaccdisadvantaged.ToString()
                 },
                 LAAverageP8LowerConfidence = localAuthorityEducationPerformance?.SipProgress8lowerconfidence,
-                LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence
+                LAAverageP8UpperConfidence = localAuthorityEducationPerformance?.SipProgress8upperconfidence,
+                LAEnteringEbacc = localAuthorityEducationPerformance?.SipAenteringebacclocalauthorityaverage
             };
         }
     }

--- a/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage4PerformanceResponse.cs
+++ b/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage4PerformanceResponse.cs
@@ -36,5 +36,8 @@ namespace TramsDataApi.ResponseModels.EducationalPerformance
         public DisadvantagedPupilsResponse LAAverageP8English { get; set; }
         public DisadvantagedPupilsResponse LAAverageP8Maths { get; set; }
         public DisadvantagedPupilsResponse LAAverageP8Ebacc { get; set; }
+        public decimal? LAEnteringEbacc { get; set; }
+        public decimal? Enteringebacc { get; set; }
+        public decimal? NationalEnteringEbacc { get; set; }
     }
 }


### PR DESCRIPTION
The PR adds the following fields to the educationPerformance db object and response:

- SipEnteringEbacc
- SipEnteringEbaccEngland (National average)
- SipEnteringEbaccLocalAuthorityAverage (Local authority Average)
