### PR TITLE
Allow dates to be updated to null

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -357,7 +357,121 @@ namespace TramsDataApi.Test.Factories
 
             result.Should().BeEquivalentTo(expected);
         }
-    }
+        
+        [Fact]
+        public void ReturnsUpdatedAcademyTransferProject_WhenUpdating_IfRequestIsToSetDatesBackToNull()
+        {
+            var academyTransferProject = Builder<AcademyTransferProjects>
+                .CreateNew()
+                .Build();
 
-    
+            var updateRequest = new AcademyTransferProjectRequest
+            {
+                Dates = new AcademyTransferProjectDatesRequest
+                {
+                    HasTargetDateForTransfer = false,
+                    HasTransferFirstDiscussedDate = false,
+                    HasHtbDate = false
+                }
+            };
+
+            var expected = new AcademyTransferProjects
+            {
+                Id = academyTransferProject.Id,
+                Urn = academyTransferProject.Urn,   
+                OutgoingTrustUkprn = academyTransferProject.OutgoingTrustUkprn,
+                ProjectRationale = academyTransferProject.ProjectRationale,
+                TransferringAcademies = academyTransferProject.TransferringAcademies,
+                WhoInitiatedTheTransfer = academyTransferProject.WhoInitiatedTheTransfer,
+                TargetDateForTransfer = null,
+                RddOrEsfaIntervention = academyTransferProject.RddOrEsfaIntervention,
+                RddOrEsfaInterventionDetail = academyTransferProject.RddOrEsfaInterventionDetail,
+                TypeOfTransfer = academyTransferProject.TypeOfTransfer,
+                OtherTransferTypeDescription = academyTransferProject.OtherTransferTypeDescription,
+                TransferFirstDiscussed = null,
+                HtbDate = null,
+                TrustSponsorRationale = academyTransferProject.TrustSponsorRationale,
+                State = academyTransferProject.State,
+                Status = academyTransferProject.Status,
+                Author = academyTransferProject.Author,
+                Recommendation = academyTransferProject.Recommendation,
+                HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
+                HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
+                FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
+                OtherBenefitValue = academyTransferProject.OtherBenefitValue,
+                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
+                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+            };
+
+            var result = AcademyTransferProjectFactory.Update(academyTransferProject, updateRequest);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ReturnsOriginalAcademyTransferProject_WhenUpdating_IfDatesAreNull()
+        {
+            var academyTransferProject = Builder<AcademyTransferProjects>
+                .CreateNew()
+                .Build();
+
+            var updateRequest = new AcademyTransferProjectRequest
+            {
+                Dates = new AcademyTransferProjectDatesRequest
+                {
+                    TargetDateForTransfer = null,
+                    TransferFirstDiscussed = null,
+                    HtbDate = null
+                }
+            };
+
+            var expected = new AcademyTransferProjects
+            {
+                Id = academyTransferProject.Id,
+                Urn = academyTransferProject.Urn,   
+                OutgoingTrustUkprn = academyTransferProject.OutgoingTrustUkprn,
+                ProjectRationale = academyTransferProject.ProjectRationale,
+                TransferringAcademies = academyTransferProject.TransferringAcademies,
+                WhoInitiatedTheTransfer = academyTransferProject.WhoInitiatedTheTransfer,
+                TargetDateForTransfer = academyTransferProject.TargetDateForTransfer,
+                RddOrEsfaIntervention = academyTransferProject.RddOrEsfaIntervention,
+                RddOrEsfaInterventionDetail = academyTransferProject.RddOrEsfaInterventionDetail,
+                TypeOfTransfer = academyTransferProject.TypeOfTransfer,
+                OtherTransferTypeDescription = academyTransferProject.OtherTransferTypeDescription,
+                TransferFirstDiscussed = academyTransferProject.TransferFirstDiscussed,
+                HtbDate = academyTransferProject.HtbDate,
+                TrustSponsorRationale = academyTransferProject.TrustSponsorRationale,
+                State = academyTransferProject.State,
+                Status = academyTransferProject.Status,
+                Author = academyTransferProject.Author,
+                Recommendation = academyTransferProject.Recommendation,
+                HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
+                HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
+                FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
+                OtherBenefitValue = academyTransferProject.OtherBenefitValue,
+                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
+                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+            };
+
+            var result = AcademyTransferProjectFactory.Update(academyTransferProject, updateRequest);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
 }

--- a/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
@@ -98,9 +98,9 @@ namespace TramsDataApi.Factories
             original.TypeOfTransfer = toMerge?.TypeOfTransfer ?? original.TypeOfTransfer;
             original.OtherTransferTypeDescription =
                 toMerge?.OtherTransferTypeDescription ?? original.OtherTransferTypeDescription;
-            original.TransferFirstDiscussed = toMerge.TransferFirstDiscussed ?? original.TransferFirstDiscussed;
-            original.TargetDateForTransfer = toMerge.TargetDateForTransfer ?? original.TargetDateForTransfer;
-            original.HtbDate = toMerge.HtbDate ?? original.HtbDate;
+            original.TransferFirstDiscussed = (updateRequest.Dates?.HasTransferFirstDiscussedDate ?? true) ? (toMerge.TransferFirstDiscussed ?? original.TransferFirstDiscussed) : null;
+            original.TargetDateForTransfer = (updateRequest.Dates?.HasTargetDateForTransfer ?? true) ? (toMerge.TargetDateForTransfer ?? original.TargetDateForTransfer) : null;
+            original.HtbDate = (updateRequest.Dates?.HasHtbDate ?? true) ? (toMerge.HtbDate ?? original.HtbDate) : null;
             original.ProjectRationale = toMerge.ProjectRationale ?? original.ProjectRationale;
             original.TrustSponsorRationale = toMerge.TrustSponsorRationale ?? original.TrustSponsorRationale;
             original.State = toMerge.State ?? original.State;

--- a/TramsDataApi/RequestModels/AcademyTransferProjectDatesRequest.cs
+++ b/TramsDataApi/RequestModels/AcademyTransferProjectDatesRequest.cs
@@ -3,7 +3,10 @@ namespace TramsDataApi.RequestModels
     public class AcademyTransferProjectDatesRequest
     {
         public string TransferFirstDiscussed { get; set; }
+        public bool HasTransferFirstDiscussedDate { get; set; } = true;
         public string TargetDateForTransfer { get; set; }
+        public bool HasTargetDateForTransfer { get; set; } = true;
         public string HtbDate { get; set; }
+        public bool HasHtbDate { get; set; } = true;
     }
 }


### PR DESCRIPTION
This PR is to allow the dates used in academy transfers to be reset back to null after they have previously been populated.