### PR TITLE
Add PATCH update route for Concerns Cases

### DIFF
--- a/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsCaseControllerTests.cs
@@ -35,6 +35,7 @@ namespace TramsDataApi.Test.Controllers
                 mockLogger.Object,
                 createConcernsCase.Object, 
                 null, 
+                null, 
                 null
             );
             
@@ -60,6 +61,7 @@ namespace TramsDataApi.Test.Controllers
                 mockLogger.Object,
                 null, 
                 getConcernsCaseByUrn.Object, 
+                null,
                 null
             );
             
@@ -83,6 +85,7 @@ namespace TramsDataApi.Test.Controllers
                 mockLogger.Object,
                 null, 
                 getConcernsCaseByUrn.Object, 
+                null,
                 null
             );
             
@@ -109,7 +112,8 @@ namespace TramsDataApi.Test.Controllers
                 mockLogger.Object,
                 null, 
                 null, 
-                getConcernsCaseByTrustUkprn.Object
+                getConcernsCaseByTrustUkprn.Object,
+                null
             );
             
             var result = controller.GetByTrustUkprn(trustUkprn, 1, 10);
@@ -122,6 +126,58 @@ namespace TramsDataApi.Test.Controllers
             var expected = new ApiResponseV2<ConcernsCaseResponse>(new List<ConcernsCaseResponse>{concernsCaseResponse}, expectedPagingResponse);
             
             result.Result.Should().BeEquivalentTo(new OkObjectResult(expected));
+        }
+        
+        [Fact]
+        public void UpdateConcernsCase_Returns200AndTheUpdatedConcernsCase_WhenSuccessfullyGetsAConcernsCase()
+        {
+            var updateConcernsCase = new Mock<IUpdateConcernsCase>();
+            var urn = 456;
+            var updateRequest = Builder<ConcernCaseRequest>.CreateNew().Build();
+            
+            var concernsCaseResponse = Builder<ConcernsCaseResponse>
+                .CreateNew().Build();
+
+            updateConcernsCase.Setup(a => a.Execute(urn, updateRequest))
+                .Returns(concernsCaseResponse);
+
+            var controller = new ConcernsCaseController(
+                mockLogger.Object,
+                null, 
+                null, 
+                null,
+                updateConcernsCase.Object
+            );
+            
+            var result = controller.Update(urn, updateRequest);
+           
+            var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCaseResponse);
+            
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expected));
+        }
+        
+        [Fact]
+        public void UpdateConcernsCase_Returns2404NotFound_WhenNoConcernsCaseIsFound()
+        {
+            var updateConcernsCase = new Mock<IUpdateConcernsCase>();
+            var urn = 7;
+            var updateRequest = Builder<ConcernCaseRequest>.CreateNew().Build();
+            
+
+            updateConcernsCase.Setup(a => a.Execute(urn, updateRequest))
+                .Returns(() => null);
+
+            var controller = new ConcernsCaseController(
+                mockLogger.Object,
+                null, 
+                null, 
+                null,
+                updateConcernsCase.Object
+            );
+            
+            var result = controller.Update(urn, updateRequest);
+
+            result.Result.Should().BeEquivalentTo(new NotFoundResult());
         }
     }
 }

--- a/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
@@ -243,6 +243,58 @@ namespace TramsDataApi.Test.Integration
             content.Data.Count().Should().Be(3);
             
         }
+        
+        [Fact]
+        public async Task UpdateConcernsCase_ShouldReturnTheUpdatedConcernsCase()
+        {
+            var concernsCase = new ConcernsCase
+            {
+                CreatedAt = _randomGenerator.DateTime(),
+                UpdatedAt = _randomGenerator.DateTime(),
+                ReviewAt = _randomGenerator.DateTime(),
+                ClosedAt = _randomGenerator.DateTime(),
+                CreatedBy = _randomGenerator.NextString(3, 10),
+                Description = _randomGenerator.NextString(3, 10),
+                CrmEnquiry = _randomGenerator.NextString(3, 10),
+                TrustUkprn = _randomGenerator.NextString(3, 10),
+                ReasonAtReview = _randomGenerator.NextString(3, 10),
+                DeEscalation = _randomGenerator.DateTime(),
+                Issue = _randomGenerator.NextString(3, 10),
+                CurrentStatus = _randomGenerator.NextString(3, 10),
+                CaseAim = _randomGenerator.NextString(3, 10),
+                DeEscalationPoint = _randomGenerator.NextString(3, 10),
+                NextSteps = _randomGenerator.NextString(3, 10),
+                DirectionOfTravel = _randomGenerator.NextString(3, 10),
+                StatusUrn = 2,
+            };
+            
+            var currentConcernsCase =  _dbContext.ConcernsCase.Add(concernsCase);
+            _dbContext.SaveChanges();
+            var urn = currentConcernsCase.Entity.Urn;
+
+            var updateRequest = Builder<ConcernCaseRequest>.CreateNew().Build();
+
+            var expectedConcernsCase = ConcernsCaseFactory.Create(updateRequest);
+            expectedConcernsCase.Urn = urn;
+            var expectedContent = ConcernsCaseResponseFactory.Create(expectedConcernsCase);
+
+            var httpRequestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Patch,
+                RequestUri = new Uri($"https://trams-api.com/v2/concerns-cases/{urn}"),
+                Headers =
+                {
+                    {"ApiKey", "testing-api-key"}
+                },
+                Content =  JsonContent.Create(updateRequest)
+            };
+            var response = await _client.SendAsync(httpRequestMessage);
+            var content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
+            
+            response.StatusCode.Should().Be(200);
+            content.Data.Should().BeEquivalentTo(expectedContent);
+
+        }
 
         [Fact]
         public async Task CanCreateNewConcernRecord()

