### PR TITLE
Fix - Paging Response and ProjectStatus when search without state on V2 Controller

### DIFF
--- a/TramsDataApi.Test/Controllers/AcademyConversionProjectsControllerV2Tests.cs
+++ b/TramsDataApi.Test/Controllers/AcademyConversionProjectsControllerV2Tests.cs
@@ -73,7 +73,7 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetConversionProjects_WithPaging_AndMultiplePages_ShouldHavePagingWithValuesSetAndNextPageURLProvided()
         {
-            const string expectedNextPageUrl = "localhost/?page=2&count=1";
+            const string expectedNextPageUrl = "?page=2&count=1";
             
             var mockUseCase = new Mock<IUseCase<GetAllAcademyConversionProjectsRequest, IEnumerable<AcademyConversionProjectResponse>>>();
             var controllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };

--- a/TramsDataApi.Test/Controllers/AcademyConversionProjectsControllerV2Tests.cs
+++ b/TramsDataApi.Test/Controllers/AcademyConversionProjectsControllerV2Tests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -125,8 +126,7 @@ namespace TramsDataApi.Test.Controllers
                 .Returns(data);
 
             var controller = new AcademyConversionProjectController(
-                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest,
-                    IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
                 mockUseCase.Object,
                 new Mock<IUseCase<GetAcademyConversionProjectByIdRequest, AcademyConversionProjectResponse>>().Object,
                 new Mock<IUpdateAcademyConversionProject>().Object,
@@ -141,6 +141,96 @@ namespace TramsDataApi.Test.Controllers
             var result = controller.GetConversionProjects(null, 1, 10);
             
             result.Result.Should().BeEquivalentTo(new OkObjectResult(expected));
+        }
+        
+         [Fact]
+        public void GetConversionProjectById_ReturnsAcademyConversionProject_WhenIdExists()
+        {
+            var mockUseCase =
+                new Mock<IUseCase<GetAcademyConversionProjectByIdRequest, AcademyConversionProjectResponse>>();
+            
+            
+            var academyConversionProjectResponse = Builder<AcademyConversionProjectResponse>.CreateNew().Build();
+
+            mockUseCase
+                .Setup(x => x.Execute(It.IsAny<GetAcademyConversionProjectByIdRequest>()))
+                .Returns(academyConversionProjectResponse);
+            
+            var controller = new AcademyConversionProjectController(
+                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                new Mock<IUseCase<GetAllAcademyConversionProjectsRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                mockUseCase.Object,
+                new Mock<IUpdateAcademyConversionProject>().Object,
+                _mockLogger.Object
+            );
+
+            var expectedData = new List<AcademyConversionProjectResponse> {academyConversionProjectResponse};
+            var expected = new ApiResponseV2<AcademyConversionProjectResponse>(expectedData, null);
+            
+            var result = controller.GetConversionProjectById(It.IsAny<int>());
+            
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expected));
+        }
+        
+        [Fact]
+        public void GetConversionProjectById_ReturnsNotFound_WhenNoConversionProjectExists()
+        {
+            var controller = new AcademyConversionProjectController(
+                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                new Mock<IUseCase<GetAllAcademyConversionProjectsRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object, 
+                new Mock<IUseCase<GetAcademyConversionProjectByIdRequest, AcademyConversionProjectResponse>>().Object,
+                new Mock<IUpdateAcademyConversionProject>().Object,
+                _mockLogger.Object
+            );
+
+            var result = controller.GetConversionProjectById(It.IsAny<int>());
+            
+            result.Result.Should().BeEquivalentTo(new NotFoundResult());
+        }
+
+        [Fact]
+        public void UpdateConversionProject_Returns_UpdatedConversionProject_WhenConversionProjectExists()
+        {
+            var mockUseCase = new Mock<IUpdateAcademyConversionProject>();
+            
+            var updatedAcademyConversionProjectResponse = Builder<AcademyConversionProjectResponse>.CreateNew().Build();
+
+            mockUseCase
+                .Setup(x => x.Execute(It.IsAny<int>(),It.IsAny<UpdateAcademyConversionProjectRequest>()))
+                .Returns(updatedAcademyConversionProjectResponse);
+            
+            var controller = new AcademyConversionProjectController(
+                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                new Mock<IUseCase<GetAllAcademyConversionProjectsRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object, 
+                new Mock<IUseCase<GetAcademyConversionProjectByIdRequest, AcademyConversionProjectResponse>>().Object,
+                mockUseCase.Object,
+                _mockLogger.Object
+            );
+
+            var expectedData = new List<AcademyConversionProjectResponse> { updatedAcademyConversionProjectResponse };
+            var expectedResult = new ApiResponseV2<AcademyConversionProjectResponse>(expectedData, null);
+            
+            var result = controller.UpdateConversionProject(It.IsAny<int>(), It.IsAny<UpdateAcademyConversionProjectRequest>());
+            
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedResult));
+        }
+
+        [Fact]
+        public void UpdateConversionProject_ReturnsNotFound_WhenConversionProjectExists()
+        {
+            var controller = new AcademyConversionProjectController(
+                new Mock<IUseCase<GetAcademyConversionProjectsByStatusesRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object,
+                new Mock<IUseCase<GetAllAcademyConversionProjectsRequest, IEnumerable<AcademyConversionProjectResponse>>>().Object, 
+                new Mock<IUseCase<GetAcademyConversionProjectByIdRequest, AcademyConversionProjectResponse>>().Object,
+                new Mock<IUpdateAcademyConversionProject>().Object,
+                _mockLogger.Object
+            );
+
+            var result =
+                controller.UpdateConversionProject(It.IsAny<int>(), It.IsAny<UpdateAcademyConversionProjectRequest>());
+
+            result.Result.Should().BeEquivalentTo(new NotFoundResult());
+            
         }
     }
 }

