### PR TITLE
Add applied general and academy progress data to ks5

### DIFF
--- a/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EducationPerformanceIntegrationTests.cs
@@ -95,6 +95,10 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
                 .With(epd => epd.SipEnteringEbacc = 51.44M)
+                .With(epd => epd.SipAcademicProgress = 51.44M)
+                .With(epd => epd.SipAcademicProgressDisadvantaged = 51.44M)
+                .With(epd => epd.SipAppliedGeneralProgress = 51.44M)
+                .With(epd => epd.SipAppliedGeneralProgressDisadvantaged = 51.44M)
                 .Build();
 
             var nationalAverageEducationPerformanceData = Builder<SipEducationalperformancedata>.CreateNew()
@@ -374,6 +378,10 @@ namespace TramsDataApi.Test.Integration
                 .With(epd => epd.SipAcademicLevelAveragePspe = 40.54M)
                 .With(epd => epd.SipAppliedGeneralAveragePspe = 51.44M)
                 .With(epd => epd.SipEnteringEbacc = 20.98M)
+                .With(epd => epd.SipAcademicProgress = 77.40M)
+                .With(epd => epd.SipAcademicProgressDisadvantaged = 88.20M)
+                .With(epd => epd.SipAppliedGeneralProgress = 12.94M)
+                .With(epd => epd.SipAppliedGeneralProgressDisadvantaged = 54.18M)
                 .Build();
 
             var nationalEducationPerformance1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -732,7 +740,17 @@ namespace TramsDataApi.Test.Integration
                 NationalAcademicQualificationAverage = nationalEducationPerformance1.SipAcademicLevelAveragePspe,
                 NationalAppliedGeneralQualificationAverage = nationalEducationPerformance1.SipAppliedGeneralAveragePspe,
                 LAAcademicQualificationAverage = laEducationPerformance2.SipAcademicLevelAveragePspe,
-                LAAppliedGeneralQualificationAverage = laEducationPerformance2.SipAppliedGeneralAveragePspe
+                LAAppliedGeneralQualificationAverage = laEducationPerformance2.SipAppliedGeneralAveragePspe,
+                AppliedGeneralProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationPerformanceData.SipAppliedGeneralProgress.ToString(),
+                    Disadvantaged = educationPerformanceData.SipAppliedGeneralProgressDisadvantaged.ToString()
+                },
+                AcademicProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationPerformanceData.SipAcademicProgress.ToString(),
+                    Disadvantaged = educationPerformanceData.SipAcademicProgressDisadvantaged.ToString()
+                }
             };
 
             var expected = new EducationalPerformanceResponse

--- a/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetKeyStagePerformanceByUrnTests.cs
@@ -82,6 +82,10 @@ namespace TramsDataApi.Test.UseCases
                 .With(epd => epd.SipProgress8ebacc = _randomGenerator.Int())
                 .With(epd => epd.SipProgress8ebaccdisadvantaged = _randomGenerator.Int())
                 .With(epd => epd.SipEnteringEbacc = _randomGenerator.Int())
+                .With(epd => epd.SipAcademicProgress = _randomGenerator.Int())
+                .With(epd => epd.SipAcademicProgressDisadvantaged = _randomGenerator.Int())
+                .With(epd => epd.SipAppliedGeneralProgress = _randomGenerator.Int())
+                .With(epd => epd.SipAppliedGeneralProgressDisadvantaged = _randomGenerator.Int())
                 .Build();
 
             var nationalEducationPerformanceData1 = Builder<SipEducationalperformancedata>.CreateNew()
@@ -492,7 +496,17 @@ namespace TramsDataApi.Test.UseCases
                 NationalAcademicQualificationAverage = nationalEducationPerformanceData2.SipAcademicLevelAveragePspe,
                 NationalAppliedGeneralQualificationAverage = nationalEducationPerformanceData2.SipAppliedGeneralAveragePspe,
                 LAAcademicQualificationAverage = localAuthorityEducationPerformance?.SipAcademicLevelAveragePspe,
-                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance?.SipAppliedGeneralAveragePspe
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance?.SipAppliedGeneralAveragePspe,
+                AppliedGeneralProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationPerformanceData.SipAppliedGeneralProgress.ToString(),
+                    Disadvantaged = educationPerformanceData.SipAppliedGeneralProgressDisadvantaged.ToString()
+                },
+                AcademicProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationPerformanceData.SipAcademicProgress.ToString(),
+                    Disadvantaged = educationPerformanceData.SipAcademicProgressDisadvantaged.ToString()
+                }
             };
             
             var expected = new EducationalPerformanceResponse

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.EducationPerformanceData.cs
@@ -170,6 +170,22 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.SipEnteringEbaccLocalAuthorityAverage)
                     .HasColumnName("sip_aenteringebacclocalauthorityaverage")
                     .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipAppliedGeneralProgress)
