### PR TITLE
Add fk relationship between ConcernsRecords and ConcernsCases

### DIFF
--- a/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
@@ -48,7 +48,7 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetConcernsCaseByUrn_ReturnsNotFound_WhenConcernsCaseIsNotFound()
         {
-            var urn = "10021231";
+            var urn = 100;
             
             var getConcernsCaseByUrn = new Mock<IGetConcernsCaseByUrn>();
             
@@ -71,7 +71,7 @@ namespace TramsDataApi.Test.Controllers
         public void GetConcernsCaseByUrn_Returns200AndTheFoundConcernsCase_WhenSuccessfullyGetsAConcernsCaseByUrn()
         {
             var getConcernsCaseByUrn = new Mock<IGetConcernsCaseByUrn>();
-            var urn = "12345";
+            var urn = 123;
 
             var concernsCaseResponse = Builder<ConcernsCaseResponse>
                 .CreateNew().Build();

--- a/TramsDataApi.Test/Factories/ConcernsCaseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsCaseFactoryTests.cs
@@ -32,6 +32,8 @@ namespace TramsDataApi.Test.Factories
                 .With(c => c.StatusUrn = 3)
                 .Build();
 
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
+
             var expected = new ConcernsCase
             {
                 CreatedAt = request.CreatedAt,
@@ -50,10 +52,10 @@ namespace TramsDataApi.Test.Factories
                 DeEscalationPoint = request.DeEscalationPoint,
                 NextSteps = request.NextSteps,
                 DirectionOfTravel = request.DirectionOfTravel,
-                StatusUrn = request.StatusUrn
+                Status = status
             };
 
-            var result = ConcernsCaseFactory.Create(request);
+            var result = ConcernsCaseFactory.Create(request, status);
             result.Should().BeEquivalentTo(expected);
         }
     }

--- a/TramsDataApi.Test/Factories/ConcernsCaseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsCaseFactoryTests.cs
@@ -32,8 +32,6 @@ namespace TramsDataApi.Test.Factories
                 .With(c => c.StatusUrn = 3)
                 .Build();
 
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
-
             var expected = new ConcernsCase
             {
                 CreatedAt = request.CreatedAt,
@@ -52,10 +50,10 @@ namespace TramsDataApi.Test.Factories
                 DeEscalationPoint = request.DeEscalationPoint,
                 NextSteps = request.NextSteps,
                 DirectionOfTravel = request.DirectionOfTravel,
-                Status = status
+                StatusUrn = request.StatusUrn
             };
 
-            var result = ConcernsCaseFactory.Create(request, status);
+            var result = ConcernsCaseFactory.Create(request);
             result.Should().BeEquivalentTo(expected);
         }
     }

--- a/TramsDataApi.Test/Factories/ConcernsCaseResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsCaseResponseFactoryTests.cs
@@ -13,6 +13,7 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void ReturnsConcernsCaseResponse_WhenGivenAnConcernsCase()
         {
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
             var concernsCase = new ConcernsCase
             {
                 Id = 123,
@@ -33,7 +34,7 @@ namespace TramsDataApi.Test.Factories
                 NextSteps = "next steps",
                 DirectionOfTravel = "Direction",
                 Urn = "10988",
-                StatusUrn = 1
+                Status = status
             };
 
             var expected = new ConcernsCaseResponse
@@ -55,7 +56,7 @@ namespace TramsDataApi.Test.Factories
                 NextSteps = concernsCase.NextSteps,
                 DirectionOfTravel = concernsCase.DirectionOfTravel,
                 Urn = concernsCase.Urn,
-                StatusUrn = concernsCase.StatusUrn
+                StatusUrn = status.Urn
             };
 
             var result = ConcernsCaseResponseFactory.Create(concernsCase);

--- a/TramsDataApi.Test/Factories/ConcernsCaseResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsCaseResponseFactoryTests.cs
@@ -13,7 +13,6 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void ReturnsConcernsCaseResponse_WhenGivenAnConcernsCase()
         {
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
             var concernsCase = new ConcernsCase
             {
                 Id = 123,
@@ -33,8 +32,8 @@ namespace TramsDataApi.Test.Factories
                 DeEscalationPoint = "20394",
                 NextSteps = "next steps",
                 DirectionOfTravel = "Direction",
-                Urn = "10988",
-                Status = status
+                Urn = 109,
+                StatusUrn = 123
             };
 
             var expected = new ConcernsCaseResponse
@@ -56,7 +55,7 @@ namespace TramsDataApi.Test.Factories
                 NextSteps = concernsCase.NextSteps,
                 DirectionOfTravel = concernsCase.DirectionOfTravel,
                 Urn = concernsCase.Urn,
-                StatusUrn = status.Urn
+                StatusUrn = concernsCase.StatusUrn
             };
 
             var result = ConcernsCaseResponseFactory.Create(concernsCase);

--- a/TramsDataApi.Test/Factories/ConcernsRecordFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsRecordFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
@@ -27,6 +28,8 @@ namespace TramsDataApi.Test.Factories
                 Primary = true,
                 StatusUrn = 1
             };
+            
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
 
             var expected = new ConcernsRecord
             {
@@ -41,10 +44,10 @@ namespace TramsDataApi.Test.Factories
                 TypeId = recordRequest.TypeId,
                 RatingId = recordRequest.RatingId,
                 Primary = recordRequest.Primary,
-                StatusUrn = recordRequest.StatusUrn
+                Status = status
             };
 
-            var result = ConcernsRecordFactory.Create(recordRequest);
+            var result = ConcernsRecordFactory.Create(recordRequest, status);
             result.Should().BeEquivalentTo(expected);
         }
     }

