### PR TITLE
Remove depreciated table column from gias establishment

### DIFF
--- a/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/EstablishmentResponseFactoryTests.cs
@@ -214,7 +214,6 @@ namespace TramsDataApi.Test.Factories
                 GSSLACode = establishment.GsslacodeName,
                 Easting = establishment.Easting,
                 Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
                 MSOA = new NameAndCodeResponse { Name = establishment.MsoaName, Code = establishment.MsoaCode },
                 LSOA = new NameAndCodeResponse { Name = establishment.LsoaName, Code = establishment.LsoaCode },
                 SENStat = establishment.Senstat,

--- a/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsIntegrationTests.cs
@@ -1160,7 +1160,6 @@ namespace TramsDataApi.Test.Integration
                 GsslacodeName = "E09000001",
                 Easting = "533498",
                 Northing = "181201",
-                CensusAreaStatisticWardName = null,
                 MsoaName = "City of London 001",
                 LsoaName = "City of London 001F",
                 Senstat = "0",

--- a/TramsDataApi/DatabaseModels/Establishment.cs
+++ b/TramsDataApi/DatabaseModels/Establishment.cs
@@ -117,7 +117,6 @@
         public string GsslacodeName { get; set; }
         public string Easting { get; set; }
         public string Northing { get; set; }
-        public string CensusAreaStatisticWardName { get; set; }
         public string MsoaName { get; set; }
         public string LsoaName { get; set; }
         public string Senstat { get; set; }

--- a/TramsDataApi/DatabaseModels/LegacyTramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/LegacyTramsDbContext.cs
@@ -90,10 +90,6 @@ namespace TramsDataApi.DatabaseModels
                     .HasColumnName("CCF (name)")
                     .IsUnicode(false);
 
-                entity.Property(e => e.CensusAreaStatisticWardName)
-                    .HasColumnName("CensusAreaStatisticWard (name)")
-                    .IsUnicode(false);
-
                 entity.Property(e => e.CensusDate).IsUnicode(false);
 
                 entity.Property(e => e.Chnumber)

--- a/TramsDataApi/Factories/EstablishmentResponseFactory.cs
+++ b/TramsDataApi/Factories/EstablishmentResponseFactory.cs
@@ -167,7 +167,6 @@ namespace TramsDataApi.Factories
                 GSSLACode = establishment.GsslacodeName,
                 Easting = establishment.Easting,
                 Northing = establishment.Northing,
-                CensusAreaStatisticWard = establishment.CensusAreaStatisticWardName,
                 MSOA = new NameAndCodeResponse { Name = establishment.MsoaName, Code = establishment.MsoaCode },
                 LSOA = new NameAndCodeResponse { Name = establishment.LsoaName, Code = establishment.LsoaCode },
                 SENStat = establishment.Senstat,


### PR DESCRIPTION
Removes depreciated table column from GIAS establishment as it has ben removed from the database and pipelines.