### PR TITLE
Update v2 controllers to use the single response

### DIFF
--- a/TramsDataApi.Test/Controllers/TrustsControllerV2Tests.cs
+++ b/TramsDataApi.Test/Controllers/TrustsControllerV2Tests.cs
@@ -69,7 +69,7 @@ namespace TramsDataApi.Test.Controllers
             var controller = new TrustsController(getTrustByUkPrn.Object, new Mock<ISearchTrusts>().Object, _mockLogger.Object);
             var result = controller.GetTrustByUkPrn(ukprn);
 
-            var expected = new OkObjectResult(new ApiResponseV2<TrustResponse>(trustResponse));
+            var expected = new OkObjectResult(new ApiSingleResponseV2<TrustResponse>(trustResponse));
             result.Result.Should().BeEquivalentTo(expected);
         }
         

--- a/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
@@ -32,7 +32,7 @@ namespace TramsDataApi.Controllers.V2
         
         [HttpPost]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiResponseV2<ConcernsCaseResponse>> Create(ConcernCaseRequest request)
+        public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(ConcernCaseRequest request)
         {
             var createdConcernsCase = _createConcernsCase.Execute(request);
             var response = new ApiSingleResponseV2<ConcernsCaseResponse>(createdConcernsCase);
@@ -43,7 +43,7 @@ namespace TramsDataApi.Controllers.V2
         [HttpGet]
         [Route("urn/{urn}")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiResponseV2<ConcernsCaseResponse>> GetByUrn(int urn)
+        public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> GetByUrn(int urn)
         {
             _logger.LogInformation($"Attempting to get Concerns Case by Urn {urn}");
             var concernsCase = _getConcernsCaseByUrn.Execute(urn);

--- a/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
@@ -26,7 +26,7 @@ namespace TramsDataApi.Controllers.V2
         
         [HttpPost]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiResponseV2<ConcernsRecordResponse>> Create(ConcernsRecordRequest request)
+        public ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>> Create(ConcernsRecordRequest request)
         {
             var createdConcernsRecord = _createConcernsRecord.Execute(request);
             var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);

--- a/TramsDataApi/Controllers/V2/TrustsController.cs
+++ b/TramsDataApi/Controllers/V2/TrustsController.cs
@@ -51,7 +51,7 @@ namespace TramsDataApi.Controllers.V2
         [HttpGet]
         [Route("trust/{ukprn}")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiResponseV2<TrustResponse>> GetTrustByUkPrn(string ukPrn)
+        public ActionResult<ApiSingleResponseV2<TrustResponse>> GetTrustByUkPrn(string ukPrn)
         {
             _logger.LogInformation("Attempting to get trust by UKPRN {prn}", ukPrn);
             var trust = _getTrustByUkPrn.Execute(ukPrn);
@@ -65,7 +65,7 @@ namespace TramsDataApi.Controllers.V2
             _logger.LogInformation("Returning trust found by UKPRN {prn}", ukPrn);
             _logger.LogDebug(JsonSerializer.Serialize(trust));
 
-            var response = new ApiResponseV2<TrustResponse>(trust);
+            var response = new ApiSingleResponseV2<TrustResponse>(trust);
             return new OkObjectResult(response);
         }
     }


### PR DESCRIPTION
Update v2 controllers to use the single response object for single response endpoints