### PR TITLE
Update concerns db object createdat and updatedat fields

### DIFF
--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -137,21 +137,21 @@ namespace TramsDataApi.DatabaseModels
                     {
                         Id = 1,
                         Name = "Live",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     }, 
                     new ConcernsStatus
                     {
                         Id = 2,
                         Name = "Monitoring",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsStatus
                     {   Id = 3,
                         Name = "Close",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     }
                     );
             });
@@ -198,104 +198,104 @@ namespace TramsDataApi.DatabaseModels
                         Id = 1,
                         Name = "Compliance",
                         Description = "Financial reporting",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 2,
                         Name = "Compliance",
                         Description = "Financial returns",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 3,
                         Name = "Financial",
                         Description = "Deficit",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 4,
                         Name = "Financial",
                         Description = "Projected deficit / Low future surplus",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 5,
                         Name = "Financial",
                         Description = "Cash flow shortfall",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 6,
                         Name = "Financial",
                         Description = "Clawback",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 7,
                         Name = "Force majeure",
                         Description = null,
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 8,
                         Name = "Governance",
                         Description = "Governance",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 9,
                         Name = "Governance",
                         Description = "Closure",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 10,
                         Name = "Governance",
                         Description = "Executive Pay",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 11,
                         Name = "Governance",
                         Description = "Safeguarding",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 12,
                         Name = "Irregularity",
                         Description = "Allegations and self reported concerns",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsType
                     {
                         Id = 13,
                         Name = "Irregularity",
                         Description = "Related party transactions - in year",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     }
                 );
             });
@@ -315,36 +315,36 @@ namespace TramsDataApi.DatabaseModels
                     {
                         Id = 1,
                         Name = "Red-Plus",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsRating
                     {
                         Id = 2,
                         Name = "Red",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsRating
                     {
                         Id = 3,
                         Name = "Red-Amber",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsRating
                     {
                         Id = 4,
                         Name = "Amber-Green",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     },
                     new ConcernsRating
                     {
                         Id = 5,
                         Name = "n/a",
-                        CreatedAt = DateTime.Now,
-                        UpdatedAt = DateTime.Now
+                        CreatedAt = new DateTime(2021,11,17),
+                        UpdatedAt = new DateTime(2021,11,17)
                     });
             });
             OnModelCreatingPartial(modelBuilder);

--- a/TramsDataApi/Migrations/TramsDb/20211119100948_UpdateConcernsUpdatedCreatedAtFieldsMigration.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211119100948_UpdateConcernsUpdatedCreatedAtFieldsMigration.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211119100948_UpdateConcernsUpdatedCreatedAtFieldsMigration")]
+    partial class UpdateConcernsUpdatedCreatedAtFieldsMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20211119100948_UpdateConcernsUpdatedCreatedAtFieldsMigration.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211119100948_UpdateConcernsUpdatedCreatedAtFieldsMigration.cs
@@ -1,0 +1,350 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class UpdateConcernsUpdatedCreatedAtFieldsMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 12,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 13,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(180), new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(680) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1070), new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1080) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1090), new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1090) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1090), new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1100) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsRating",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1100), new DateTime(2021, 11, 18, 15, 17, 20, 586, DateTimeKind.Local).AddTicks(1100) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 571, DateTimeKind.Local).AddTicks(640), new DateTime(2021, 11, 18, 15, 17, 20, 575, DateTimeKind.Local).AddTicks(290) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 575, DateTimeKind.Local).AddTicks(880), new DateTime(2021, 11, 18, 15, 17, 20, 575, DateTimeKind.Local).AddTicks(900) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsStatus",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 575, DateTimeKind.Local).AddTicks(900), new DateTime(2021, 11, 18, 15, 17, 20, 575, DateTimeKind.Local).AddTicks(910) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(5940), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6400) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6760), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6770) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6780), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6790), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6800) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6800), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6800) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6800), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(6800) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7190), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7190) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7190), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7190) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 12,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200) });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 13,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200), new DateTime(2021, 11, 18, 15, 17, 20, 584, DateTimeKind.Local).AddTicks(7200) });
+        }
+    }
+}


### PR DESCRIPTION
In this PR:
- Update the concerns db models to make the created and updated at fields stop updating in every db migrations