### PR TITLE
Support patching conversion grant fields

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -25,20 +25,22 @@ namespace TramsDataApi.Test.Factories
         public void ReturnsOriginalAcademyConversionProject_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestIsNull()
         {
             var academyConversionProject = CreateAcademyConversionProject();
-
+            var expected = JsonConvert.DeserializeObject<AcademyConversionProject>(JsonConvert.SerializeObject(academyConversionProject));
+            
             var result = AcademyConversionProjectFactory.Update(academyConversionProject, null);
 
-            result.Should().BeEquivalentTo(academyConversionProject);
+            result.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void ReturnsOriginalAcademyConversionProject_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectRequestFieldsAreNull()
         {
             var academyConversionProject = CreateAcademyConversionProject();
+            var expected = JsonConvert.DeserializeObject<AcademyConversionProject>(JsonConvert.SerializeObject(academyConversionProject));
 
             var updateRequest = _fixture.Build<UpdateAcademyConversionProjectRequest>().OmitAutoProperties().Create();
 
-            AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest).Should().BeEquivalentTo(academyConversionProject);
+            AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest).Should().BeEquivalentTo(expected);
         }
 
         [Fact]

--- a/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyConversionProjectFactoryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using AutoFixture;
 using FluentAssertions;
+using FluentAssertions.Common;
 using Newtonsoft.Json;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
@@ -38,6 +39,24 @@ namespace TramsDataApi.Test.Factories
             var updateRequest = _fixture.Build<UpdateAcademyConversionProjectRequest>().OmitAutoProperties().Create();
 
             AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest).Should().BeEquivalentTo(academyConversionProject);
+        }
+
+        [Fact]
+        public void
+            ReturnsOriginalAcademyConversionProject_WhenUpdatingAcademyConversionProject_IfUpdateAcademyConversionProjectGrantFieldsAreNullOrDefault()
+        {
+            var academyConversionProject = CreateAcademyConversionProject();
+            var expected = JsonConvert.DeserializeObject<AcademyConversionProject>(JsonConvert.SerializeObject(academyConversionProject));
+            
+            var updateRequest = new UpdateAcademyConversionProjectRequest
+            {
+                ConversionSupportGrantAmount = null,
+                ConversionSupportGrantChangeReason = null
+            };
+
+            var updatedProject = AcademyConversionProjectFactory.Update(academyConversionProject, updateRequest);
+            updatedProject.ConversionSupportGrantAmount.Should().Be(expected.ConversionSupportGrantAmount);
+            updatedProject.ConversionSupportGrantChangeReason.Should().Be(expected.ConversionSupportGrantChangeReason);
         }
 
         [Fact]
@@ -79,7 +98,7 @@ namespace TramsDataApi.Test.Factories
 
         private AcademyConversionProject CreateAcademyConversionProject()
         {
-            return _fixture.Build<AcademyConversionProject>().OmitAutoProperties().Create();
+            return _fixture.Build<AcademyConversionProject>().Create();
         }
 
         private AcademyConversionProject CreateExpectedAcademyConversionProject(AcademyConversionProject original, UpdateAcademyConversionProjectRequest updateRequest)
@@ -128,7 +147,7 @@ namespace TramsDataApi.Test.Factories
             expected.KeyStage2PerformanceAdditionalInformation = updateRequest.KeyStage2PerformanceAdditionalInformation;
             expected.KeyStage4PerformanceAdditionalInformation = updateRequest.KeyStage4PerformanceAdditionalInformation;
             expected.KeyStage5PerformanceAdditionalInformation = updateRequest.KeyStage5PerformanceAdditionalInformation;
-            expected.ConversionSupportGrantAmount = updateRequest.ConversionSupportGrantAmount;
+            expected.ConversionSupportGrantAmount = updateRequest.ConversionSupportGrantAmount ?? default;
             expected.ConversionSupportGrantChangeReason = updateRequest.ConversionSupportGrantChangeReason;
 
             return expected;

--- a/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyConversionProjectFactory.cs
@@ -87,8 +87,9 @@ namespace TramsDataApi.Factories
                 project.PreviousHeadTeacherBoardDateQuestion;
             project.PreviousHeadTeacherBoardDate = updateRequest.PreviousHeadTeacherBoardDate == default(DateTime) ? null
                 : updateRequest.PreviousHeadTeacherBoardDate ?? project.PreviousHeadTeacherBoardDate;
-            project.ConversionSupportGrantAmount = updateRequest.ConversionSupportGrantAmount;
-            project.ConversionSupportGrantChangeReason = updateRequest.ConversionSupportGrantChangeReason;
+            project.ConversionSupportGrantAmount =
+                updateRequest.ConversionSupportGrantAmount ?? project.ConversionSupportGrantAmount;
+            project.ConversionSupportGrantChangeReason = updateRequest.ConversionSupportGrantChangeReason ?? project.ConversionSupportGrantChangeReason;
 
             return project;
         }

--- a/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
+++ b/TramsDataApi/RequestModels/AcademyConversionProject/UpdateAcademyConversionProjectRequest.cs
@@ -27,7 +27,7 @@ namespace TramsDataApi.RequestModels.AcademyConversionProject
         public bool? SchoolAndTrustInformationSectionComplete { get; set; }
         public string PreviousHeadTeacherBoardDateQuestion { get; set; }
         public DateTime? PreviousHeadTeacherBoardDate { get; set; }
-        public decimal ConversionSupportGrantAmount { get; set; }
+        public decimal? ConversionSupportGrantAmount { get; set; }
         public string ConversionSupportGrantChangeReason { get; set; }
 
         //general info


### PR DESCRIPTION
Conversion grant fields were being updated when given null - this updates the request object/factory to support patching and only update when given data