--- a/TramsDataApi.Test/UseCases/UpdateConcernsCaseTests.cs
+++ b/TramsDataApi.Test/UseCases/UpdateConcernsCaseTests.cs
@@ -1,0 +1,36 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class UpdateConcernsCaseTests
+    {
+        [Fact]
+        public void ShouldSaveAConcernsCase_WhenGivenAModelToUpdate()
+        {
+            var urn = 1234;
+            var gateway = new Mock<IConcernsCaseGateway>();
+            var concernsCase = Builder<ConcernsCase>.CreateNew().With(c => c.Urn = urn).Build();
+            var updateRequest = Builder<ConcernCaseRequest>.CreateNew().Build();
+
+            var concernsToUpdate = ConcernsCaseFactory.Update(concernsCase, updateRequest);
+            
+            gateway.Setup(g => g.GetConcernsCaseByUrn(urn)).Returns(concernsCase);
+            gateway.Setup(g => g.Update(It.IsAny<ConcernsCase>())).Returns(concernsToUpdate);
+            
+            var expected = ConcernsCaseResponseFactory.Create(concernsToUpdate);
+            
+            var useCase = new UpdateConcernsCase(gateway.Object);
+            var result = useCase.Execute(urn, updateRequest);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
@@ -17,17 +17,20 @@ namespace TramsDataApi.Controllers.V2
         private readonly ICreateConcernsCase _createConcernsCase;
         private readonly IGetConcernsCaseByUrn _getConcernsCaseByUrn;
         private readonly IGetConcernsCaseByTrustUkprn _getConcernsCaseByTrustUkprn;
+        private readonly IUpdateConcernsCase _updateConcernsCase;
 
         public ConcernsCaseController(
             ILogger<ConcernsCaseController> logger, 
             ICreateConcernsCase createConcernsCase,
             IGetConcernsCaseByUrn getConcernsCaseByUrn,
-            IGetConcernsCaseByTrustUkprn getConcernsCaseByTrustUkprn)
+            IGetConcernsCaseByTrustUkprn getConcernsCaseByTrustUkprn,
+            IUpdateConcernsCase updateConcernsCase)
         {
             _logger = logger;
             _createConcernsCase = createConcernsCase;
             _getConcernsCaseByUrn = getConcernsCaseByUrn;
             _getConcernsCaseByTrustUkprn = getConcernsCaseByTrustUkprn;
+            _updateConcernsCase = updateConcernsCase;
         }
         
         [HttpPost]
@@ -74,6 +77,25 @@ namespace TramsDataApi.Controllers.V2
             var pagingResponse = PagingResponseFactory.Create(page, count, concernsCases.Count, Request);
             var response = new ApiResponseV2<ConcernsCaseResponse>(concernsCases, pagingResponse);
             
+            return Ok(response);
+        }
+        
+        [HttpPatch("{urn}")]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Update(int urn, ConcernCaseRequest request)
+        {
+            _logger.LogInformation($"Attempting to update Concerns Case {urn}");
+            var updatedAcademyConcernsCase = _updateConcernsCase.Execute(urn, request);
+            if (updatedAcademyConcernsCase == null)
+            {
+                _logger.LogInformation($"Updating Concerns Case failed: No Concerns Case matching Urn {urn} was found");
+                return NotFound();
+            }
+
+            _logger.LogInformation($"Successfully Updated Concerns Case {urn}");
+            _logger.LogDebug(JsonSerializer.Serialize(updatedAcademyConcernsCase));
+			
+            var response = new ApiSingleResponseV2<ConcernsCaseResponse>(updatedAcademyConcernsCase);
             return Ok(response);
         }
     }

--- a/TramsDataApi/Factories/ConcernsCaseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseFactory.cs
@@ -28,5 +28,35 @@ namespace TramsDataApi.Factories
                 StatusUrn = request.StatusUrn
             };
         }