--- a/TramsDataApi.Test/Factories/PagingResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/PagingResponseFactoryTests.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using TramsDataApi.ResponseModels;
@@ -38,7 +36,7 @@ namespace TramsDataApi.Test.Factories
             const int recordCount = 1;
             const int count = 1;
             const int page = 1;
-            var expectedNextPageUrl = $@"https://localhost/?page={page + 1}&count={count}";
+            var expectedNextPageUrl = $@"/controller-name/?page={page + 1}&count={count}";
 
             var expectedPagingResponse = new PagingResponse
             {
@@ -49,6 +47,7 @@ namespace TramsDataApi.Test.Factories
 
             var mockHttpRequest = new Mock<HttpRequest>();
             mockHttpRequest.SetupGet(r => r.Scheme).Returns("https");
+            mockHttpRequest.SetupGet(r => r.Path).Returns("/controller-name/");
             mockHttpRequest.SetupGet(r => r.Query).Returns(() => new QueryCollection());
 
             var result = PagingResponseFactory.Create(page, count, recordCount, mockHttpRequest.Object);
@@ -70,7 +69,7 @@ namespace TramsDataApi.Test.Factories
 
             var queryCollection = new QueryCollection(query);
 
-            var expectedNextPageUrl = $@"https://localhost/?queryParameter=queryValue&page={page + 1}&count={count}";
+            var expectedNextPageUrl = $@"/controller-name/?queryParameter=queryValue&page={page + 1}&count={count}";
 
             var expectedPagingResponse = new PagingResponse
             {
@@ -81,34 +80,8 @@ namespace TramsDataApi.Test.Factories
 
             var mockHttpRequest = new Mock<HttpRequest>();
             mockHttpRequest.SetupGet(r => r.Scheme).Returns("https");
+            mockHttpRequest.SetupGet(r => r.Path).Returns("/controller-name/");
             mockHttpRequest.SetupGet(r => r.Query).Returns(queryCollection);
-
-            var result = PagingResponseFactory.Create(page, count, recordCount, mockHttpRequest.Object);
-            
-            result.Should().BeEquivalentTo(expectedPagingResponse);
-        }
-
-        [Fact]
-        public void CreatingPagingResponse_WithHttpRequestContainingPort_ShouldReturnPortInResponseNextPageUrl()
-        {
-            const int recordCount = 1;
-            const int count = 1;
-            const int page = 1;
-            const int port = 8080;
-            
-            var expectedNextPageUrl = $@"https://localhost:{port}/?page={page + 1}&count={count}";
-            
-            var expectedPagingResponse = new PagingResponse
-            {
-                Page = page,
-                RecordCount = recordCount,
-                NextPageUrl = expectedNextPageUrl
-            };
-
-            var mockHttpRequest = new Mock<HttpRequest>();
-            mockHttpRequest.SetupGet(r => r.Scheme).Returns("https");
-            mockHttpRequest.SetupGet(r => r.Host).Returns(new HostString(string.Empty, port));
-            mockHttpRequest.SetupGet(r => r.Query).Returns(() => new QueryCollection());
 
             var result = PagingResponseFactory.Create(page, count, recordCount, mockHttpRequest.Object);
             

--- a/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
@@ -43,20 +43,49 @@ namespace TramsDataApi.Test.Integration
         [Fact]
         public async Task Get_request_should_get_all_academy_conversion_projects()
         {
-            var academyConversionProjects = _fixture.Build<AcademyConversionProject>()
-                .Without(x => x.Id)
-                .CreateMany()
-                .ToList();
-
+            var expectedProjects = new List<AcademyConversionProject>
+            {
+                _fixture.Build<AcademyConversionProject>()
+                    .Without(x => x.Id)
+                    .With(x => x.IfdPipelineId, 100002).Create(),
+                _fixture.Build<AcademyConversionProject>()
+                    .Without(x => x.Id)
+                    .With(x => x.IfdPipelineId, 100056).Create()
+            };
+            
             var academyConversionProjectWithoutName = _fixture.Build<AcademyConversionProject>()
                 .Without(x => x.Id)
                 .Without(x => x.SchoolName)
+                .With(x => x.IfdPipelineId, 100120)
                 .Create();
-            
-            _dbContext.AcademyConversionProjects.AddRange(academyConversionProjects);
+
+            var ifdPipelineProjects = new List<IfdPipeline>
+            {
+                _fixture.Build<IfdPipeline>()
+                    .With(i => i.Sk, 100002)
+                    .Without(i => i.EfaFundingUpin)
+                    .Without(i => i.ProposedAcademyDetailsNewAcademyUrn)
+                    .With(i => i.GeneralDetailsProjectStatus, "Approved for AO").Create(),
+                _fixture.Build<IfdPipeline>()
+                    .With(i => i.Sk, 100056)
+                    .Without(i => i.EfaFundingUpin)
+                    .Without(i => i.ProposedAcademyDetailsNewAcademyUrn)
+                    .With(i => i.GeneralDetailsProjectStatus, "Converter Pre-AO").Create(),
+                _fixture.Build<IfdPipeline>()
+                    .With(i => i.Sk, 100120)
+                    .Without(i => i.EfaFundingUpin)
+                    .Without(i => i.ProposedAcademyDetailsNewAcademyUrn)
+                    .With(i => i.GeneralDetailsProjectStatus, "Converter Pre-AO").Create()
+            };
+         
+            _dbContext.AcademyConversionProjects.AddRange(expectedProjects);
             _dbContext.AcademyConversionProjects.Add(academyConversionProjectWithoutName);
+            _legacyDbContext.IfdPipeline.AddRange(ifdPipelineProjects);
+
+            _legacyDbContext.SaveChanges();
             _dbContext.SaveChanges();
-            var expected = academyConversionProjects.Select(p => AcademyConversionProjectResponseFactory.Create(p)).ToList();
+            
+            var expected = expectedProjects.Select(p => AcademyConversionProjectResponseFactory.Create(p)).ToList();
             expected.ForEach(p => p.ProjectStatus = PreHtb);
             
             var response = await _client.GetAsync("/conversion-projects");
@@ -199,9 +228,23 @@ namespace TramsDataApi.Test.Integration
         public async void Get_request_should_return_response_with_data_having_ukPrn_and_Laestab_set()
         {
             var urns = new List<int> {1, 2};
+            
             var projects = urns
-                .Select(u => _fixture.Build<AcademyConversionProject>().Without(f => f.Id).With(f => f.Urn, u).Create())
+                .Select(u => _fixture.Build<AcademyConversionProject>()
+                    .Without(f => f.Id)
+                    .With(f => f.Urn, u)
+                    .With(f => f.IfdPipelineId, u)
+                    .Create())
                 .ToList();
+
+            var ifdPipelineProjects = urns
+                .Select(u => _fixture.Build<IfdPipeline>()
+                    .With(i => i.Sk, u)
+                    .Without(i => i.EfaFundingUpin)
+                    .Without(i => i.ProposedAcademyDetailsNewAcademyUrn)
+                    .With(i => i.GeneralDetailsProjectStatus, "Approved for AO").Create()
+                ).ToList();
+            
             var establishments = urns
                 .Select(u => _fixture.Build<Establishment>().With(e => e.Urn, u).With(e => e.Ukprn, $"est{u}").Create())
                 .ToList();
@@ -212,6 +255,7 @@ namespace TramsDataApi.Test.Integration
             _dbContext.AcademyConversionProjects.AddRange(projects);
             _legacyDbContext.Establishment.AddRange(establishments);
             _legacyDbContext.MisEstablishments.AddRange(misEstablishments);
+            _legacyDbContext.IfdPipeline.AddRange(ifdPipelineProjects);
             
             _dbContext.SaveChanges();
             _legacyDbContext.SaveChanges();
@@ -248,9 +292,23 @@ namespace TramsDataApi.Test.Integration
                 .Without(x => x.SchoolName)
                 .Create();
             
+            var ifdIds = academyConversionProjects.Select(p => p.IfdPipelineId).ToList();
+            ifdIds.Add(academyConversionProjectWithoutName.IfdPipelineId);
+
+            var ifdProjects = ifdIds.Select(id => _fixture.Build<IfdPipeline>()
+                .With(i => i.Sk, id)
+                .Without(i => i.EfaFundingUpin)
+                .Without(i => i.ProposedAcademyDetailsNewAcademyUrn)
+                .With(i => i.GeneralDetailsProjectStatus, "Approved for AO")
+                .Create()
+            ).ToList();
+            
             _dbContext.AcademyConversionProjects.AddRange(academyConversionProjects);
             _dbContext.AcademyConversionProjects.Add(academyConversionProjectWithoutName);
+            _legacyDbContext.IfdPipeline.AddRange(ifdProjects);
+           
             _dbContext.SaveChanges();
+            _legacyDbContext.SaveChanges();
             
             var expectedData = academyConversionProjects.Select(p => AcademyConversionProjectResponseFactory.Create(p)).ToList();
             var expectedPaging = new PagingResponse {Page = 1, RecordCount = expectedData.Count};

--- a/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyConversionProjectsIntegrationTests.cs
@@ -15,7 +15,6 @@ using TramsDataApi.ResponseModels;
 using TramsDataApi.ResponseModels.AcademyConversionProject;
 using TramsDataApi.Test.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace TramsDataApi.Test.Integration
 {
@@ -265,6 +264,7 @@ namespace TramsDataApi.Test.Integration
                 var acpResponse = AcademyConversionProjectResponseFactory.Create(p);
                 acpResponse.UkPrn = $"est{p.Urn}";
                 acpResponse.Laestab = 1000 + p.Urn ?? 0;
+                acpResponse.ProjectStatus = "Approved for AO";
                 return acpResponse;
             }).ToList();
             
@@ -311,6 +311,8 @@ namespace TramsDataApi.Test.Integration
             _legacyDbContext.SaveChanges();
             
             var expectedData = academyConversionProjects.Select(p => AcademyConversionProjectResponseFactory.Create(p)).ToList();
+            expectedData.ForEach(ed => ed.ProjectStatus = "Approved for AO");
+            
             var expectedPaging = new PagingResponse {Page = 1, RecordCount = expectedData.Count};
             var expected = new ApiResponseV2<AcademyConversionProjectResponse>(expectedData, expectedPaging);
             
@@ -363,6 +365,7 @@ namespace TramsDataApi.Test.Integration
         public async void Get_request_should_return_response_with_data_having_Upin_and_NewAcademyUrn_set()
         {
             var urns = new List<int> {1, 2};
+            
             var projects = urns
                 .Select(u => _fixture.Build<AcademyConversionProject>().Without(f => f.Id)
                     .With(f => f.Urn, u)

--- a/TramsDataApi.Test/UseCases/GetAcademyConversionProjectsTests.cs
+++ b/TramsDataApi.Test/UseCases/GetAcademyConversionProjectsTests.cs
@@ -36,7 +36,8 @@ namespace TramsDataApi.Test.UseCases
             var useCase = new GetAcademyConversionProjects(
                 mockProjectsGateway.Object, 
                 new Mock<ITrustGateway>().Object,
-                new Mock<IEstablishmentGateway>().Object);
+                new Mock<IEstablishmentGateway>().Object,
+                new Mock<IIfdPipelineGateway>().Object);
             
             var result = useCase.Execute(request).ToList();
 
@@ -49,19 +50,20 @@ namespace TramsDataApi.Test.UseCases
             var request = new GetAllAcademyConversionProjectsRequest { Page = 1, Count = 50 };
 
             var mockProjectsGateway = new Mock<IAcademyConversionProjectGateway>();
-
+ 
             var project = _fixture.Build<AcademyConversionProject>().Create();
 
             var expectedProject = AcademyConversionProjectResponseFactory.Create(project);
-
+            
             mockProjectsGateway
-                .Setup(acg => acg.GetProjects(1, 50))
+                .Setup(acg => acg.GetByIfdPipelineIds(new List<long>()))
                 .Returns(() => new List<AcademyConversionProject> { project });
             
             var useCase = new GetAcademyConversionProjects(
                 mockProjectsGateway.Object,
                 new Mock<ITrustGateway>().Object,
-                new Mock<IEstablishmentGateway>().Object);
+                new Mock<IEstablishmentGateway>().Object,
+                new Mock<IIfdPipelineGateway>().Object);
 
             var result = useCase.Execute(request).ToList();
             

--- a/TramsDataApi/Controllers/V2/AcademyConversionProjectController.cs
+++ b/TramsDataApi/Controllers/V2/AcademyConversionProjectController.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TramsDataApi.RequestModels.AcademyConversionProject;
@@ -48,11 +45,11 @@ namespace TramsDataApi.Controllers.V2
 		{
 			var statusList = string.IsNullOrWhiteSpace(states) ? null : states.Split(',').ToList();
 
-			_logger.LogInformation(statusList == null
+			_logger.LogInformation(statusList == null || !statusList.Any()
 				? $"Attempting to retrieve {count} Academy Conversion Projects."
 				: $"Attempting to retrieve {count} Academy Conversion Projects filtered by {states}");
 			
-			var projects = statusList == null
+			var projects = statusList == null || !statusList.Any()
 				? _getAllAcademyConversionProjects
 					.Execute(new GetAllAcademyConversionProjectsRequest { Page = page, Count = count})
 					.ToList()

--- a/TramsDataApi/Gateways/IIfdPipelineGateway.cs
+++ b/TramsDataApi/Gateways/IIfdPipelineGateway.cs
@@ -6,5 +6,6 @@ namespace TramsDataApi.Gateways
     public interface IIfdPipelineGateway
     {
         IEnumerable<IfdPipeline> GetPipelineProjectsByStatus(int page, int take, List<string> statues);
+        IEnumerable<IfdPipeline> GetPipelineProjects(int page, int take);
     }
 }

--- a/TramsDataApi/Gateways/IfdPipelineGateway.cs
+++ b/TramsDataApi/Gateways/IfdPipelineGateway.cs
@@ -26,5 +26,16 @@ namespace TramsDataApi.Gateways
             
             return results;
         }
+        
+        public IEnumerable<IfdPipeline> GetPipelineProjects(int page, int count)
+        {
+            var results = _dbContext.IfdPipeline
+                .Skip((page - 1) * count)
+                .Take(count)
+                .AsNoTracking()
+                .ToList();
+            
+            return results;
+        }
     }
 }

--- a/TramsDataApi/ResponseModels/PagingResponseFactory.cs
+++ b/TramsDataApi/ResponseModels/PagingResponseFactory.cs
@@ -28,15 +28,7 @@ namespace TramsDataApi.ResponseModels
                 {nameof(count), $"{count}"}
             };
 
