### PR TITLE
Add get concerns types route

### DIFF
--- a/TramsDataApi.Test/Factories/ConcernsTypeResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/ConcernsTypeResponseFactoryTests.cs
@@ -1,0 +1,39 @@
+using System;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.ResponseModels;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class ConcernsTypeResponseFactoryTests
+    {
+        [Fact]
+        public void ReturnsConcernsTypeResponse_WhenGivenAnConcernsType()
+        {
+            
+            var concernType = new ConcernsType
+            {
+                Id = 2,
+                Name = "test concerns type",
+                Description = "a test concerns type",
+                CreatedAt = new DateTime(2021, 04,07),
+                UpdatedAt = new DateTime(2021, 04,07),
+                Urn = 123,
+            };
+
+            var expected = new ConcernsTypeResponse
+            {
+                Name = concernType.Name,
+                Description = concernType.Description,
+                CreatedAt = concernType.CreatedAt,
+                UpdatedAt = concernType.UpdatedAt,
+                Urn = concernType.Urn
+            };
+
+            var result = ConcernsTypeResponseFactory.Create(concernType);
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/ConcernsIntegrationTests.cs
@@ -245,6 +245,26 @@ namespace TramsDataApi.Test.Integration
         }
         
         [Fact]
+        public async Task IndexConcernsTypes_ShouldReturnAllConcernsTypes()
+        {
+            var httpRequestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"https://trams-api.com/v2/concerns-types/"),
+                Headers =
+                {
+                    {"ApiKey", "testing-api-key"}
+                }
+            };
+            var response = await _client.SendAsync(httpRequestMessage);
+            var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsTypeResponse>>();
+            
+            response.StatusCode.Should().Be(200);
+            content.Data.Count().Should().Be(13);
+            
+        }
+        
+        [Fact]
         public async Task UpdateConcernsCase_ShouldReturnTheUpdatedConcernsCase()
         {
             var concernsCase = new ConcernsCase

--- a/TramsDataApi.Test/UseCases/IndexConcernsTypesTests.cs
+++ b/TramsDataApi.Test/UseCases/IndexConcernsTypesTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class IndexConcernsTypesTests
+    {
+        [Fact]
+        public void Execute_WhenConcernsTypesAreNotFound_ReturnsEmptyList()
+        {
+            var mockGateway = new Mock<IConcernsTypeGateway>();
+            var useCase = new IndexConcernsTypes(mockGateway.Object);
+
+            mockGateway
+                .Setup(g => g.GetTypes())
+                .Returns(new List<ConcernsType>());
+            
+            var result = useCase.Execute();
+
+            result.Should().BeOfType<List<ConcernsTypeResponse>>();
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Execute_WhenConcernsTypesAreFound_ReturnsListOfConcernsTypeResponses()
+        {
+            
+            var mockGateway = new Mock<IConcernsTypeGateway>();
+            var useCase = new IndexConcernsTypes(mockGateway.Object);
+
+            var concernsTypes = Builder<ConcernsType>.CreateListOfSize(20).Build();
+
+            mockGateway
+                .Setup(g => g.GetTypes())
+                .Returns(concernsTypes);
+            
+            var result = useCase.Execute();
+            
+            result.Should().BeOfType<List<ConcernsTypeResponse>>();
+            result.Count.Should().Be(concernsTypes.Count);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V2/ConcernsStatusController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsStatusController.cs
@@ -34,6 +34,5 @@ namespace TramsDataApi.Controllers.V2
             var response = new ApiResponseV2<ConcernsStatusResponse>(statuses, pagingResponse);
             return Ok(response);
         }
-
     }
 }

--- a/TramsDataApi/Controllers/V2/ConcernsTypeController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTypeController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.UseCases;
+
+namespace TramsDataApi.Controllers.V2
+{
+    [ApiVersion("2.0")]
+    [ApiController]
+    [Route("v{version:apiVersion}/concerns-types")]
+    public class ConcernsTypeController: ControllerBase
+    {
+        
+        private ILogger<ConcernsTypeController> _logger;
+        private IIndexConcernsTypes _indexConcernsTypes;
+
+        public ConcernsTypeController(
+            ILogger<ConcernsTypeController> logger, 
+            IIndexConcernsTypes indexConcernsTypes)
+        {
+            _logger = logger;
+            _indexConcernsTypes = indexConcernsTypes;
+        }
+        
+        [HttpGet]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiResponseV2<ConcernsTypeResponse>> Index()
+        {
+            _logger.LogInformation($"Attempting to get Concerns Types");
+            var types = _indexConcernsTypes.Execute();
+            
+            _logger.LogInformation($"Returning Concerns types");
+            var pagingResponse = PagingResponseFactory.Create(1, 50, types.Count, Request);
+            var response = new ApiResponseV2<ConcernsTypeResponse>(types, pagingResponse);
+            return Ok(response);
+        }
+    }
+}

--- a/TramsDataApi/Factories/ConcernsTypeResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsTypeResponseFactory.cs
@@ -1,0 +1,20 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.Factories
+{
+    public class ConcernsTypeResponseFactory
+    {
+        public static ConcernsTypeResponse Create(ConcernsType concernsType)
+        {
+            return new ConcernsTypeResponse
+            {
+                Name = concernsType.Name,
+                Description = concernsType.Description,
+                CreatedAt = concernsType.CreatedAt,
+                UpdatedAt = concernsType.UpdatedAt,
+                Urn = concernsType.Urn
+            };
+        }
+    }
+}

--- a/TramsDataApi/Gateways/ConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsTypeGateway.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels;
 
@@ -15,6 +16,11 @@ namespace TramsDataApi.Gateways
         public ConcernsType GetConcernsTypeByUrn(int urn)
         {
             return _tramsDbContext.ConcernsTypes.FirstOrDefault(t => t.Urn == urn);
+        }
+
+        public IList<ConcernsType> GetTypes()
+        {
+            return _tramsDbContext.ConcernsTypes.ToList();
         }
     }
 }

