### PR TITLE
Add get concerns records by case urn

### DIFF
--- a/TramsDataApi.Test/UseCases/GetConcernsRecordsByCaseUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetConcernsRecordsByCaseUrnTests.cs
@@ -34,7 +34,7 @@ namespace TramsDataApi.Test.UseCases
             concernsCase.ConcernsRecords = concernsRecords;
             
             var gateway = new Mock<IConcernsCaseGateway>();
-            gateway.Setup(g => g.GetConcernsCaseByUrn(caseUrn))
+            gateway.Setup(g => g.GetConcernsCaseIncludingRecordsByUrn(caseUrn))
                 .Returns(concernsCase);
 
             var useCase = new GetConcernsRecordsByCaseUrn(gateway.Object);

--- a/TramsDataApi.Test/UseCases/GetConcernsRecordsByCaseUrnTests.cs
+++ b/TramsDataApi.Test/UseCases/GetConcernsRecordsByCaseUrnTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class GetConcernsRecordsByCaseUrnTests
+    {
+        [Fact]
+        public void Execute_ShouldReturnListOfConcernsRecordResponsesForAGivenCaseUrn()
+        {
+            var caseUrn = 1234;
+            var concernsCase = Builder<ConcernsCase>.CreateNew()
+                .With(c => c.Urn = caseUrn)
+                .Build();
+            
+            var concernsType = Builder<ConcernsType>.CreateNew().Build();
+            var concernsRating = Builder<ConcernsRating>.CreateNew().Build();
+            
+            var concernsRecords = Builder<ConcernsRecord>.CreateListOfSize(5)
+                .All()
+                .With(r => r.ConcernsCase = concernsCase)
+                .With(r => r.ConcernsType = concernsType)
+                .With(r => r.ConcernsRating = concernsRating)
+                .Build();
+
+            concernsCase.ConcernsRecords = concernsRecords;
+            
+            var gateway = new Mock<IConcernsCaseGateway>();
+            gateway.Setup(g => g.GetConcernsCaseByUrn(caseUrn))
+                .Returns(concernsCase);
+
+            var useCase = new GetConcernsRecordsByCaseUrn(gateway.Object);
+            var expected = concernsRecords
+                .Select(ConcernsRecordResponseFactory.Create).ToList();
+            
+            var result = useCase.Execute(caseUrn);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
@@ -17,15 +17,18 @@ namespace TramsDataApi.Controllers.V2
         private readonly ILogger<ConcernsRecordController> _logger;
         private readonly ICreateConcernsRecord _createConcernsRecord;
         private readonly IUpdateConcernsRecord _updateConcernsRecord;
+        private readonly IGetConcernsRecordsByCaseUrn _getConcernsRecordsByCaseUrn;
 
         public ConcernsRecordController(
             ILogger<ConcernsRecordController> logger, 
             ICreateConcernsRecord createConcernsRecord,
-            IUpdateConcernsRecord updateConcernsRecord)
+            IUpdateConcernsRecord updateConcernsRecord,
+            IGetConcernsRecordsByCaseUrn getConcernsRecordsByCaseUrn)
         {
             _logger = logger;
             _createConcernsRecord = createConcernsRecord;
             _updateConcernsRecord = updateConcernsRecord;
+            _getConcernsRecordsByCaseUrn = getConcernsRecordsByCaseUrn;
         }
         
         [HttpPost]
@@ -42,7 +45,7 @@ namespace TramsDataApi.Controllers.V2
         [MapToApiVersion("2.0")]
         public ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>> Update(int urn, ConcernsRecordRequest request)
         {
-            _logger.LogInformation($"Attempting to update Concerns Case {urn}");
+            _logger.LogInformation($"Attempting to update Concerns Record {urn}");
             var updatedAcademyConcernsRecord = _updateConcernsRecord.Execute(urn, request);
             if (updatedAcademyConcernsRecord == null)
             {
@@ -54,6 +57,19 @@ namespace TramsDataApi.Controllers.V2
             _logger.LogDebug(JsonSerializer.Serialize(updatedAcademyConcernsRecord));
 			
             var response = new ApiSingleResponseV2<ConcernsRecordResponse>(updatedAcademyConcernsRecord);
+            return Ok(response);
+        }
+        
+        [HttpGet("case/urn/{urn}")]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiResponseV2<ConcernsRecordResponse>> GetByCaseUrn(int urn, int page = 1, int count = 50)
+        {
+            _logger.LogInformation($"Attempting to update Concerns Case {urn}");
+            var records = _getConcernsRecordsByCaseUrn.Execute(urn);
+
+            _logger.LogInformation($"Returning Records for Case urn: {urn}");
+            var pagingResponse = PagingResponseFactory.Create(page, count, records.Count, Request);
+            var response = new ApiResponseV2<ConcernsRecordResponse>(records, pagingResponse);
             return Ok(response);
         }
     }

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -35,6 +35,15 @@ namespace TramsDataApi.Gateways
         public ConcernsCase GetConcernsCaseByUrn(int urn)
         {
             var concernsCase = _tramsDbContext.ConcernsCase
+                .AsNoTracking()
+                .FirstOrDefault(c => c.Urn == urn);
+            
+            return concernsCase;
+        }
+        
+        public ConcernsCase GetConcernsCaseIncludingRecordsByUrn(int urn)
+        {
+            var concernsCase = _tramsDbContext.ConcernsCase
                 .Include(c => c.ConcernsRecords)
                 .ThenInclude(record => record.ConcernsRating)
                 .Include(c => c.ConcernsRecords)

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -34,9 +34,15 @@ namespace TramsDataApi.Gateways
 
         public ConcernsCase GetConcernsCaseByUrn(int urn)
         {
-            return _tramsDbContext.ConcernsCase
+            var concernsCase = _tramsDbContext.ConcernsCase
+                .Include(c => c.ConcernsRecords)
+                .ThenInclude(record => record.ConcernsRating)
+                .Include(c => c.ConcernsRecords)
+                .ThenInclude(record => record.ConcernsType)
                 .AsNoTracking()
                 .FirstOrDefault(c => c.Urn == urn);
+            
+            return concernsCase;
         }
 
         public ConcernsCase Update(ConcernsCase concernsCase)

--- a/TramsDataApi/Gateways/IConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsCaseGateway.cs
@@ -9,5 +9,6 @@ namespace TramsDataApi.Gateways
         IList<ConcernsCase> GetConcernsCaseByTrustUkprn(string trustUkprn, int page, int count);
         ConcernsCase GetConcernsCaseByUrn(int urn);
         ConcernsCase Update(ConcernsCase concernsCase);
+        ConcernsCase GetConcernsCaseIncludingRecordsByUrn(int urn);
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -68,7 +68,8 @@ namespace TramsDataApi
             services.AddScoped<IUpdateConcernsCase, UpdateConcernsCase>();
             services.AddScoped<IIndexConcernsTypes, IndexConcernsTypes>();
             services.AddScoped<IUpdateConcernsRecord, UpdateConcernsRecord>();
-
+            services.AddScoped<IGetConcernsRecordsByCaseUrn, GetConcernsRecordsByCaseUrn>();
+            
             
             // this is a temporary solution to move academy conversion projects from mstr.IfdPipeline to sdd.AcademyConversionProject
             // once the a2b external service can write directly to trams this should be removed

--- a/TramsDataApi/UseCases/GetConcernsRecordsByCaseUrn.cs
+++ b/TramsDataApi/UseCases/GetConcernsRecordsByCaseUrn.cs
@@ -17,7 +17,7 @@ namespace TramsDataApi.UseCases
         }
         public IList<ConcernsRecordResponse> Execute(int caseUrn)
         {
-            var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(caseUrn);
+            var concernsCase = _concernsCaseGateway.GetConcernsCaseIncludingRecordsByUrn(caseUrn);
             return concernsCase?.ConcernsRecords
                 .Select(ConcernsRecordResponseFactory.Create).ToList();
         }

--- a/TramsDataApi/UseCases/GetConcernsRecordsByCaseUrn.cs
+++ b/TramsDataApi/UseCases/GetConcernsRecordsByCaseUrn.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public class GetConcernsRecordsByCaseUrn : IGetConcernsRecordsByCaseUrn
+    {
+        private readonly IConcernsCaseGateway _concernsCaseGateway;
+
+        public GetConcernsRecordsByCaseUrn(
+            IConcernsCaseGateway concernsCaseGateway)
+        {
+            _concernsCaseGateway = concernsCaseGateway;
+        }
+        public IList<ConcernsRecordResponse> Execute(int caseUrn)
+        {
+            var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(caseUrn);
+            return concernsCase?.ConcernsRecords
+                .Select(ConcernsRecordResponseFactory.Create).ToList();
+        }
+    }
+}

--- a/TramsDataApi/UseCases/IGetConcernsRecordsByCaseUrn.cs
+++ b/TramsDataApi/UseCases/IGetConcernsRecordsByCaseUrn.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IGetConcernsRecordsByCaseUrn
+    {
+        public IList<ConcernsRecordResponse> Execute(int caseUrn);
+    }
+}


### PR DESCRIPTION
In this PR:
- Add the `concerns-records/case/urn/{urn}` route to get concerns records by case urn.
- Add `GetConcernsCaseIncludingRecordsByUrn` gateway method to eager load records and record data when getting a concerns case.
- Add usecase to get concerns records by case urn