-            var uriBuilder = new UriBuilder
-            {
-                Scheme = request.Scheme,
-                Path = request.Path,
-                Query = queryBuilder.ToString()
-            };
-            if (request.Host.Port != null) uriBuilder.Port = request.Host.Port.Value;
-
-            pagingResponse.NextPageUrl = uriBuilder.ToString();
+            pagingResponse.NextPageUrl = $"{request.GetDisplayUrl().Split('?')[0]}{queryBuilder}";
 
             return pagingResponse;
         }

--- a/TramsDataApi/ResponseModels/PagingResponseFactory.cs
+++ b/TramsDataApi/ResponseModels/PagingResponseFactory.cs
@@ -28,7 +28,7 @@ namespace TramsDataApi.ResponseModels
                 {nameof(count), $"{count}"}
             };
 
-            pagingResponse.NextPageUrl = $"{request.GetDisplayUrl().Split('?')[0]}{queryBuilder}";
+            pagingResponse.NextPageUrl = $"{request.Path}{queryBuilder}";
 
             return pagingResponse;
         }

--- a/TramsDataApi/UseCases/GetAcademyConversionProjects.cs
+++ b/TramsDataApi/UseCases/GetAcademyConversionProjects.cs
@@ -12,15 +12,18 @@ namespace TramsDataApi.UseCases
         private readonly IAcademyConversionProjectGateway _academyConversionProjectGateway;
         private readonly ITrustGateway _trustGateway;
         private readonly IEstablishmentGateway _establishmentGateway;
