### PR TITLE
Add single object v2 response

### DIFF
--- a/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
@@ -40,7 +40,7 @@ namespace TramsDataApi.Test.Controllers
             
             var result = controller.Create(createConcernsCaseRequest);
             
-            var expected = new ApiResponseV2<ConcernsCaseResponse>(concernsCaseResponse);
+            var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCaseResponse);
             
             result.Result.Should().BeEquivalentTo(new ObjectResult(expected) {StatusCode = StatusCodes.Status201Created});
         }
@@ -88,7 +88,7 @@ namespace TramsDataApi.Test.Controllers
             
             var result = controller.GetByUrn(urn);
             
-            var expected = new ApiResponseV2<ConcernsCaseResponse>(concernsCaseResponse);
+            var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCaseResponse);
             
             result.Result.Should().BeEquivalentTo(new OkObjectResult(expected));
         }

--- a/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
@@ -70,14 +70,14 @@ namespace TramsDataApi.Test.Integration
             var caseToBeCreated = ConcernsCaseFactory.Create(createRequest);
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(caseToBeCreated);
             
-            var expected = new ApiResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
+            var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
             
             var response = await _client.SendAsync(httpRequestMessage);
             response.StatusCode.Should().Be(201);
-            var result = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
+            var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
             
-            var createdCase = _dbContext.ConcernsCase.FirstOrDefault(c => c.Urn == result.Data.First().Urn);
-            expected.Data.First().Urn = createdCase.Urn;
+            var createdCase = _dbContext.ConcernsCase.FirstOrDefault(c => c.Urn == result.Data.Urn);
+            expected.Data.Urn = createdCase.Urn;
             
             result.Should().BeEquivalentTo(expected);
             createdCase.Description.Should().BeEquivalentTo(createRequest.Description);
@@ -101,14 +101,14 @@ namespace TramsDataApi.Test.Integration
             
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(concernsCase);
             
-            var expected = new ApiResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
+            var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
             
             var response = await _client.SendAsync(httpRequestMessage);
             
             response.StatusCode.Should().Be(200);
-            var result = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
+            var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
             result.Should().BeEquivalentTo(expected);
-            result.Data.First().Urn.Should().BeEquivalentTo(concernsCase.Urn);
+            result.Data.Urn.Should().BeEquivalentTo(concernsCase.Urn);
         }
         
         [Fact]
@@ -262,14 +262,14 @@ namespace TramsDataApi.Test.Integration
 
             var recordToBeCreated = ConcernsRecordFactory.Create(createRequest);
             var expectedConcernsRecordResponse = ConcernsRecordResponseFactory.Create(recordToBeCreated);
-            var expected = new ApiResponseV2<ConcernsRecordResponse>(expectedConcernsRecordResponse);
+            var expected = new ApiSingleResponseV2<ConcernsRecordResponse>(expectedConcernsRecordResponse);
             
             var response = await _client.SendAsync(httpRequestMessage);
             response.StatusCode.Should().Be(201);
-            var result = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
+            var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
             
-            var createdRecord = _dbContext.ConcernsRecord.FirstOrDefault(c => c.Urn == result.Data.First().Urn);
-            expected.Data.First().Urn = createdRecord.Urn;
+            var createdRecord = _dbContext.ConcernsRecord.FirstOrDefault(c => c.Urn == result.Data.Urn);
+            expected.Data.Urn = createdRecord.Urn;
             
             result.Should().BeEquivalentTo(expected);
         }

--- a/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
@@ -35,7 +35,7 @@ namespace TramsDataApi.Controllers.V2
         public ActionResult<ApiResponseV2<ConcernsCaseResponse>> Create(ConcernCaseRequest request)
         {
             var createdConcernsCase = _createConcernsCase.Execute(request);
-            var response = new ApiResponseV2<ConcernsCaseResponse>(createdConcernsCase);
+            var response = new ApiSingleResponseV2<ConcernsCaseResponse>(createdConcernsCase);
             
             return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
         }
@@ -56,7 +56,7 @@ namespace TramsDataApi.Controllers.V2
             
             _logger.LogInformation($"Returning Concerns case with Urn {urn}");
             _logger.LogDebug(JsonSerializer.Serialize(concernsCase));
-            var response = new ApiResponseV2<ConcernsCaseResponse>(concernsCase);
+            var response = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCase);
             
             return Ok(response);
         }

--- a/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
@@ -29,7 +29,7 @@ namespace TramsDataApi.Controllers.V2
         public ActionResult<ApiResponseV2<ConcernsRecordResponse>> Create(ConcernsRecordRequest request)
         {
             var createdConcernsRecord = _createConcernsRecord.Execute(request);
-            var response = new ApiResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
+            var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
             
             return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
         }

--- a/TramsDataApi/ResponseModels/ApiResponseV2.cs
+++ b/TramsDataApi/ResponseModels/ApiResponseV2.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using TramsDataApi.UseCases;
 
 namespace TramsDataApi.ResponseModels
 {

--- a/TramsDataApi/ResponseModels/ApiSingleResponseV2.cs
+++ b/TramsDataApi/ResponseModels/ApiSingleResponseV2.cs
@@ -1,0 +1,10 @@
+namespace TramsDataApi.ResponseModels
+{
+    public class ApiSingleResponseV2<TResponse> where TResponse : class
+    {
+        public TResponse Data { get; set; }
+        
+        public ApiSingleResponseV2() => Data = null;
+        public ApiSingleResponseV2(TResponse data) => Data = data ;
+    }
+}


### PR DESCRIPTION
In this PR:
- Add`ApiSingleResponseV2` response object to use when we need to return a single object