--- a/TramsDataApi.Test/Factories/ConcernsRecordFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsRecordFactoryTests.cs
@@ -13,6 +13,10 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void ReturnsConcernsRecord_WhenGivenAnConcernsRecordRequest()
         {
+
+            var concernsCase = Builder<ConcernsCase>.CreateNew().Build();
+            var concernsType = Builder<ConcernsType>.CreateNew().Build();
+            
             var recordRequest = new ConcernsRecordRequest
             {
                 CreatedAt = new DateTime(2021, 05, 14),
@@ -22,14 +26,12 @@ namespace TramsDataApi.Test.Factories
                 Name = "Test concerns record",
                 Description = "Test concerns record desc",
                 Reason = "Test concern",
-                CaseId = 1,
-                TypeId = 2,
+                CaseUrn = 1,
+                TypeUrn = 2,
                 RatingId = 3,
                 Primary = true,
                 StatusUrn = 1
             };
-            
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
 
             var expected = new ConcernsRecord
             {
@@ -40,14 +42,14 @@ namespace TramsDataApi.Test.Factories
                 Name = recordRequest.Name,
                 Description = recordRequest.Description,
                 Reason = recordRequest.Reason,
-                CaseId = recordRequest.CaseId,
-                TypeId = recordRequest.TypeId,
+                ConcernsCase = concernsCase,
+                ConcernsType = concernsType,
                 RatingId = recordRequest.RatingId,
                 Primary = recordRequest.Primary,
-                Status = status
+                StatusUrn = recordRequest.StatusUrn
             };
 
-            var result = ConcernsRecordFactory.Create(recordRequest, status);
+            var result = ConcernsRecordFactory.Create(recordRequest, concernsCase, concernsType);
             result.Should().BeEquivalentTo(expected);
         }
     }

--- a/TramsDataApi.Test/Factories/ConcernsRecordResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsRecordResponseFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
@@ -12,6 +13,8 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void ReturnsConcernsRecordResponse_WhenGivenAnConcernsRecord()
         {
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
+            
             var concernsRecord = new ConcernsRecord
             {
                 Id = 1,
@@ -27,7 +30,7 @@ namespace TramsDataApi.Test.Factories
                 RatingId = 5,
                 Primary = false,
                 Urn = "4",
-                StatusUrn = 3
+                Status = status
             };
 
             var expected = new ConcernsRecordResponse
@@ -44,7 +47,7 @@ namespace TramsDataApi.Test.Factories
                 RatingId = concernsRecord.RatingId,
                 Primary = concernsRecord.Primary,
                 Urn = concernsRecord.Urn,
-                StatusUrn = concernsRecord.StatusUrn
+                StatusUrn = status.Urn
             };
 
             var result = ConcernsRecordResponseFactory.Create(concernsRecord);

--- a/TramsDataApi.Test/Factories/ConcernsRecordResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsRecordResponseFactoryTests.cs
@@ -13,8 +13,8 @@ namespace TramsDataApi.Test.Factories
         [Fact]
         public void ReturnsConcernsRecordResponse_WhenGivenAnConcernsRecord()
         {
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
-            
+            var concernCase = Builder<ConcernsCase>.CreateNew().Build();
+            var concernType = Builder<ConcernsType>.CreateNew().Build();
             var concernsRecord = new ConcernsRecord
             {
                 Id = 1,
@@ -30,7 +30,9 @@ namespace TramsDataApi.Test.Factories
                 RatingId = 5,
                 Primary = false,
                 Urn = "4",
-                Status = status
+                StatusUrn = 23,
+                ConcernsCase = concernCase,
+                ConcernsType = concernType
             };
 
             var expected = new ConcernsRecordResponse
@@ -42,12 +44,12 @@ namespace TramsDataApi.Test.Factories
                 Name = concernsRecord.Name,
                 Description = concernsRecord.Description,
                 Reason = concernsRecord.Reason,
-                CaseId = concernsRecord.CaseId,
-                TypeId = concernsRecord.TypeId,
                 RatingId = concernsRecord.RatingId,
                 Primary = concernsRecord.Primary,
                 Urn = concernsRecord.Urn,
-                StatusUrn = status.Urn
+                StatusUrn = concernsRecord.StatusUrn,
+                TypeUrn = concernType.Urn,
+                CaseUrn = concernCase.Urn
             };
 
             var result = ConcernsRecordResponseFactory.Create(concernsRecord);

--- a/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
@@ -55,6 +55,8 @@ namespace TramsDataApi.Test.Integration
                 .With(c => c.DirectionOfTravel = "Up")
                 .With(c => c.StatusUrn = 1)
                 .Build();
+
+            var status = _dbContext.ConcernsStatus.FirstOrDefault(s => s.Urn == createRequest.StatusUrn);
             
             var httpRequestMessage = new HttpRequestMessage
             {
@@ -67,7 +69,7 @@ namespace TramsDataApi.Test.Integration
                 Content =  JsonContent.Create(createRequest)
             };
 
-            var caseToBeCreated = ConcernsCaseFactory.Create(createRequest);
+            var caseToBeCreated = ConcernsCaseFactory.Create(createRequest, status);
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(caseToBeCreated);
             
             var expected = new ApiResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
@@ -247,6 +249,7 @@ namespace TramsDataApi.Test.Integration
         public async Task CanCreateNewConcernRecord()
         {
             var createRequest = Builder<ConcernsRecordRequest>.CreateNew()
+                .With(c => c.StatusUrn = 1)
                 .Build();
             
             var httpRequestMessage = new HttpRequestMessage
@@ -259,8 +262,10 @@ namespace TramsDataApi.Test.Integration
                 },
                 Content =  JsonContent.Create(createRequest)
             };
+            
+            var status = _dbContext.ConcernsStatus.FirstOrDefault(s => s.Urn == createRequest.StatusUrn);
 
-            var recordToBeCreated = ConcernsRecordFactory.Create(createRequest);
+            var recordToBeCreated = ConcernsRecordFactory.Create(createRequest, status);
             var expectedConcernsRecordResponse = ConcernsRecordResponseFactory.Create(recordToBeCreated);
             var expected = new ApiResponseV2<ConcernsRecordResponse>(expectedConcernsRecordResponse);
             