+        private readonly IIfdPipelineGateway _ifdPipelineGateway;
 
         public GetAcademyConversionProjects(
             IAcademyConversionProjectGateway academyConversionProjectGateway,
             ITrustGateway trustGateway, 
-            IEstablishmentGateway establishmentGateway)
+            IEstablishmentGateway establishmentGateway,
+            IIfdPipelineGateway ifdPipelineGateway)
         {
             _academyConversionProjectGateway = academyConversionProjectGateway;
             _trustGateway = trustGateway;
             _establishmentGateway = establishmentGateway;
+            _ifdPipelineGateway = ifdPipelineGateway;
         }
 
         /// <remarks>
@@ -29,10 +32,12 @@ namespace TramsDataApi.UseCases
         /// </remarks>
         public IEnumerable<AcademyConversionProjectResponse> Execute(GetAllAcademyConversionProjectsRequest request)
         {
-            var academyConversionProjects = _academyConversionProjectGateway
-                .GetProjects(request.Page, request.Count)
+            var ifdProjects = _ifdPipelineGateway.GetPipelineProjects(request.Page, request.Count)
                 .ToList();
 
+            var academyConversionProjects = _academyConversionProjectGateway
+                .GetByIfdPipelineIds(ifdProjects.Select(i => i.Sk).ToList()).ToList();
+            
             var trustRefs = academyConversionProjects
                 .Where(acp => !string.IsNullOrEmpty(acp.TrustReferenceNumber))
                 .Select(acp => acp.TrustReferenceNumber)

--- a/TramsDataApi/UseCases/GetAcademyConversionProjects.cs
+++ b/TramsDataApi/UseCases/GetAcademyConversionProjects.cs
@@ -50,7 +50,8 @@ namespace TramsDataApi.UseCases
 
             var responses = academyConversionProjects
                 .Where(p => !string.IsNullOrEmpty(p.SchoolName))
-                .Select(p => AcademyConversionProjectResponseFactory.Create(p))
+                .Select(p => AcademyConversionProjectResponseFactory
+                    .Create(p, null, ifdProjects.FirstOrDefault(ifd => ifd.Sk == p.IfdPipelineId)))
                 .ToList();
 
             responses.ForEach(r =>


### PR DESCRIPTION
Update paging response factory to use the VirtualPath as path base is now default populated with string.empty and request.path always returns localhost