+                    .HasColumnName("sip_appliedgeneralprogress")
+                    .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipAppliedGeneralProgressDisadvantaged)
+                    .HasColumnName("sip_appliedgeneralprogressdisadvantaged")
+                    .HasColumnType("decimal(38, 2)");
+                
+                entity.Property(e => e.SipAcademicProgress)
+                    .HasColumnName("sip_academicprogress")
+                    .HasColumnType("decimal(38, 2)");
+
+                entity.Property(e => e.SipAcademicProgressDisadvantaged)
+                    .HasColumnName("sip_academicprogressdisadvantaged")
+                    .HasColumnType("decimal(38, 2)");
             });
         }
     }

--- a/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
+++ b/TramsDataApi/DatabaseModels/SipEducationalperformancedata.cs
@@ -49,5 +49,9 @@ namespace TramsDataApi.DatabaseModels
         public decimal? SipEnteringEbacc { get; set; }
         public decimal? SipEnteringEbaccEngland { get; set; }
         public decimal? SipEnteringEbaccLocalAuthorityAverage { get; set; }
+        public decimal? SipAppliedGeneralProgress { get; set; }
+        public decimal? SipAppliedGeneralProgressDisadvantaged { get; set; }
+        public decimal? SipAcademicProgress { get; set; }
+        public decimal? SipAcademicProgressDisadvantaged { get; set; }
     }
 }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/GroupedEducationPerformanceFactory.cs
@@ -47,7 +47,11 @@ namespace TramsDataApi.Factories
                     SipAppliedGeneralAveragePspe = nationalEducationPerformance1.SipAppliedGeneralAveragePspe ?? nationalEducationPerformance2.SipAppliedGeneralAveragePspe,
                     SipEnteringEbacc = nationalEducationPerformance1.SipEnteringEbacc ?? nationalEducationPerformance2.SipEnteringEbacc,
                     SipEnteringEbaccLocalAuthorityAverage = nationalEducationPerformance1.SipEnteringEbaccLocalAuthorityAverage ?? nationalEducationPerformance2.SipEnteringEbaccLocalAuthorityAverage,
-                    SipEnteringEbaccEngland = nationalEducationPerformance1.SipEnteringEbaccEngland ?? nationalEducationPerformance2.SipEnteringEbaccEngland
+                    SipEnteringEbaccEngland = nationalEducationPerformance1.SipEnteringEbaccEngland ?? nationalEducationPerformance2.SipEnteringEbaccEngland,
+                    SipAcademicProgress = nationalEducationPerformance1.SipAcademicProgress ?? nationalEducationPerformance2.SipAcademicProgress,
+                    SipAcademicProgressDisadvantaged = nationalEducationPerformance1.SipAcademicProgressDisadvantaged ?? nationalEducationPerformance2.SipAcademicProgressDisadvantaged,
+                    SipAppliedGeneralProgress = nationalEducationPerformance1.SipAppliedGeneralProgress ?? nationalEducationPerformance2.SipAppliedGeneralProgress,
+                    SipAppliedGeneralProgressDisadvantaged = nationalEducationPerformance1.SipAppliedGeneralProgressDisadvantaged ?? nationalEducationPerformance2.SipAppliedGeneralProgressDisadvantaged
                 };
         }
     }

--- a/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
+++ b/TramsDataApi/Factories/EducationPerformanceFactories/KeyStage5PerformanceResponseFactory.cs
@@ -17,7 +17,17 @@ namespace TramsDataApi.Factories
                 NationalAcademicQualificationAverage = nationalEducationPerformance.SipAcademicLevelAveragePspe,
                 NationalAppliedGeneralQualificationAverage = nationalEducationPerformance.SipAppliedGeneralAveragePspe,
                 LAAcademicQualificationAverage = localAuthorityEducationPerformance.SipAcademicLevelAveragePspe,
-                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance.SipAppliedGeneralAveragePspe
+                LAAppliedGeneralQualificationAverage = localAuthorityEducationPerformance.SipAppliedGeneralAveragePspe,
+                AppliedGeneralProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationalPerformanceData.SipAppliedGeneralProgress.ToString(),
+                    Disadvantaged = educationalPerformanceData.SipAppliedGeneralProgressDisadvantaged.ToString()
+                },
+                AcademicProgress = new DisadvantagedPupilsResponse
+                {
+                    NotDisadvantaged = educationalPerformanceData.SipAcademicProgress.ToString(),
+                    Disadvantaged = educationalPerformanceData.SipAcademicProgressDisadvantaged.ToString()
+                }
             };
         }
     }

--- a/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage5PerformanceResponse.cs
+++ b/TramsDataApi/ResponseModels/EducationalPerformance/KeyStage5PerformanceResponse.cs
@@ -9,5 +9,7 @@ namespace TramsDataApi.ResponseModels.EducationalPerformance
         public decimal? NationalAppliedGeneralQualificationAverage { get; set; }
         public decimal? LAAcademicQualificationAverage { get; set; }
         public decimal? LAAppliedGeneralQualificationAverage { get; set; }
+        public DisadvantagedPupilsResponse AppliedGeneralProgress { get; set; }
+        public DisadvantagedPupilsResponse AcademicProgress { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the data for:
- AppliedGeneral Progress
- Academic Progress

to the ks5 object and api response. 