@@ -276,6 +281,7 @@ namespace TramsDataApi.Test.Integration
 
         private void SetupConcernsCaseTestData(string trustUkprn, int count = 1)
         {
+            
             for (var i = 0; i < count; i++)
             {
                 var concernsCase = new ConcernsCase
@@ -296,7 +302,7 @@ namespace TramsDataApi.Test.Integration
                     DeEscalationPoint = _randomGenerator.NextString(3, 10),
                     NextSteps = _randomGenerator.NextString(3, 10),
                     DirectionOfTravel = _randomGenerator.NextString(3, 10),
-                    StatusUrn = 2,
+                    StatusId = 2,
                 };
 
                 _dbContext.ConcernsCase.Add(concernsCase);

--- a/TramsDataApi.Test/UseCases/CreateConcernsCaseTests.cs
+++ b/TramsDataApi.Test/UseCases/CreateConcernsCaseTests.cs
@@ -16,7 +16,8 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void ShouldCreateAndReturnAConcernsCase_WhenGivenAConcernsCaseRequest()
         {
-            var gateway = new Mock<IConcernsCaseGateway>();
+            var concernsCaseGateway = new Mock<IConcernsCaseGateway>();
+            var concernsStatusGateway = new Mock<IConcernsStatusGateway>();
             
             var createRequest = Builder<ConcernCaseRequest>.CreateNew()
                 .With(c => c.CreatedAt = new DateTime(2022,10,13))
@@ -36,13 +37,16 @@ namespace TramsDataApi.Test.UseCases
                 .With(c => c.DirectionOfTravel = "Up")
                 .With(c => c.StatusUrn = 2)
                 .Build();
+
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
             
-            var createdConcernsCase = ConcernsCaseFactory.Create(createRequest);
+            var createdConcernsCase = ConcernsCaseFactory.Create(createRequest, status);
             var expected = ConcernsCaseResponseFactory.Create(createdConcernsCase);
             
-            gateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsCase>())).Returns(createdConcernsCase);
+            concernsCaseGateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsCase>())).Returns(createdConcernsCase);
+            concernsStatusGateway.Setup(g => g.GetStatusByUrn(It.IsAny<int>())).Returns(status);
             
-            var useCase = new CreateConcernsCase(gateway.Object);
+            var useCase = new CreateConcernsCase(concernsCaseGateway.Object, concernsStatusGateway.Object);
             var result = useCase.Execute(createRequest);
             
             result.Should().BeEquivalentTo(expected);

--- a/TramsDataApi.Test/UseCases/CreateConcernsCaseTests.cs
+++ b/TramsDataApi.Test/UseCases/CreateConcernsCaseTests.cs
@@ -17,7 +17,6 @@ namespace TramsDataApi.Test.UseCases
         public void ShouldCreateAndReturnAConcernsCase_WhenGivenAConcernsCaseRequest()
         {
             var concernsCaseGateway = new Mock<IConcernsCaseGateway>();
-            var concernsStatusGateway = new Mock<IConcernsStatusGateway>();
             
             var createRequest = Builder<ConcernCaseRequest>.CreateNew()
                 .With(c => c.CreatedAt = new DateTime(2022,10,13))
@@ -38,15 +37,12 @@ namespace TramsDataApi.Test.UseCases
                 .With(c => c.StatusUrn = 2)
                 .Build();
 
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
-            
-            var createdConcernsCase = ConcernsCaseFactory.Create(createRequest, status);
+            var createdConcernsCase = ConcernsCaseFactory.Create(createRequest);
             var expected = ConcernsCaseResponseFactory.Create(createdConcernsCase);
             
             concernsCaseGateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsCase>())).Returns(createdConcernsCase);
-            concernsStatusGateway.Setup(g => g.GetStatusByUrn(It.IsAny<int>())).Returns(status);
-            
-            var useCase = new CreateConcernsCase(concernsCaseGateway.Object, concernsStatusGateway.Object);
+
+            var useCase = new CreateConcernsCase(concernsCaseGateway.Object);
             var result = useCase.Execute(createRequest);
             
             result.Should().BeEquivalentTo(expected);

--- a/TramsDataApi.Test/UseCases/CreateConcernsRecordTests.cs
+++ b/TramsDataApi.Test/UseCases/CreateConcernsRecordTests.cs
@@ -16,18 +16,21 @@ namespace TramsDataApi.Test.UseCases
         public void ShouldCreateAndReturnAConcernsRecord_WhenGivenAConcernsRecordRequest()
         {
             var concernsRecordGateway = new Mock<IConcernsRecordGateway>();
-            var concernsStatusGateway = new Mock<IConcernsStatusGateway>();
+            var concernsCaseGateway = new Mock<IConcernsCaseGateway>();
+            var concernsTypeGateway = new Mock<IConcernsTypeGateway>();
             
             var createRequest = Builder<ConcernsRecordRequest>.CreateNew().Build();
-            var status = Builder<ConcernsStatus>.CreateNew().Build();
+            var concernsCase = Builder<ConcernsCase>.CreateNew().Build();
+            var concernsType = Builder<ConcernsType>.CreateNew().Build();
             
-            var createdConcernsRecord = ConcernsRecordFactory.Create(createRequest, status);
+            var createdConcernsRecord = ConcernsRecordFactory.Create(createRequest, concernsCase, concernsType);
             var expected = ConcernsRecordResponseFactory.Create(createdConcernsRecord);
             
             concernsRecordGateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsRecord>())).Returns(createdConcernsRecord);
-            concernsStatusGateway.Setup(g => g.GetStatusByUrn(It.IsAny<int>())).Returns(status);
-            
-            var useCase = new CreateConcernsRecord(concernsRecordGateway.Object, concernsStatusGateway.Object);
+            concernsCaseGateway.Setup(g => g.GetConcernsCaseByUrn(It.IsAny<int>())).Returns(concernsCase);
+            concernsTypeGateway.Setup(g => g.GetConcernsTypeByUrn(It.IsAny<int>())).Returns(concernsType);
+
+            var useCase = new CreateConcernsRecord(concernsRecordGateway.Object, concernsCaseGateway.Object, concernsTypeGateway.Object);
             var result = useCase.Execute(createRequest);
             
             result.Should().BeEquivalentTo(expected);

--- a/TramsDataApi.Test/UseCases/CreateConcernsRecordTests.cs
+++ b/TramsDataApi.Test/UseCases/CreateConcernsRecordTests.cs
@@ -15,16 +15,19 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void ShouldCreateAndReturnAConcernsRecord_WhenGivenAConcernsRecordRequest()
         {
-            var gateway = new Mock<IConcernsRecordGateway>();
-
-            var createRequest = Builder<ConcernsRecordRequest>.CreateNew().Build();
+            var concernsRecordGateway = new Mock<IConcernsRecordGateway>();
+            var concernsStatusGateway = new Mock<IConcernsStatusGateway>();
             
-            var createdConcernsRecord = ConcernsRecordFactory.Create(createRequest);
+            var createRequest = Builder<ConcernsRecordRequest>.CreateNew().Build();
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
+            
+            var createdConcernsRecord = ConcernsRecordFactory.Create(createRequest, status);
             var expected = ConcernsRecordResponseFactory.Create(createdConcernsRecord);
             
-            gateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsRecord>())).Returns(createdConcernsRecord);
+            concernsRecordGateway.Setup(g => g.SaveConcernsCase(It.IsAny<ConcernsRecord>())).Returns(createdConcernsRecord);
+            concernsStatusGateway.Setup(g => g.GetStatusByUrn(It.IsAny<int>())).Returns(status);
             