--- a/TramsDataApi/Gateways/IConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsTypeGateway.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
@@ -5,5 +6,6 @@ namespace TramsDataApi.Gateways
     public interface IConcernsTypeGateway
     {
         ConcernsType GetConcernsTypeByUrn(int urn);
+        IList<ConcernsType> GetTypes();
     }
 }

--- a/TramsDataApi/ResponseModels/ConcernsTypeResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsTypeResponse.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TramsDataApi.ResponseModels
+{
+    public class ConcernsTypeResponse
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public int Urn { get; set; }
+    }
+}

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -66,6 +66,7 @@ namespace TramsDataApi
             services.AddScoped<IConcernsRatingGateway, ConcernsRatingsGateway>();
             services.AddScoped<IIndexConcernsRatings, IndexConcernsRatings>();
             services.AddScoped<IUpdateConcernsCase, UpdateConcernsCase>();
+            services.AddScoped<IIndexConcernsTypes, IndexConcernsTypes>();
 
 
 

--- a/TramsDataApi/UseCases/IIndexConcernsTypes.cs
+++ b/TramsDataApi/UseCases/IIndexConcernsTypes.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IIndexConcernsTypes
+    {
+        public IList<ConcernsTypeResponse> Execute();
+    }
+}

--- a/TramsDataApi/UseCases/IndexConcernsTypes.cs
+++ b/TramsDataApi/UseCases/IndexConcernsTypes.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public class IndexConcernsTypes : IIndexConcernsTypes
+    {
+        private IConcernsTypeGateway _concernsTypeGateway;
+
+        public IndexConcernsTypes(IConcernsTypeGateway concernsTypeGateway)
+        {
+            _concernsTypeGateway = concernsTypeGateway;
+        }
+        public IList<ConcernsTypeResponse> Execute()
+        {
+            var types = _concernsTypeGateway.GetTypes();
+            return types.Select(ConcernsTypeResponseFactory.Create).ToList();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the GET route `concerns-types` to get all concern type objects.