+        
+        public static ConcernsCase Update(ConcernsCase original, ConcernCaseRequest updateRequest)
+        {
+            if (updateRequest == null)
+            {
+                return original;
+            }
+            
+            var toMerge = Create(updateRequest);
+
+            original.CreatedAt = toMerge.CreatedAt;
+            original.UpdatedAt = toMerge.UpdatedAt;
+            original.ReviewAt = toMerge.ReviewAt;
+            original.ClosedAt = toMerge.ClosedAt;
+            original.CreatedBy = toMerge.CreatedBy ?? original.CreatedBy;
+            original.Description = toMerge.Description ?? original.Description;
+            original.CrmEnquiry = toMerge.CrmEnquiry ?? original.CrmEnquiry;
+            original.TrustUkprn = toMerge.TrustUkprn ?? original.TrustUkprn;
+            original.ReasonAtReview = toMerge.ReasonAtReview ?? original.ReasonAtReview;
+            original.DeEscalation = toMerge.DeEscalation ?? original.DeEscalation;
+            original.Issue = toMerge.Issue ?? original.Issue;
+            original.CurrentStatus = toMerge.CurrentStatus ?? original.CurrentStatus;
+            original.CaseAim = toMerge.CaseAim ?? original.CaseAim;
+            original.DeEscalationPoint = toMerge.DeEscalationPoint ?? original.DeEscalationPoint;
+            original.NextSteps = toMerge.NextSteps ?? original.NextSteps;
+            original.DirectionOfTravel = toMerge.DirectionOfTravel ?? original.DirectionOfTravel;
+            original.StatusUrn = toMerge.StatusUrn;
+
+            return original;
+        }
     }
 }

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -38,5 +38,12 @@ namespace TramsDataApi.Gateways
                 .AsNoTracking()
                 .FirstOrDefault(c => c.Urn == urn);
         }
+
+        public ConcernsCase Update(ConcernsCase concernsCase)
+        {
+            var entity = _tramsDbContext.ConcernsCase.Update(concernsCase);
+            _tramsDbContext.SaveChanges();
+            return entity.Entity;
+        }
     }
 }

--- a/TramsDataApi/Gateways/IConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsCaseGateway.cs
@@ -8,5 +8,6 @@ namespace TramsDataApi.Gateways
         ConcernsCase SaveConcernsCase(ConcernsCase concernsCase);
         IList<ConcernsCase> GetConcernsCaseByTrustUkprn(string trustUkprn, int page, int count);
         ConcernsCase GetConcernsCaseByUrn(int urn);
+        ConcernsCase Update(ConcernsCase concernsCase);
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -65,6 +65,7 @@ namespace TramsDataApi
             services.AddScoped<IConcernsTypeGateway, ConcernsTypeGateway>();
             services.AddScoped<IConcernsRatingGateway, ConcernsRatingsGateway>();
             services.AddScoped<IIndexConcernsRatings, IndexConcernsRatings>();
+            services.AddScoped<IUpdateConcernsCase, UpdateConcernsCase>();
 
 
 

--- a/TramsDataApi/UseCases/IUpdateConcernsCase.cs
+++ b/TramsDataApi/UseCases/IUpdateConcernsCase.cs
@@ -1,0 +1,10 @@
+using TramsDataApi.RequestModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IUpdateConcernsCase
+    {
+       ConcernsCaseResponse Execute(int urn, ConcernCaseRequest request);
+    }
+}

--- a/TramsDataApi/UseCases/UpdateConcernsCase.cs
+++ b/TramsDataApi/UseCases/UpdateConcernsCase.cs
@@ -1,0 +1,25 @@
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public class UpdateConcernsCase : IUpdateConcernsCase
+    {
+        private readonly IConcernsCaseGateway _concernsCaseGateway;
+
+        public UpdateConcernsCase(IConcernsCaseGateway concernsCaseGateway)
+        {
+            _concernsCaseGateway = concernsCaseGateway;
+        }
+        
+        public ConcernsCaseResponse Execute(int urn, ConcernCaseRequest request)
+        {
+            var currentConcernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(urn);
+            var concernsCaseToUpdate = ConcernsCaseFactory.Update(currentConcernsCase, request);
+            var updatedConcernsCase = _concernsCaseGateway.Update(concernsCaseToUpdate);
+            return ConcernsCaseResponseFactory.Create(updatedConcernsCase);
+        }
+    }
+}


### PR DESCRIPTION
In this PR:
- Add the `UpdateConcernsCase` usecase
- Add the PATCH `concerns-cases/{urn}` endpoint to update concerns cases.
- Add the Update method in `ConcernsCaseFactory` to update an existing Concerns Case object using data from request.
- Add Update function on the Concerns Case Gateway to update and save the updated data.