-            var useCase = new CreateConcernsRecord(gateway.Object);
+            var useCase = new CreateConcernsRecord(concernsRecordGateway.Object, concernsStatusGateway.Object);
             var result = useCase.Execute(createRequest);
             
             result.Should().BeEquivalentTo(expected);

--- a/TramsDataApi.Test/UseCases/GetConcernsCaseByTrustUkPrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetConcernsCaseByTrustUkPrnTests.cs
@@ -48,10 +48,7 @@ namespace TramsDataApi.Test.UseCases
             var mockGateway = new Mock<IConcernsCaseGateway>();
             var useCase = new GetConcernsCaseByTrustUkprn(mockGateway.Object);
             var status = Builder<ConcernsStatus>.CreateNew().Build();
-            var concernsCases = Builder<ConcernsCase>.CreateListOfSize(20)
-                .All()
-                .With(c => c.Status = status)
-                .Build();
+            var concernsCases = Builder<ConcernsCase>.CreateListOfSize(20).Build();
 
             mockGateway
                 .Setup(g => g.GetConcernsCaseByTrustUkprn(It.IsAny<string>(), 1, 50))

--- a/TramsDataApi.Test/UseCases/GetConcernsCaseByTrustUkPrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetConcernsCaseByTrustUkPrnTests.cs
@@ -47,7 +47,11 @@ namespace TramsDataApi.Test.UseCases
         {
             var mockGateway = new Mock<IConcernsCaseGateway>();
             var useCase = new GetConcernsCaseByTrustUkprn(mockGateway.Object);
-            var concernsCases = Builder<ConcernsCase>.CreateListOfSize(20).Build();
+            var status = Builder<ConcernsStatus>.CreateNew().Build();
+            var concernsCases = Builder<ConcernsCase>.CreateListOfSize(20)
+                .All()
+                .With(c => c.Status = status)
+                .Build();
 
             mockGateway
                 .Setup(g => g.GetConcernsCaseByTrustUkprn(It.IsAny<string>(), 1, 50))

--- a/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
@@ -43,7 +43,7 @@ namespace TramsDataApi.Controllers.V2
         [HttpGet]
         [Route("urn/{urn}")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiResponseV2<ConcernsCaseResponse>> GetByUrn(string urn)
+        public ActionResult<ApiResponseV2<ConcernsCaseResponse>> GetByUrn(int urn)
         {
             _logger.LogInformation($"Attempting to get Concerns Case by Urn {urn}");
             var concernsCase = _getConcernsCaseByUrn.Execute(urn);

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -24,8 +24,8 @@ namespace TramsDataApi.DatabaseModels
         public string NextSteps { get; set; }
         public string DirectionOfTravel { get; set; }
         public string Urn { get; set; }
-        public int StatusUrn { get; set; }
-        public ConcernsStatus Status { get; set; }
+        public int StatusId { get; set; }
+        public virtual ConcernsStatus Status { get; set; }
         public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
@@ -24,5 +25,7 @@ namespace TramsDataApi.DatabaseModels
         public string DirectionOfTravel { get; set; }
         public string Urn { get; set; }
         public int StatusUrn { get; set; }
+        public ConcernsStatus Status { get; set; }
+        public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -23,9 +23,8 @@ namespace TramsDataApi.DatabaseModels
         public string DeEscalationPoint { get; set; }
         public string NextSteps { get; set; }
         public string DirectionOfTravel { get; set; }
-        public string Urn { get; set; }
-        public int StatusId { get; set; }
-        public virtual ConcernsStatus Status { get; set; }
+        public int Urn { get; set; }
+        public int StatusUrn { get; set; }
         public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsRecord.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsRecord.cs
@@ -17,9 +17,8 @@ namespace TramsDataApi.DatabaseModels
         public int RatingId { get; set; }
         public bool Primary { get; set; }
         public string Urn { get; set; }
-        public ConcernsStatus Status { get; set; }
-        public int StatusId { get; set; }
-        public virtual ConcernsCase FkConcernsCase { get; set; }
-        public virtual ConcernsType FkConcernsType { get; set; }
+        public int StatusUrn { get; set; }
+        public virtual ConcernsCase ConcernsCase { get; set; }
+        public virtual ConcernsType ConcernsType { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsRecord.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsRecord.cs
@@ -18,5 +18,7 @@ namespace TramsDataApi.DatabaseModels
         public bool Primary { get; set; }
         public string Urn { get; set; }
         public int StatusUrn { get; set; }
+        public ConcernsStatus Status { get; set; }
+        public virtual ConcernsCase FkConcernsCase { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsRecord.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsRecord.cs
@@ -17,8 +17,9 @@ namespace TramsDataApi.DatabaseModels
         public int RatingId { get; set; }
         public bool Primary { get; set; }
         public string Urn { get; set; }
-        public int StatusUrn { get; set; }
         public ConcernsStatus Status { get; set; }
+        public int StatusId { get; set; }
         public virtual ConcernsCase FkConcernsCase { get; set; }
+        public virtual ConcernsType FkConcernsType { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsStatus.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsStatus.cs
@@ -5,16 +5,11 @@ namespace TramsDataApi.DatabaseModels
 {
     public class ConcernsStatus
     {
-        public ConcernsStatus() {
-            ConcernsCases = new HashSet<ConcernsCase>();
-        }
-
         public int Id { get; set; }
         public string Name { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public int Urn { get; set; }
-        public virtual ICollection<ConcernsCase> ConcernsCases  { get; set; }
-        public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
+        
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsStatus.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsStatus.cs
@@ -15,5 +15,6 @@ namespace TramsDataApi.DatabaseModels
         public DateTime UpdatedAt { get; set; }
         public int Urn { get; set; }
         public virtual ICollection<ConcernsCase> ConcernsCases  { get; set; }
+        public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsType.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels
 {
@@ -10,5 +11,6 @@ namespace TramsDataApi.DatabaseModels
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public int Urn { get; set; }
+        public virtual ICollection<ConcernsRecord> FkConcernsRecord { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -118,6 +118,10 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
                 
+                entity.HasOne(c => c.Status)
+                    .WithMany(s => s.ConcernsCases)
+                    .HasForeignKey(c => c.StatusId)
+                    .HasConstraintName("FK__ConcernsCase_ConcernsStatus");
             });
 
             modelBuilder.Entity<ConcernsStatus>(entity =>
@@ -168,6 +172,16 @@ namespace TramsDataApi.DatabaseModels
                     .WithMany(c => c.ConcernsRecords)
                     .HasForeignKey(r => r.CaseId)
                     .HasConstraintName("FK__ConcernsCase_ConcernsRecord");
+                
+                entity.HasOne(r => r.FkConcernsType)
+                    .WithMany(c => c.FkConcernsRecord)
+                    .HasForeignKey(r => r.TypeId)
+                    .HasConstraintName("FK__ConcernsRecord_ConcernsType");
+                
+                entity.HasOne(r => r.Status)
+                    .WithMany(c => c.ConcernsRecords)
+                    .HasForeignKey(r => r.StatusId)
+                    .HasConstraintName("FK__ConcernsRecord_ConcernsStatus");
             });
 
             modelBuilder.Entity<ConcernsType>(entity =>

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -163,6 +163,11 @@ namespace TramsDataApi.DatabaseModels
 
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
+                
+                entity.HasOne(r => r.FkConcernsCase)
+                    .WithMany(c => c.ConcernsRecords)
+                    .HasForeignKey(r => r.CaseId)
+                    .HasConstraintName("FK__ConcernsCase_ConcernsRecord");
             });
 
             modelBuilder.Entity<ConcernsType>(entity =>

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -22,6 +22,7 @@ namespace TramsDataApi.DatabaseModels
         public virtual DbSet<ConcernsCase> ConcernsCase { get; set; }
         public virtual DbSet<ConcernsStatus> ConcernsStatus { get; set; }
         public virtual DbSet<ConcernsRecord> ConcernsRecord { get; set; }
+        public virtual DbSet<ConcernsType> ConcernsTypes{ get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -118,10 +119,6 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
                 
-                entity.HasOne(c => c.Status)
-                    .WithMany(s => s.ConcernsCases)
-                    .HasForeignKey(c => c.StatusId)
-                    .HasConstraintName("FK__ConcernsCase_ConcernsStatus");
             });
 
             modelBuilder.Entity<ConcernsStatus>(entity =>
@@ -168,20 +165,15 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
                 
-                entity.HasOne(r => r.FkConcernsCase)
+                entity.HasOne(r => r.ConcernsCase)
                     .WithMany(c => c.ConcernsRecords)
                     .HasForeignKey(r => r.CaseId)
                     .HasConstraintName("FK__ConcernsCase_ConcernsRecord");
                 
-                entity.HasOne(r => r.FkConcernsType)
+                entity.HasOne(r => r.ConcernsType)
                     .WithMany(c => c.FkConcernsRecord)
                     .HasForeignKey(r => r.TypeId)
                     .HasConstraintName("FK__ConcernsRecord_ConcernsType");
-                
-                entity.HasOne(r => r.Status)
-                    .WithMany(c => c.ConcernsRecords)
-                    .HasForeignKey(r => r.StatusId)
-                    .HasConstraintName("FK__ConcernsRecord_ConcernsStatus");
             });
 
             modelBuilder.Entity<ConcernsType>(entity =>

--- a/TramsDataApi/Factories/ConcernsCaseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseFactory.cs
@@ -5,7 +5,7 @@ namespace TramsDataApi.Factories
 {
     public class ConcernsCaseFactory
     {
-        public static ConcernsCase Create(ConcernCaseRequest request)
+        public static ConcernsCase Create(ConcernCaseRequest request, ConcernsStatus status)
         {
             return new ConcernsCase
             {
@@ -25,7 +25,7 @@ namespace TramsDataApi.Factories
                 DeEscalationPoint = request.DeEscalationPoint,
                 NextSteps = request.NextSteps,
                 DirectionOfTravel = request.DirectionOfTravel,
-                StatusUrn = request.StatusUrn
+                Status = status
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsCaseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseFactory.cs
@@ -5,7 +5,7 @@ namespace TramsDataApi.Factories
 {
     public class ConcernsCaseFactory
     {
-        public static ConcernsCase Create(ConcernCaseRequest request, ConcernsStatus status)
+        public static ConcernsCase Create(ConcernCaseRequest request)
         {
             return new ConcernsCase
             {
@@ -25,7 +25,7 @@ namespace TramsDataApi.Factories
                 DeEscalationPoint = request.DeEscalationPoint,
                 NextSteps = request.NextSteps,
                 DirectionOfTravel = request.DirectionOfTravel,
-                Status = status
+                StatusUrn = request.StatusUrn
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
@@ -26,7 +26,7 @@ namespace TramsDataApi.Factories
                 NextSteps = concernsCase.NextSteps,
                 DirectionOfTravel = concernsCase.DirectionOfTravel,
                 Urn = concernsCase.Urn,
-                StatusUrn = concernsCase.StatusUrn
+                StatusUrn = concernsCase.Status.Urn
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
@@ -26,7 +26,7 @@ namespace TramsDataApi.Factories
                 NextSteps = concernsCase.NextSteps,
                 DirectionOfTravel = concernsCase.DirectionOfTravel,
                 Urn = concernsCase.Urn,
-                StatusUrn = concernsCase.Status.Urn
+                StatusUrn = concernsCase.StatusUrn
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsRecordFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordFactory.cs
@@ -5,7 +5,7 @@ namespace TramsDataApi.Factories
 {
     public class ConcernsRecordFactory
     {
-        public static ConcernsRecord Create(ConcernsRecordRequest concernsRecordRequest, ConcernsStatus status)
+        public static ConcernsRecord Create(ConcernsRecordRequest concernsRecordRequest, ConcernsCase concernsCase, ConcernsType concernsType)
         {
             return new ConcernsRecord
             {
@@ -16,11 +16,11 @@ namespace TramsDataApi.Factories
                 Name = concernsRecordRequest.Name,
                 Description = concernsRecordRequest.Description,
                 Reason = concernsRecordRequest.Reason,
-                CaseId = concernsRecordRequest.CaseId,
-                TypeId = concernsRecordRequest.TypeId,
+                ConcernsCase = concernsCase,
+                ConcernsType = concernsType,
                 RatingId = concernsRecordRequest.RatingId,
                 Primary = concernsRecordRequest.Primary,
-                Status = status
+                StatusUrn = concernsRecordRequest.StatusUrn
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsRecordFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordFactory.cs
@@ -5,7 +5,7 @@ namespace TramsDataApi.Factories
 {
     public class ConcernsRecordFactory
     {
-        public static ConcernsRecord Create(ConcernsRecordRequest concernsRecordRequest)
+        public static ConcernsRecord Create(ConcernsRecordRequest concernsRecordRequest, ConcernsStatus status)
         {
             return new ConcernsRecord
             {
@@ -20,7 +20,7 @@ namespace TramsDataApi.Factories
                 TypeId = concernsRecordRequest.TypeId,
                 RatingId = concernsRecordRequest.RatingId,
                 Primary = concernsRecordRequest.Primary,
-                StatusUrn = concernsRecordRequest.StatusUrn
+                Status = status
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
@@ -21,7 +21,7 @@ namespace TramsDataApi.Factories
                 RatingId = concernsRecord.RatingId,
                 Primary = concernsRecord.Primary,
                 Urn = concernsRecord.Urn,
-                StatusUrn = concernsRecord.StatusUrn
+                StatusUrn = concernsRecord.Status.Urn
             };
         }
     }

--- a/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
@@ -16,12 +16,12 @@ namespace TramsDataApi.Factories
                 Name = concernsRecord.Name,
                 Description = concernsRecord.Description,
                 Reason = concernsRecord.Reason,
-                CaseId = concernsRecord.CaseId,
-                TypeId = concernsRecord.TypeId,
                 RatingId = concernsRecord.RatingId,
                 Primary = concernsRecord.Primary,
                 Urn = concernsRecord.Urn,
-                StatusUrn = concernsRecord.Status.Urn
+                StatusUrn = concernsRecord.StatusUrn,
+                TypeUrn = concernsRecord.ConcernsType.Urn,
+                CaseUrn = concernsRecord.ConcernsCase.Urn
             };
         }
     }

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -32,7 +32,7 @@ namespace TramsDataApi.Gateways
                 .ToList();
         }
 
-        public ConcernsCase GetConcernsCaseByUrn(string urn)
+        public ConcernsCase GetConcernsCaseByUrn(int urn)
         {
             return _tramsDbContext.ConcernsCase
                 .AsNoTracking()

--- a/TramsDataApi/Gateways/ConcernsStatusGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsStatusGateway.cs
@@ -17,5 +17,10 @@ namespace TramsDataApi.Gateways
         {
             return _tramsDbContext.ConcernsStatus.ToList();
         }
+
+        public ConcernsStatus GetStatusByUrn(int urn)
+        {
+            return _tramsDbContext.ConcernsStatus.FirstOrDefault(s => s.Urn == urn);
+        }
     }
 }

--- a/TramsDataApi/Gateways/ConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsTypeGateway.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using TramsDataApi.DatabaseModels;
+
+namespace TramsDataApi.Gateways
+{
+    public class ConcernsTypeGateway : IConcernsTypeGateway
+    {
+        private readonly TramsDbContext _tramsDbContext;
+
+        public ConcernsTypeGateway(TramsDbContext tramsDbContext)
+        {
+            _tramsDbContext = tramsDbContext;
+        }
+
+        public ConcernsType GetConcernsTypeByUrn(int urn)
+        {
+            return _tramsDbContext.ConcernsTypes.FirstOrDefault(t => t.Urn == urn);
+        }
+    }
+}

--- a/TramsDataApi/Gateways/IConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsCaseGateway.cs
@@ -7,6 +7,6 @@ namespace TramsDataApi.Gateways
     {
         ConcernsCase SaveConcernsCase(ConcernsCase concernsCase);
         IList<ConcernsCase> GetConcernsCaseByTrustUkprn(string trustUkprn, int page, int count);
-        ConcernsCase GetConcernsCaseByUrn(string urn);
+        ConcernsCase GetConcernsCaseByUrn(int urn);
     }
 }

--- a/TramsDataApi/Gateways/IConcernsStatusGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsStatusGateway.cs
@@ -6,5 +6,6 @@ namespace TramsDataApi.Gateways
     public interface IConcernsStatusGateway
     {
         IList<ConcernsStatus> GetStatuses();
+        ConcernsStatus GetStatusByUrn(int urn);
     }
 }

--- a/TramsDataApi/Gateways/IConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsTypeGateway.cs
@@ -1,0 +1,9 @@
+using TramsDataApi.DatabaseModels;
+
+namespace TramsDataApi.Gateways
+{
+    public interface IConcernsTypeGateway
+    {
+        ConcernsType GetConcernsTypeByUrn(int urn);
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/20211112143658_AddConcernsForeignKeysMigration.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211112143658_AddConcernsForeignKeysMigration.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211112143658_AddConcernsForeignKeysMigration")]
+    partial class AddConcernsForeignKeysMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20211112143658_AddConcernsForeignKeysMigration.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211112143658_AddConcernsForeignKeysMigration.cs
@@ -1,0 +1,381 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class AddConcernsForeignKeysMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ConcernsCase_ConcernsStatus_ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ConcernsCase_ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase");
+
+            migrationBuilder.DropColumn(
+                name: "ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Urn",
+                schema: "sdd",
+                table: "ConcernsCase",
+                nullable: false,
+                defaultValueSql: "NEXT VALUE FOR ConcernsGlobalSequence",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true,
+                oldDefaultValueSql: "NEXT VALUE FOR ConcernsGlobalSequence");
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 815, DateTimeKind.Local).AddTicks(8250), new DateTime(2021, 11, 12, 14, 36, 57, 818, DateTimeKind.Local).AddTicks(7820) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 818, DateTimeKind.Local).AddTicks(8630), new DateTime(2021, 11, 12, 14, 36, 57, 818, DateTimeKind.Local).AddTicks(8650) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 818, DateTimeKind.Local).AddTicks(8660), new DateTime(2021, 11, 12, 14, 36, 57, 818, DateTimeKind.Local).AddTicks(8660) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1060), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1450) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1840), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1850) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1860), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1860) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1860), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1860) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1870) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1880) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1950), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1950) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 12,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1960), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1960) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 13,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1960), new DateTime(2021, 11, 12, 14, 36, 57, 828, DateTimeKind.Local).AddTicks(1960) });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConcernsRecord_CaseId",
+                schema: "sdd",
+                table: "ConcernsRecord",
+                column: "CaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConcernsRecord_TypeId",
+                schema: "sdd",
+                table: "ConcernsRecord",
+                column: "TypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__ConcernsCase_ConcernsRecord",
+                schema: "sdd",
+                table: "ConcernsRecord",
+                column: "CaseId",
+                principalSchema: "sdd",
+                principalTable: "ConcernsCase",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK__ConcernsRecord_ConcernsType",
+                schema: "sdd",
+                table: "ConcernsRecord",
+                column: "TypeId",
+                principalSchema: "sdd",
+                principalTable: "ConcernsType",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK__ConcernsCase_ConcernsRecord",
+                schema: "sdd",
+                table: "ConcernsRecord");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK__ConcernsRecord_ConcernsType",
+                schema: "sdd",
+                table: "ConcernsRecord");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ConcernsRecord_CaseId",
+                schema: "sdd",
+                table: "ConcernsRecord");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ConcernsRecord_TypeId",
+                schema: "sdd",
+                table: "ConcernsRecord");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Urn",
+                schema: "sdd",
+                table: "ConcernsCase",
+                type: "nvarchar(max)",
+                nullable: true,
+                defaultValueSql: "NEXT VALUE FOR ConcernsGlobalSequence",
+                oldClrType: typeof(int),
+                oldDefaultValueSql: "NEXT VALUE FOR ConcernsGlobalSequence");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 225, DateTimeKind.Local).AddTicks(2040), new DateTime(2021, 11, 9, 13, 51, 35, 228, DateTimeKind.Local).AddTicks(260) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 228, DateTimeKind.Local).AddTicks(720), new DateTime(2021, 11, 9, 13, 51, 35, 228, DateTimeKind.Local).AddTicks(740) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 228, DateTimeKind.Local).AddTicks(750), new DateTime(2021, 11, 9, 13, 51, 35, 228, DateTimeKind.Local).AddTicks(750) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(2950), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(3500) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(3970), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(3990) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4000), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4000) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4100), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4110) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4110), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4110) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4110), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4110) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4120), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4120) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4120), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4120) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4120), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 12,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4130), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4140) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 13,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4140), new DateTime(2021, 11, 9, 13, 51, 35, 232, DateTimeKind.Local).AddTicks(4140) });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConcernsCase_ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase",
+                column: "ConcernsStatusId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ConcernsCase_ConcernsStatus_ConcernsStatusId",
+                schema: "sdd",
+                table: "ConcernsCase",
+                column: "ConcernsStatusId",
+                principalSchema: "sdd",
+                principalTable: "ConcernsStatus",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/ConcernsRecordRequest.cs
+++ b/TramsDataApi/RequestModels/ConcernsRecordRequest.cs
@@ -11,8 +11,8 @@ namespace TramsDataApi.RequestModels
         public string Name { get; set; }
         public string Description { get; set; }
         public string Reason { get; set; }
-        public int CaseId { get; set; }
-        public int TypeId { get; set; }
+        public int CaseUrn { get; set; }
+        public int TypeUrn { get; set; }
         public int RatingId { get; set; }
         public bool Primary { get; set; }
         public int StatusUrn { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsCaseResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsCaseResponse.cs
@@ -20,7 +20,7 @@ namespace TramsDataApi.ResponseModels
         public string DeEscalationPoint { get; set; }
         public string NextSteps { get; set; }
         public string DirectionOfTravel { get; set; }
-        public string Urn { get; set; }
+        public int Urn { get; set; }
         public int StatusUrn { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/ConcernsRecordResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsRecordResponse.cs
@@ -11,11 +11,11 @@ namespace TramsDataApi.ResponseModels
         public string Name { get; set; }
         public string Description { get; set; }
         public string Reason { get; set; }
-        public int CaseId { get; set; }
-        public int TypeId { get; set; }
         public int RatingId { get; set; }
         public bool Primary { get; set; }
         public string Urn { get; set; }
         public int StatusUrn { get; set; }
+        public int TypeUrn { get; set; }
+        public int CaseUrn { get; set; }
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -62,6 +62,7 @@ namespace TramsDataApi
             services.AddScoped<IConcernsStatusGateway, ConcernsStatusGateway>();
             services.AddScoped<IConcernsRecordGateway, ConcernsRecordGateway>();
             services.AddScoped<ICreateConcernsRecord, CreateConcernsRecord>();
+            services.AddScoped<IConcernsTypeGateway, ConcernsTypeGateway>();
 
 
 

--- a/TramsDataApi/UseCases/CreateConcernsCase.cs
+++ b/TramsDataApi/UseCases/CreateConcernsCase.cs
@@ -8,15 +8,18 @@ namespace TramsDataApi.UseCases
     public class CreateConcernsCase : ICreateConcernsCase
     {
         private readonly IConcernsCaseGateway _concernsCaseGateway;
+        private readonly IConcernsStatusGateway _concernsStatusGateway;
 
-        public CreateConcernsCase(IConcernsCaseGateway concernsCaseGateway)
+        public CreateConcernsCase(IConcernsCaseGateway concernsCaseGateway, IConcernsStatusGateway concernsStatusGateway)
         {
             _concernsCaseGateway = concernsCaseGateway;
+            _concernsStatusGateway = concernsStatusGateway;
         }
 
         public ConcernsCaseResponse Execute(ConcernCaseRequest request)
         {
-            var concernsCaseToCreate = ConcernsCaseFactory.Create(request);
+            var concernsStatus = _concernsStatusGateway.GetStatusByUrn(request.StatusUrn);
+            var concernsCaseToCreate = ConcernsCaseFactory.Create(request, concernsStatus);
             var createdConcernsCase = _concernsCaseGateway.SaveConcernsCase(concernsCaseToCreate);
             return ConcernsCaseResponseFactory.Create(createdConcernsCase);
         }

--- a/TramsDataApi/UseCases/CreateConcernsCase.cs
+++ b/TramsDataApi/UseCases/CreateConcernsCase.cs
@@ -8,18 +8,15 @@ namespace TramsDataApi.UseCases
     public class CreateConcernsCase : ICreateConcernsCase
     {
         private readonly IConcernsCaseGateway _concernsCaseGateway;
-        private readonly IConcernsStatusGateway _concernsStatusGateway;
 
-        public CreateConcernsCase(IConcernsCaseGateway concernsCaseGateway, IConcernsStatusGateway concernsStatusGateway)
+        public CreateConcernsCase(IConcernsCaseGateway concernsCaseGateway)
         {
             _concernsCaseGateway = concernsCaseGateway;
-            _concernsStatusGateway = concernsStatusGateway;
         }
 
         public ConcernsCaseResponse Execute(ConcernCaseRequest request)
         {
-            var concernsStatus = _concernsStatusGateway.GetStatusByUrn(request.StatusUrn);
-            var concernsCaseToCreate = ConcernsCaseFactory.Create(request, concernsStatus);
+            var concernsCaseToCreate = ConcernsCaseFactory.Create(request);
             var createdConcernsCase = _concernsCaseGateway.SaveConcernsCase(concernsCaseToCreate);
             return ConcernsCaseResponseFactory.Create(createdConcernsCase);
         }

--- a/TramsDataApi/UseCases/CreateConcernsRecord.cs
+++ b/TramsDataApi/UseCases/CreateConcernsRecord.cs
@@ -8,17 +8,23 @@ namespace TramsDataApi.UseCases
     public class CreateConcernsRecord : ICreateConcernsRecord
     {
         private readonly IConcernsRecordGateway _concernsRecordGateway;
-        private readonly IConcernsStatusGateway _concernsStatusGateway;
+        private readonly IConcernsCaseGateway _concernsCaseGateway;
+        private readonly IConcernsTypeGateway _concernsTypeGateway;
 
-        public CreateConcernsRecord(IConcernsRecordGateway concernsRecordGateway, IConcernsStatusGateway concernsStatusGateway)
+        public CreateConcernsRecord(
+            IConcernsRecordGateway concernsRecordGateway, 
+            IConcernsCaseGateway concernsCaseGateway,
+            IConcernsTypeGateway concernsTypeGateway)
         {
             _concernsRecordGateway = concernsRecordGateway;
-            _concernsStatusGateway = concernsStatusGateway;
+            _concernsCaseGateway = concernsCaseGateway;
+            _concernsTypeGateway = concernsTypeGateway;
         }
         public ConcernsRecordResponse Execute(ConcernsRecordRequest request)
         {
-            var concernsStatus = _concernsStatusGateway.GetStatusByUrn(request.StatusUrn);
-            var concernsRecordToCreate = ConcernsRecordFactory.Create(request, concernsStatus);
+            var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(request.CaseUrn);
+            var concernsType = _concernsTypeGateway.GetConcernsTypeByUrn(request.TypeUrn);
+            var concernsRecordToCreate = ConcernsRecordFactory.Create(request, concernsCase, concernsType);
             var savedConcernsRecord = _concernsRecordGateway.SaveConcernsCase(concernsRecordToCreate);
             return ConcernsRecordResponseFactory.Create(savedConcernsRecord);
         }

--- a/TramsDataApi/UseCases/CreateConcernsRecord.cs
+++ b/TramsDataApi/UseCases/CreateConcernsRecord.cs
@@ -8,14 +8,17 @@ namespace TramsDataApi.UseCases
     public class CreateConcernsRecord : ICreateConcernsRecord
     {
         private readonly IConcernsRecordGateway _concernsRecordGateway;
+        private readonly IConcernsStatusGateway _concernsStatusGateway;
 
-        public CreateConcernsRecord(IConcernsRecordGateway concernsRecordGateway)
+        public CreateConcernsRecord(IConcernsRecordGateway concernsRecordGateway, IConcernsStatusGateway concernsStatusGateway)
         {
             _concernsRecordGateway = concernsRecordGateway;
+            _concernsStatusGateway = concernsStatusGateway;
         }
         public ConcernsRecordResponse Execute(ConcernsRecordRequest request)
         {
-            var concernsRecordToCreate = ConcernsRecordFactory.Create(request);
+            var concernsStatus = _concernsStatusGateway.GetStatusByUrn(request.StatusUrn);
+            var concernsRecordToCreate = ConcernsRecordFactory.Create(request, concernsStatus);
             var savedConcernsRecord = _concernsRecordGateway.SaveConcernsCase(concernsRecordToCreate);
             return ConcernsRecordResponseFactory.Create(savedConcernsRecord);
         }

--- a/TramsDataApi/UseCases/GetConcernsCaseByUrn.cs
+++ b/TramsDataApi/UseCases/GetConcernsCaseByUrn.cs
@@ -13,7 +13,7 @@ namespace TramsDataApi.UseCases
             _concernsCaseGateway = concernsCaseGateway;
         }
 
-        public ConcernsCaseResponse Execute(string urn)
+        public ConcernsCaseResponse Execute(int urn)
         {
            var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(urn);
            return concernsCase == null ? null : ConcernsCaseResponseFactory.Create(concernsCase);

--- a/TramsDataApi/UseCases/IGetConcernsCaseByUrn.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseByUrn.cs
@@ -4,6 +4,6 @@ namespace TramsDataApi.UseCases
 {
     public interface IGetConcernsCaseByUrn
     {
-        public ConcernsCaseResponse Execute(string urn);
+        public ConcernsCaseResponse Execute(int urn);
     }
 }


### PR DESCRIPTION
In this PR:
- Add fk relationship between Concerns Records and Concerns Cases
- Add fk relationship between Concerns Records and Concerns Types
- Get the Concerns Case and Concerns Type when creating a new Concerns Record
- Change Concerns URN to be an int
- Remove Concerns Status id from Concerns Case as the we will use the Status Urn to get the Concerns Status for both Concerns Cases and Concern Records.