### PR TITLE
A2b create get post endpoints for application

### DIFF
--- a/TramsDataApi.Test/Controllers/A2BApplicationController.cs
+++ b/TramsDataApi.Test/Controllers/A2BApplicationController.cs
@@ -2,8 +2,10 @@ using FizzWare.NBuilder;
 using Microsoft.Extensions.Logging;
 using Moq;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using TramsDataApi.Controllers.V2;
+using TramsDataApi.DatabaseModels;
 using TramsDataApi.RequestModels.ApplyToBecome;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.ResponseModels.ApplyToBecome;
@@ -24,8 +26,8 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetApplicationByApplicationId_ReturnsApiSingleResponseWithApplicationWhenApplicationExists()
         {
-            var applicationId = "ApplicationId";
-            var mockUseCase = new Mock<IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>>();
+            var applicationId = 10001;
+            var mockUseCase = new Mock<IGetA2BApplication>();
 
             var response = Builder<A2BApplicationResponse>
                 .CreateNew()
@@ -38,9 +40,9 @@ namespace TramsDataApi.Test.Controllers
                 .Setup(x => x.Execute(It.IsAny<A2BApplicationByIdRequest>()))
                 .Returns(response);
 
-            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object);
+            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object, new Mock<ICreateA2BApplication>().Object);
 
-            var result = controller.GetApplicationByApplicationId("applicationId");
+            var result = controller.GetApplicationByApplicationId(applicationId);
 
             result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedResponse));
         }
@@ -48,14 +50,65 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetApplicationByApplicationId_ReturnsNotFound_WhenApplicationNotFound()
         {
+
             var expectedResponse = new NotFoundResult();
-            var mockUseCase = new Mock<IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>>();
+            var mockUseCase = new Mock<IGetA2BApplication>();
 
-            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object);
+            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object, new Mock<ICreateA2BApplication>().Object);
 
-            var result = controller.GetApplicationByApplicationId("applicationId");
+            var result = controller.GetApplicationByApplicationId(10001);
 
             result.Result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public void xxxx_Returns201_WithCreatedObject_WhenApplicationCreated()
+        {
+            var request = Builder<A2BApplicationCreateRequest>.CreateNew().Build();
+            var expectedApplicationResponse =  new A2BApplicationResponse
+            {
+                ApplicationId = 10001,
+                Name = request.Name,
+                ApplicationType = request.ApplicationType,
+                TrustId = request.TrustId,
+                FormTrustProposedNameOfTrust = request.FormTrustProposedNameOfTrust,
+                ApplicationSubmitted = request.ApplicationSubmitted,
+                ApplicationLeadAuthorId = request.ApplicationLeadAuthorId,
+                ApplicationVersion = request.ApplicationVersion,
+                ApplicationLeadAuthorName = request.ApplicationLeadAuthorName,
+                ApplicationRole = request.ApplicationRole,
+                ApplicationRoleOtherDescription = request.ApplicationRoleOtherDescription,
+                ChangesToTrust = request.ChangesToTrust,
+                ChangesToTrustExplained = request.ChangesToTrustExplained,
+                FormTrustOpeningDate = request.FormTrustOpeningDate,
+                TrustApproverName = request.TrustApproverName,
+                TrustApproverEmail = request.TrustApproverEmail,
+                FormTrustReasonApprovalToConvertAsSat = request.FormTrustReasonApprovalToConvertAsSat,
+                FormTrustReasonApprovedPerson = request.FormTrustReasonApprovedPerson,
+                FormTrustReasonForming = request.FormTrustReasonForming,
+                FormTrustReasonVision = request.FormTrustReasonVision,
+                FormTrustReasonGeoAreas = request.FormTrustReasonGeoAreas,
+                FormTrustReasonFreedom = request.FormTrustReasonFreedom,
+                FormTrustReasonImproveTeaching = request.FormTrustReasonImproveTeaching,
+                FormTrustPlanForGrowth = request.FormTrustPlanForGrowth,
+                FormTrustPlansForNoGrowth = request.FormTrustPlansForNoGrowth,
+                FormTrustGrowthPlansYesNo = request.FormTrustGrowthPlansYesNo,
+                FormTrustImprovementSupport = request.FormTrustImprovementSupport,
+                FormTrustImprovementStrategy = request.FormTrustImprovementStrategy,
+                FormTrustImprovementApprovedSponsor = request.FormTrustImprovementApprovedSponsor
+            };
+
+            var expectedResponse = new ApiSingleResponseV2<A2BApplicationResponse>(expectedApplicationResponse);
+            var expectedResult = new ObjectResult(expectedResponse) {StatusCode = StatusCodes.Status201Created};
+            
+            var mockUseCase = new Mock<ICreateA2BApplication>();
+            mockUseCase.Setup(u => u.Execute(It.IsAny<A2BApplicationCreateRequest>())).Returns(expectedApplicationResponse);
+            
+            var controller = new A2BApplicationController(_mockLogger.Object, new Mock<IGetA2BApplication>().Object, mockUseCase.Object);
+
+            var controllerResponse = controller.Create(request);
+
+            controllerResponse.Result.Should().BeEquivalentTo(expectedResult);
         }
     }
 }

--- a/TramsDataApi.Test/Controllers/A2BApplicationController.cs
+++ b/TramsDataApi.Test/Controllers/A2BApplicationController.cs
@@ -1,0 +1,61 @@
+using FizzWare.NBuilder;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using TramsDataApi.Controllers.V2;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.Controllers
+{
+    public class A2BApplicationControllerTests
+    {
+        private readonly Mock<ILogger<A2BApplicationController>> _mockLogger;
+
+        public A2BApplicationControllerTests()
+        {
+            _mockLogger = new Mock<ILogger<A2BApplicationController>>();
+        }
+
+        [Fact]
+        public void GetApplicationByApplicationId_ReturnsApiSingleResponseWithApplicationWhenApplicationExists()
+        {
+            var applicationId = "ApplicationId";
+            var mockUseCase = new Mock<IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>>();
+
+            var response = Builder<A2BApplicationResponse>
+                .CreateNew()
+                .With(r => r.ApplicationId = applicationId)
+                .Build();
+
+            var expectedResponse = new ApiSingleResponseV2<A2BApplicationResponse>(response);
+
+            mockUseCase
+                .Setup(x => x.Execute(It.IsAny<A2BApplicationByIdRequest>()))
+                .Returns(response);
+
+            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object);
+
+            var result = controller.GetApplicationByApplicationId("applicationId");
+
+            result.Result.Should().BeEquivalentTo(new OkObjectResult(expectedResponse));
+        }
+
+        [Fact]
+        public void GetApplicationByApplicationId_ReturnsNotFound_WhenApplicationNotFound()
+        {
+            var expectedResponse = new NotFoundResult();
+            var mockUseCase = new Mock<IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>>();
+
+            var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object);
+
+            var result = controller.GetApplicationByApplicationId("applicationId");
+
+            result.Result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/A2BApplicationFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/A2BApplicationFactoryTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using FizzWare.NBuilder;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class A2BApplicationFactoryTests
+    {
+	    [Fact]
+        public void Create_ReturnsNull_WhenA2BApplicationIsNull()
+        {
+            var response = A2BApplicationFactory.Create(null);
+
+            response.Should().BeNull();
+        }
+
+        [Fact]
+        public void Create_ReturnsExpectedA2BApplication_WhenA2BApplicationResponseIsProvided()
+        {
+            var applicationCreateRequest = Builder<A2BApplicationCreateRequest>
+                .CreateNew()
+                .Build();
+
+            var expectedApplication = new A2BApplication
+            {
+	            Name = applicationCreateRequest.Name,
+	            ApplicationType = applicationCreateRequest.ApplicationType,
+	            FormTrustProposedNameOfTrust = applicationCreateRequest.FormTrustProposedNameOfTrust,
+	            ApplicationSubmitted = applicationCreateRequest.ApplicationSubmitted,
+	            ApplicationLeadAuthorId = applicationCreateRequest.ApplicationLeadAuthorId,
+	            ApplicationVersion = applicationCreateRequest.ApplicationVersion,
+	            ApplicationLeadAuthorName = applicationCreateRequest.ApplicationLeadAuthorName,
+	            ApplicationRole = applicationCreateRequest.ApplicationRole,
+	            ApplicationRoleOtherDescription = applicationCreateRequest.ApplicationRoleOtherDescription,
+	            ChangesToTrust = applicationCreateRequest.ChangesToTrust,
+	            ChangesToTrustExplained = applicationCreateRequest.ChangesToTrustExplained,
+	            ChangesToLaGovernance = applicationCreateRequest.ChangesToLaGovernance,
+	            ChangesToLaGovernanceExplained = applicationCreateRequest.ChangesToLaGovernanceExplained,
+	            FormTrustOpeningDate = applicationCreateRequest.FormTrustOpeningDate,
+	            TrustId = applicationCreateRequest.TrustId,
+	            TrustApproverName = applicationCreateRequest.TrustApproverName,
+	            TrustApproverEmail = applicationCreateRequest.TrustApproverEmail,
+	            FormTrustReasonApprovalToConvertAsSat = applicationCreateRequest.FormTrustReasonApprovalToConvertAsSat,
+	            FormTrustReasonApprovedPerson = applicationCreateRequest.FormTrustReasonApprovedPerson,
+	            FormTrustReasonForming = applicationCreateRequest.FormTrustReasonForming,
+	            FormTrustReasonVision = applicationCreateRequest.FormTrustReasonVision,
+	            FormTrustReasonGeoAreas = applicationCreateRequest.FormTrustReasonGeoAreas,
+	            FormTrustReasonFreedom = applicationCreateRequest.FormTrustReasonFreedom,
+	            FormTrustReasonImproveTeaching = applicationCreateRequest.FormTrustReasonImproveTeaching,
+	            FormTrustPlanForGrowth = applicationCreateRequest.FormTrustPlanForGrowth,
+	            FormTrustPlansForNoGrowth = applicationCreateRequest.FormTrustPlansForNoGrowth,
+	            FormTrustGrowthPlansYesNo = applicationCreateRequest.FormTrustGrowthPlansYesNo,
+	            FormTrustImprovementSupport = applicationCreateRequest.FormTrustImprovementSupport,
+	            FormTrustImprovementStrategy = applicationCreateRequest.FormTrustImprovementStrategy,
+	            FormTrustImprovementApprovedSponsor = applicationCreateRequest.FormTrustImprovementApprovedSponsor
+            };
+                
+            var response = A2BApplicationFactory.Create(applicationCreateRequest);
+
+            response.Should().BeEquivalentTo(expectedApplication);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/A2BApplicationResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/A2BApplicationResponseFactoryTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using FizzWare.NBuilder;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories
+{
+    public class A2BApplicationResponseFactoryTests
+    {
+	    [Fact]
+        public void Create_ReturnsNull_WhenA2BApplicationIsNull()
+        {
+            var response = A2BApplicationResponseFactory.Create(null, null);
+
+            response.Should().BeNull();
+        }
+
+        [Fact]
+        public void Create_ReturnsExpectedA2BApplicationResponse_WhenA2BApplicationIsProvided()
+        {
+            var application = Builder<A2BApplication>
+                .CreateNew()
+                .Build();
+
+            var expectedResponse = new A2BApplicationResponse
+            {
+	            Name = application.Name,
+	            ApplicationId = application.ApplicationId,
+	            ApplicationType = application.ApplicationType,
+	            FormTrustProposedNameOfTrust = application.FormTrustProposedNameOfTrust,
+	            ApplicationSubmitted = application.ApplicationSubmitted,
+	            ApplicationLeadAuthorId = application.ApplicationLeadAuthorId,
+	            ApplicationVersion = application.ApplicationVersion,
+	            ApplicationLeadAuthorName = application.ApplicationLeadAuthorName,
+	            ApplicationRole = application.ApplicationRole,
+	            ApplicationRoleOtherDescription = application.ApplicationRoleOtherDescription,
+	            ChangesToTrust = application.ChangesToTrust,
+	            ChangesToTrustExplained = application.ChangesToTrustExplained,
+	            ChangesToLaGovernance = application.ChangesToLaGovernance,
+	            ChangesToLaGovernanceExplained = application.ChangesToLaGovernanceExplained,
+	            FormTrustOpeningDate = application.FormTrustOpeningDate,
+	            TrustId = application.TrustId,
+	            TrustApproverName = application.TrustApproverEmail,
+	            TrustApproverEmail = application.TrustApproverEmail,
+	            FormTrustReasonApprovalToConvertAsSat = application.FormTrustReasonApprovalToConvertAsSat,
+	            FormTrustReasonApprovedPerson = application.FormTrustReasonApprovedPerson,
+	            FormTrustReasonForming = application.FormTrustReasonForming,
+	            FormTrustReasonVision = application.FormTrustReasonVision,
+	            FormTrustReasonGeoAreas = application.FormTrustReasonGeoAreas,
+	            FormTrustReasonFreedom = application.FormTrustReasonFreedom,
+	            FormTrustReasonImproveTeaching = application.FormTrustReasonImproveTeaching,
+	            FormTrustPlanForGrowth = application.FormTrustPlanForGrowth,
+	            FormTrustPlansForNoGrowth = application.FormTrustPlansForNoGrowth,
+	            FormTrustGrowthPlansYesNo = application.FormTrustGrowthPlansYesNo,
+	            FormTrustImprovementSupport = application.FormTrustImprovementSupport,
+	            FormTrustImprovementStrategy = application.FormTrustImprovementStrategy,
+	            FormTrustImprovementApprovedSponsor = application.FormTrustImprovementApprovedSponsor,
+            };
+                
+            var response = A2BApplicationResponseFactory.Create(application, null);
+
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/A2BApplicationResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/A2BApplicationResponseFactoryTests.cs
@@ -42,7 +42,7 @@ namespace TramsDataApi.Test.Factories
 	            ChangesToLaGovernanceExplained = application.ChangesToLaGovernanceExplained,
 	            FormTrustOpeningDate = application.FormTrustOpeningDate,
 	            TrustId = application.TrustId,
-	            TrustApproverName = application.TrustApproverEmail,
+	            TrustApproverName = application.TrustApproverName,
 	            TrustApproverEmail = application.TrustApproverEmail,
 	            FormTrustReasonApprovalToConvertAsSat = application.FormTrustReasonApprovalToConvertAsSat,
 	            FormTrustReasonApprovedPerson = application.FormTrustReasonApprovedPerson,

--- a/TramsDataApi.Test/Integration/ApplyToBecomeIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/ApplyToBecomeIntegrationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using AutoFixture;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.RequestModels;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+using TramsDataApi.Test.Utils;
+using Xunit;
+
+namespace TramsDataApi.Test.Integration
+{
+    [Collection("Database")]
+    public class ApplyToBecomeIntegrationTests: IClassFixture<TramsDataApiFactory>, IDisposable
+    {
+        
+        private readonly HttpClient _client;
+        private readonly TramsDbContext _dbContext;
+        private readonly Fixture _fixture;
+        private readonly RandomGenerator _randomGenerator;
+
+        public ApplyToBecomeIntegrationTests(TramsDataApiFactory fixture)
+        {
+            _client = fixture.CreateClient();
+            _client.DefaultRequestHeaders.Add("ApiKey", "testing-api-key");
+            _dbContext = fixture.Services.GetRequiredService<TramsDbContext>();
+            _fixture = new Fixture();
+            _randomGenerator = new RandomGenerator();
+        }
+
+        
+        
+        [Fact]
+        public async Task CanGetApplicationByApplicationId()
+        {
+            SetupA2BApplicationData();
+            
+            var application = _dbContext.A2BApplications.First();
+            var expected = A2BApplicationResponseFactory.Create(application, null);
+            var expectedResponse = new ApiSingleResponseV2<A2BApplicationResponse>(expected);
+            
+            var response = await _client.GetAsync($"/v2/apply-to-become/application/{application.ApplicationId}");
+
+            response.StatusCode.Should().Be(200);
+            
+            var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<A2BApplicationResponse>>();
+            result.Should().BeEquivalentTo(expectedResponse); 
+            result.Data.ApplicationId.Should().Be(expectedResponse.Data.ApplicationId);
+        }
+        
+        private void SetupA2BApplicationData()
+        {
+            var applications = Builder<A2BApplication>
+                .CreateListOfSize(10)
+                .Build()
+                .ToList();
+
+            _dbContext.A2BApplications.AddRange(applications);
+            _dbContext.SaveChanges();
+        }
+        
+        public void Dispose()
+        {
+            _dbContext.A2BApplications.RemoveRange(_dbContext.A2BApplications);
+            _dbContext.SaveChanges();
+        }
+    }
+}

--- a/TramsDataApi.Test/UseCases/CreateA2BApplicationTests.cs
+++ b/TramsDataApi.Test/UseCases/CreateA2BApplicationTests.cs
@@ -1,0 +1,94 @@
+using System;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    
+    public class CreateA2BApplicationTests
+    {
+	    [Fact]
+        public void CreateA2BApplication_ShouldCreateAndReturnA2BApplication_WhenGiveA2BApplication()
+        {
+            var applicationCreateRequest = Builder<A2BApplicationCreateRequest>.CreateNew().Build();
+
+            var expectedApplication = new A2BApplication
+            {
+	            ApplicationId = 10001,
+	            Name = applicationCreateRequest.Name,
+	            ApplicationType = applicationCreateRequest.ApplicationType,
+	            FormTrustProposedNameOfTrust = applicationCreateRequest.FormTrustProposedNameOfTrust,
+	            ApplicationSubmitted = applicationCreateRequest.ApplicationSubmitted,
+	            ApplicationLeadAuthorId = applicationCreateRequest.ApplicationLeadAuthorId,
+	            ApplicationVersion = applicationCreateRequest.ApplicationVersion,
+	            ApplicationLeadAuthorName = applicationCreateRequest.ApplicationLeadAuthorName,
+	            ApplicationRole = applicationCreateRequest.ApplicationRole,
+	            ApplicationRoleOtherDescription = applicationCreateRequest.ApplicationRoleOtherDescription,
+	            ChangesToTrust = applicationCreateRequest.ChangesToTrust,
+	            ChangesToTrustExplained = applicationCreateRequest.ChangesToTrustExplained,
+	            ChangesToLaGovernance = applicationCreateRequest.ChangesToLaGovernance,
+	            ChangesToLaGovernanceExplained = applicationCreateRequest.ChangesToLaGovernanceExplained,
+	            FormTrustOpeningDate = applicationCreateRequest.FormTrustOpeningDate,
+	            TrustId = applicationCreateRequest.TrustId,
+	            TrustApproverName = applicationCreateRequest.TrustApproverName,
+	            TrustApproverEmail = applicationCreateRequest.TrustApproverEmail,
+	            FormTrustReasonApprovalToConvertAsSat = applicationCreateRequest.FormTrustReasonApprovalToConvertAsSat,
+	            FormTrustReasonApprovedPerson = applicationCreateRequest.FormTrustReasonApprovedPerson,
+	            FormTrustReasonForming = applicationCreateRequest.FormTrustReasonForming,
+	            FormTrustReasonVision = applicationCreateRequest.FormTrustReasonVision,
+	            FormTrustReasonGeoAreas = applicationCreateRequest.FormTrustReasonGeoAreas,
+	            FormTrustReasonFreedom = applicationCreateRequest.FormTrustReasonFreedom,
+	            FormTrustReasonImproveTeaching = applicationCreateRequest.FormTrustReasonImproveTeaching,
+	            FormTrustPlanForGrowth = applicationCreateRequest.FormTrustPlanForGrowth,
+	            FormTrustPlansForNoGrowth = applicationCreateRequest.FormTrustPlansForNoGrowth,
+	            FormTrustGrowthPlansYesNo = applicationCreateRequest.FormTrustGrowthPlansYesNo,
+	            FormTrustImprovementSupport = applicationCreateRequest.FormTrustImprovementSupport,
+	            FormTrustImprovementStrategy = applicationCreateRequest.FormTrustImprovementStrategy,
+	            FormTrustImprovementApprovedSponsor = applicationCreateRequest.FormTrustImprovementApprovedSponsor
+            };
+            
+            var mockGateway = new Mock<IA2BApplicationGateway>();
+            
+            mockGateway.Setup(g => g.CreateA2BApplication(It.IsAny<A2BApplication>())).Returns(expectedApplication);
+            
+            var useCase = new CreateA2BApplication(mockGateway.Object);
+            
+            var result = useCase.Execute(applicationCreateRequest);
+
+            result.Should().NotBeNull();
+            result.ApplicationId.Should().BeGreaterThan(0);
+            result.Should().BeEquivalentTo(expectedApplication);
+        }
+
+        [Fact]
+        public void GetA2BApplication_ShouldReturnA2BApplicationResponse_WhenApplicationIdIsFound()
+        {
+            var applicationId = 10001;
+            var mockGateway = new Mock<IA2BApplicationGateway>();
+            var application = Builder<A2BApplication>
+                .CreateNew()
+                .With(a => a.ApplicationId == applicationId)
+                .Build();
+
+            var request = new A2BApplicationByIdRequest
+            {
+                ApplicationId = applicationId
+            };
+            var expected = A2BApplicationResponseFactory.Create(application, null);
+
+            mockGateway.Setup(g => g.GetByApplicationId(applicationId)).Returns(application);
+            
+            var useCase = new GetA2BApplication(mockGateway.Object);
+            var result = useCase.Execute(request);
+            
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
+++ b/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
@@ -1,0 +1,69 @@
+using System;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class GetA2BApplicationTests
+    {
+        [Fact]
+        public void GetA2BApplication_ShouldReturnNull_WhenA2BApplicationRequestByIdIsNull()
+        {
+            var mockGateway = new Mock<IA2BApplicationGateway>();
+            
+            var useCase = new GetA2BApplication(mockGateway.Object);
+            var result = useCase.Execute(null);
+
+            result.Should().BeNull();
+        }
+        
+        [Fact]
+        public void GetA2BApplication_ShouldReturnNull_WhenApplicationIdIsNotFound()
+        {
+            var mockGateway = new Mock<IA2BApplicationGateway>();
+
+            var request = new A2BApplicationByIdRequest
+            {
+                ApplicationId = "ApplicationId"
+            };
+            
+            mockGateway.Setup(g => g.GetByApplicationId("ApplicationId"));
+           
+            var useCase = new GetA2BApplication(mockGateway.Object);
+            var result = useCase.Execute(null);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetA2BApplication_ShouldReturnA2BApplicationResponse_WhenApplicationIdIsFound()
+        {
+            var mockGateway = new Mock<IA2BApplicationGateway>();
+            var application = Builder<A2BApplication>
+                .CreateNew()
+                .With(a => a.ApplicationId == "ApplicationId")
+                .Build();
+
+            var request = new A2BApplicationByIdRequest
+            {
+                ApplicationId = "ApplicationId"
+            };
+            var expected = A2BApplicationResponseFactory.Create(application, null);
+
+            mockGateway.Setup(g => g.GetByApplicationId("ApplicationId")).Returns(application);
+            
+            var useCase = new GetA2BApplication(mockGateway.Object);
+            var result = useCase.Execute(request);
+            
+            result.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
+++ b/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
@@ -28,14 +28,10 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetA2BApplication_ShouldReturnNull_WhenApplicationIdIsNotFound()
         {
+            var applicationId = 10001;
             var mockGateway = new Mock<IA2BApplicationGateway>();
 
-            var request = new A2BApplicationByIdRequest
-            {
-                ApplicationId = "ApplicationId"
-            };
-            
-            mockGateway.Setup(g => g.GetByApplicationId("ApplicationId"));
+            mockGateway.Setup(g => g.GetByApplicationId(applicationId));
            
             var useCase = new GetA2BApplication(mockGateway.Object);
             var result = useCase.Execute(null);
@@ -46,19 +42,20 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetA2BApplication_ShouldReturnA2BApplicationResponse_WhenApplicationIdIsFound()
         {
+            var applicationId = 10001;
             var mockGateway = new Mock<IA2BApplicationGateway>();
             var application = Builder<A2BApplication>
                 .CreateNew()
-                .With(a => a.ApplicationId == "ApplicationId")
+                .With(a => a.ApplicationId == applicationId)
                 .Build();
 
             var request = new A2BApplicationByIdRequest
             {
-                ApplicationId = "ApplicationId"
+                ApplicationId = applicationId
             };
             var expected = A2BApplicationResponseFactory.Create(application, null);
 
-            mockGateway.Setup(g => g.GetByApplicationId("ApplicationId")).Returns(application);
+            mockGateway.Setup(g => g.GetByApplicationId(applicationId)).Returns(application);
             
             var useCase = new GetA2BApplication(mockGateway.Object);
             var result = useCase.Execute(request);

--- a/TramsDataApi/Controllers/V2/A2BApplicationController.cs
+++ b/TramsDataApi/Controllers/V2/A2BApplicationController.cs
@@ -15,24 +15,27 @@ namespace TramsDataApi.Controllers.V2
     public class A2BApplicationController: ControllerBase
     { 
         private readonly ILogger<A2BApplicationController> _logger;
-        private readonly IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse> _getApplyToBecomeApplicationById;
-
+        private readonly IGetA2BApplication _getA2BApplicationById;
+        private readonly ICreateA2BApplication _createA2BApplication;
+        
         public A2BApplicationController(
             ILogger<A2BApplicationController> logger, 
-            IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse> getApplyToBecomeApplicationById)
+            IGetA2BApplication getA2BApplicationById, 
+            ICreateA2BApplication createA2BApplication)
         {
             _logger = logger;
-            _getApplyToBecomeApplicationById = getApplyToBecomeApplicationById;
+            _getA2BApplicationById = getA2BApplicationById;
+            _createA2BApplication = createA2BApplication;
         }
         
         [HttpGet]
         [Route("{applicationId}")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiSingleResponseV2<A2BApplicationResponse>> GetApplicationByApplicationId(string applicationId)
+        public ActionResult<ApiSingleResponseV2<A2BApplicationResponse>> GetApplicationByApplicationId(int applicationId)
         {
             _logger.LogInformation("Attempting to get ApplyToBecome Application by ApplicationId {applicationId}", applicationId);
             var request = new A2BApplicationByIdRequest {ApplicationId = applicationId};
-            var application = _getApplyToBecomeApplicationById.Execute(request);
+            var application = _getA2BApplicationById.Execute(request);
             
             if (application == null)
             {
@@ -45,6 +48,16 @@ namespace TramsDataApi.Controllers.V2
             var response = new ApiSingleResponseV2<A2BApplicationResponse>(application);
             
             return Ok(response);
+        }
+
+        [HttpPost]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<A2BApplicationResponse>> Create(A2BApplicationCreateRequest request)
+        {
+            var createdA2BApplication = _createA2BApplication.Execute(request);
+            var response = new ApiSingleResponseV2<A2BApplicationResponse>(createdA2BApplication);
+            
+            return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
         }
     }
 }

--- a/TramsDataApi/Controllers/V2/A2BApplicationController.cs
+++ b/TramsDataApi/Controllers/V2/A2BApplicationController.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+using TramsDataApi.UseCases;
+
+namespace TramsDataApi.Controllers.V2
+{
+    [ApiVersion("2.0")]
+    [ApiController]
+    [Route("v{version:apiVersion}/apply-to-become/application")]
+    public class A2BApplicationController: ControllerBase
+    { 
+        private readonly ILogger<A2BApplicationController> _logger;
+        private readonly IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse> _getApplyToBecomeApplicationById;
+
+        public A2BApplicationController(
+            ILogger<A2BApplicationController> logger, 
+            IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse> getApplyToBecomeApplicationById)
+        {
+            _logger = logger;
+            _getApplyToBecomeApplicationById = getApplyToBecomeApplicationById;
+        }
+        
+        [HttpGet]
+        [Route("{applicationId}")]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<A2BApplicationResponse>> GetApplicationByApplicationId(string applicationId)
+        {
+            _logger.LogInformation("Attempting to get ApplyToBecome Application by ApplicationId {applicationId}", applicationId);
+            var request = new A2BApplicationByIdRequest {ApplicationId = applicationId};
+            var application = _getApplyToBecomeApplicationById.Execute(request);
+            
+            if (application == null)
+            {
+                _logger.LogInformation($"No ApplyToBecome Application found for ApplicationId {applicationId}", applicationId);
+                return NotFound($"Application with Id {applicationId} not found");
+            }
+            
+            _logger.LogInformation($"Returning ApplyToBecome Application by ApplicationId {applicationId}", applicationId);
+            _logger.LogDebug(JsonSerializer.Serialize(application));
+            var response = new ApiSingleResponseV2<A2BApplicationResponse>(application);
+            
+            return Ok(response);
+        }
+    }
+}

--- a/TramsDataApi/DatabaseModels/A2BApplication.cs
+++ b/TramsDataApi/DatabaseModels/A2BApplication.cs
@@ -8,7 +8,8 @@ namespace TramsDataApi.DatabaseModels
     public class A2BApplication
     {
         [Key]
-        public string ApplicationId {get; set;}
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ApplicationId {get; set;}
         public string Name {get; set;} 
         public string ApplicationType {get; set;}
         public string FormTrustProposedNameOfTrust {get; set;}

--- a/TramsDataApi/Factories/A2BApplicationFactory.cs
+++ b/TramsDataApi/Factories/A2BApplicationFactory.cs
@@ -1,0 +1,47 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.RequestModels.ApplyToBecome;
+
+namespace TramsDataApi.Factories
+{
+    public static class A2BApplicationFactory
+    {
+        public static A2BApplication Create(A2BApplicationCreateRequest request)
+        {
+            return request == null
+                ? null
+                : new A2BApplication
+                {
+                    Name = request.Name,
+                    ApplicationType = request.ApplicationType,
+                    TrustId = request.TrustId,
+                    FormTrustProposedNameOfTrust = request.FormTrustProposedNameOfTrust,
+                    ApplicationSubmitted = request.ApplicationSubmitted,
+                    ApplicationLeadAuthorId = request.ApplicationLeadAuthorId,
+                    ApplicationVersion = request.ApplicationVersion,
+                    ApplicationLeadAuthorName = request.ApplicationLeadAuthorName,
+                    ApplicationRole = request.ApplicationRole,
+                    ApplicationRoleOtherDescription = request.ApplicationRoleOtherDescription,
+                    ChangesToTrust = request.ChangesToTrust,
+                    ChangesToTrustExplained = request.ChangesToTrustExplained,
+                    ChangesToLaGovernance = request.ChangesToLaGovernance,
+                    ChangesToLaGovernanceExplained = request.ChangesToLaGovernanceExplained,
+                    FormTrustOpeningDate = request.FormTrustOpeningDate,
+                    TrustApproverName = request.TrustApproverName,
+                    TrustApproverEmail = request.TrustApproverEmail,
+                    FormTrustReasonApprovalToConvertAsSat = request.FormTrustReasonApprovalToConvertAsSat,
+                    FormTrustReasonApprovedPerson = request.FormTrustReasonApprovedPerson,
+                    FormTrustReasonForming = request.FormTrustReasonForming,
+                    FormTrustReasonVision = request.FormTrustReasonVision,
+                    FormTrustReasonGeoAreas = request.FormTrustReasonGeoAreas,
+                    FormTrustReasonFreedom = request.FormTrustReasonFreedom,
+                    FormTrustReasonImproveTeaching = request.FormTrustReasonImproveTeaching,
+                    FormTrustPlanForGrowth = request.FormTrustPlanForGrowth,
+                    FormTrustPlansForNoGrowth = request.FormTrustPlansForNoGrowth,
+                    FormTrustGrowthPlansYesNo = request.FormTrustGrowthPlansYesNo,
+                    FormTrustImprovementSupport = request.FormTrustImprovementSupport,
+                    FormTrustImprovementStrategy = request.FormTrustImprovementStrategy,
+                    FormTrustImprovementApprovedSponsor = request.FormTrustImprovementApprovedSponsor
+                };
+        }
+    }
+}

--- a/TramsDataApi/Factories/A2BApplicationResponseFactory.cs
+++ b/TramsDataApi/Factories/A2BApplicationResponseFactory.cs
@@ -25,7 +25,7 @@ namespace TramsDataApi.Factories
 			    ChangesToLaGovernance = application.ChangesToLaGovernance,
 			    ChangesToLaGovernanceExplained = application.ChangesToLaGovernanceExplained,
 			    FormTrustOpeningDate = application.FormTrustOpeningDate,
-			    TrustApproverName = application.TrustApproverEmail,
+			    TrustApproverName = application.TrustApproverName,
 			    TrustApproverEmail = application.TrustApproverEmail,
 			    TrustId = application.TrustId,
 			    FormTrustReasonApprovalToConvertAsSat = application.FormTrustReasonApprovalToConvertAsSat,

--- a/TramsDataApi/Factories/A2BApplicationResponseFactory.cs
+++ b/TramsDataApi/Factories/A2BApplicationResponseFactory.cs
@@ -1,0 +1,48 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels.AcademyConversionProject;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+
+namespace TramsDataApi.Factories
+{
+	public class A2BApplicationResponseFactory
+    {
+	    public static A2BApplicationResponse Create(A2BApplication application, A2BApplicationAccount account)
+	    { 
+		    return application is null ? null : new A2BApplicationResponse
+		    {
+			    Name = application.Name,
+			    ApplicationId = application.ApplicationId,
+			    ApplicationType = application.ApplicationType,
+			    FormTrustProposedNameOfTrust = application.FormTrustProposedNameOfTrust,
+			    ApplicationSubmitted = application.ApplicationSubmitted,
+			    ApplicationLeadAuthorId = application.ApplicationLeadAuthorId,
+			    ApplicationVersion = application.ApplicationVersion,
+			    ApplicationLeadAuthorName = application.ApplicationLeadAuthorName,
+			    ApplicationRole = application.ApplicationRole,
+			    ApplicationRoleOtherDescription = application.ApplicationRoleOtherDescription,
+			    ChangesToTrust = application.ChangesToTrust,
+			    ChangesToTrustExplained = application.ChangesToTrustExplained,
+			    ChangesToLaGovernance = application.ChangesToLaGovernance,
+			    ChangesToLaGovernanceExplained = application.ChangesToLaGovernanceExplained,
+			    FormTrustOpeningDate = application.FormTrustOpeningDate,
+			    TrustApproverName = application.TrustApproverEmail,
+			    TrustApproverEmail = application.TrustApproverEmail,
+			    TrustId = application.TrustId,
+			    FormTrustReasonApprovalToConvertAsSat = application.FormTrustReasonApprovalToConvertAsSat,
+			    FormTrustReasonApprovedPerson = application.FormTrustReasonApprovedPerson,
+			    FormTrustReasonForming = application.FormTrustReasonForming,
+			    FormTrustReasonVision = application.FormTrustReasonVision,
+			    FormTrustReasonGeoAreas = application.FormTrustReasonGeoAreas,
+			    FormTrustReasonFreedom = application.FormTrustReasonFreedom,
+			    FormTrustReasonImproveTeaching = application.FormTrustReasonImproveTeaching,
+			    FormTrustPlanForGrowth = application.FormTrustPlanForGrowth,
+			    FormTrustPlansForNoGrowth = application.FormTrustPlansForNoGrowth,
+			    FormTrustGrowthPlansYesNo = application.FormTrustGrowthPlansYesNo,
+			    FormTrustImprovementSupport = application.FormTrustImprovementSupport,
+			    FormTrustImprovementStrategy = application.FormTrustImprovementStrategy,
+			    FormTrustImprovementApprovedSponsor = application.FormTrustImprovementApprovedSponsor,
+			    Account = account
+		    };
+	    }
+    }
+}

--- a/TramsDataApi/Gateways/A2BApplicationGateway.cs
+++ b/TramsDataApi/Gateways/A2BApplicationGateway.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using TramsDataApi.DatabaseModels;
+
+namespace TramsDataApi.Gateways
+{
+    public class A2BApplicationGateway : IA2BApplicationGateway
+    {
+        private readonly TramsDbContext _tramsDbContext;
+        
+        public A2BApplicationGateway(TramsDbContext tramsDbContext)
+        {
+            _tramsDbContext = tramsDbContext;
+        }
+
+        // public ConcernsCase SaveConcernsCase(ConcernsCase concernsCase)
+        // {
+        //     _tramsDbContext.ConcernsCase.Update(concernsCase);
+        //     _tramsDbContext.SaveChanges();
+        //
+        //     return concernsCase;
+        // }
+
+        public A2BApplication GetByApplicationId(string applicationId)
+        {
+            return _tramsDbContext.A2BApplications
+                .AsNoTracking()
+                .First(a => a.ApplicationId == applicationId);
+        }
+    }
+}

--- a/TramsDataApi/Gateways/A2BApplicationGateway.cs
+++ b/TramsDataApi/Gateways/A2BApplicationGateway.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
+using TramsDataApi.RequestModels.ApplyToBecome;
 
 namespace TramsDataApi.Gateways
 {
@@ -14,19 +15,27 @@ namespace TramsDataApi.Gateways
             _tramsDbContext = tramsDbContext;
         }
 
-        // public ConcernsCase SaveConcernsCase(ConcernsCase concernsCase)
-        // {
-        //     _tramsDbContext.ConcernsCase.Update(concernsCase);
-        //     _tramsDbContext.SaveChanges();
-        //
-        //     return concernsCase;
-        // }
+        public ConcernsCase SaveConcernsCase(ConcernsCase concernsCase)
+        {
+             _tramsDbContext.ConcernsCase.Update(concernsCase);
+             _tramsDbContext.SaveChanges();
+        
+             return concernsCase;
+        }
 
-        public A2BApplication GetByApplicationId(string applicationId)
+        public A2BApplication GetByApplicationId(int applicationId)
         {
             return _tramsDbContext.A2BApplications
                 .AsNoTracking()
                 .First(a => a.ApplicationId == applicationId);
+        }
+
+        public A2BApplication CreateA2BApplication(A2BApplication application)
+        {
+            _tramsDbContext.A2BApplications.Add(application);
+            _tramsDbContext.SaveChanges();
+
+            return application;
         }
     }
 }

--- a/TramsDataApi/Gateways/IA2BApplicationGateway.cs
+++ b/TramsDataApi/Gateways/IA2BApplicationGateway.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
+using TramsDataApi.RequestModels.ApplyToBecome;
 
 namespace TramsDataApi.Gateways
 {
     public interface IA2BApplicationGateway
     {
-        A2BApplication GetByApplicationId(string applicationId);
+        A2BApplication GetByApplicationId(int applicationId);
+        A2BApplication CreateA2BApplication(A2BApplication request);
     }
 }

--- a/TramsDataApi/Gateways/IA2BApplicationGateway.cs
+++ b/TramsDataApi/Gateways/IA2BApplicationGateway.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using TramsDataApi.DatabaseModels;
+
+namespace TramsDataApi.Gateways
+{
+    public interface IA2BApplicationGateway
+    {
+        A2BApplication GetByApplicationId(string applicationId);
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/20211122170608_AddDbGeneratedIdColumnToA2BApplication.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211122170608_AddDbGeneratedIdColumnToA2BApplication.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211122170608_AddDbGeneratedIdColumnToA2BApplication")]
+    partial class AddDbGeneratedIdColumnToA2BApplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20211122170608_AddDbGeneratedIdColumnToA2BApplication.cs
+++ b/TramsDataApi/Migrations/TramsDb/20211122170608_AddDbGeneratedIdColumnToA2BApplication.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class AddDbGeneratedIdColumnToA2BApplication : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "A2BApplication",
+                schema: "sdd");
+
+            migrationBuilder.CreateTable(
+                name: "A2BApplication",
+                schema: "sdd",
+                columns: table => new
+                {
+                    ApplicationId = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(nullable: true),
+                    ApplicationType = table.Column<string>(nullable: true),
+                    FormTrustProposedNameOfTrust = table.Column<string>(nullable: true),
+                    ApplicationSubmitted = table.Column<bool>(nullable: false),
+                    ApplicationLeadAuthorId = table.Column<string>(nullable: true),
+                    ApplicationVersion = table.Column<string>(nullable: true),
+                    ApplicationLeadAuthorName = table.Column<string>(nullable: true),
+                    ApplicationRole = table.Column<string>(nullable: true),
+                    ApplicationRoleOtherDescription = table.Column<string>(nullable: true),
+                    ChangesToTrust = table.Column<int>(nullable: true),
+                    ChangesToTrustExplained = table.Column<string>(nullable: true),
+                    ChangesToLaGovernance = table.Column<int>(nullable: true),
+                    ChangesToLaGovernanceExplained = table.Column<string>(nullable: true),
+                    FormTrustOpeningDate = table.Column<DateTime>(nullable: true),
+                    TrustApproverName = table.Column<string>(nullable: true),
+                    TrustApproverEmail = table.Column<string>(nullable: true),
+                    TrustId = table.Column<string>(nullable: true),
+                    FormTrustReasonApprovalToConvertAsSat = table.Column<int>(nullable: true),
+                    FormTrustReasonApprovedPerson = table.Column<string>(nullable: true),
+                    FormTrustReasonForming = table.Column<string>(nullable: true),
+                    FormTrustReasonVision = table.Column<string>(nullable: true),
+                    FormTrustReasonGeoAreas = table.Column<string>(nullable: true),
+                    FormTrustReasonFreedom = table.Column<string>(nullable: true),
+                    FormTrustReasonImproveTeaching = table.Column<string>(nullable: true),
+                    FormTrustPlanForGrowth = table.Column<string>(nullable: true),
+                    FormTrustPlansForNoGrowth = table.Column<string>(nullable: true),
+                    FormTrustGrowthPlansYesNo = table.Column<int>(nullable: true),
+                    FormTrustImprovementSupport = table.Column<string>(nullable: true),
+                    FormTrustImprovementStrategy = table.Column<string>(nullable: true),
+                    FormTrustImprovementApprovedSponsor = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_A2BApplication", x => x.ApplicationId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "A2BApplication",
+                schema: "sdd");
+            
+            migrationBuilder.CreateTable(
+                name: "A2BApplication",
+                schema: "sdd",
+                columns: table => new
+                {
+                    ApplicationId = table.Column<string>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    ApplicationType = table.Column<string>(nullable: true),
+                    FormTrustProposedNameOfTrust = table.Column<string>(nullable: true),
+                    ApplicationSubmitted = table.Column<bool>(nullable: false),
+                    ApplicationLeadAuthorId = table.Column<string>(nullable: true),
+                    ApplicationVersion = table.Column<string>(nullable: true),
+                    ApplicationLeadAuthorName = table.Column<string>(nullable: true),
+                    ApplicationRole = table.Column<string>(nullable: true),
+                    ApplicationRoleOtherDescription = table.Column<string>(nullable: true),
+                    ChangesToTrust = table.Column<int>(nullable: true),
+                    ChangesToTrustExplained = table.Column<string>(nullable: true),
+                    ChangesToLaGovernance = table.Column<int>(nullable: true),
+                    ChangesToLaGovernanceExplained = table.Column<string>(nullable: true),
+                    FormTrustOpeningDate = table.Column<DateTime>(nullable: true),
+                    TrustApproverName = table.Column<string>(nullable: true),
+                    TrustApproverEmail = table.Column<string>(nullable: true),
+                    TrustId = table.Column<string>(nullable: true),
+                    FormTrustReasonApprovalToConvertAsSat = table.Column<int>(nullable: true),
+                    FormTrustReasonApprovedPerson = table.Column<string>(nullable: true),
+                    FormTrustReasonForming = table.Column<string>(nullable: true),
+                    FormTrustReasonVision = table.Column<string>(nullable: true),
+                    FormTrustReasonGeoAreas = table.Column<string>(nullable: true),
+                    FormTrustReasonFreedom = table.Column<string>(nullable: true),
+                    FormTrustReasonImproveTeaching = table.Column<string>(nullable: true),
+                    FormTrustPlanForGrowth = table.Column<string>(nullable: true),
+                    FormTrustPlansForNoGrowth = table.Column<string>(nullable: true),
+                    FormTrustGrowthPlansYesNo = table.Column<int>(nullable: true),
+                    FormTrustImprovementSupport = table.Column<string>(nullable: true),
+                    FormTrustImprovementStrategy = table.Column<string>(nullable: true),
+                    FormTrustImprovementApprovedSponsor = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_A2BApplication", x => x.ApplicationId);
+                });
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
+++ b/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
@@ -1,0 +1,7 @@
+namespace TramsDataApi.RequestModels.ApplyToBecome
+{
+    public class A2BApplicationByIdRequest
+    {
+        public string ApplicationId { get; set; }
+    }
+}

--- a/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
+++ b/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
@@ -2,6 +2,6 @@ namespace TramsDataApi.RequestModels.ApplyToBecome
 {
     public class A2BApplicationByIdRequest
     {
-        public string ApplicationId { get; set; }
+        public int ApplicationId { get; set; }
     }
 }

--- a/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationCreateRequest.cs
+++ b/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationCreateRequest.cs
@@ -1,15 +1,12 @@
 using System;
-using TramsDataApi.DatabaseModels;
 
-namespace TramsDataApi.ResponseModels.ApplyToBecome
+namespace TramsDataApi.RequestModels.ApplyToBecome
 {
-    public class A2BApplicationResponse
+    public class A2BApplicationCreateRequest
     {
         public string Name {get; set;}
-        public int ApplicationId {get; set;}
         public string ApplicationType {get; set;}
         public string TrustId { get; set; }
-        public A2BApplicationAccount Account { get; set; }
         public string FormTrustProposedNameOfTrust {get; set;}
         public bool ApplicationSubmitted {get; set;}
         public string ApplicationLeadAuthorId {get; set;}
@@ -37,17 +34,5 @@ namespace TramsDataApi.ResponseModels.ApplyToBecome
         public string FormTrustImprovementSupport {get; set;}
         public string FormTrustImprovementStrategy {get; set;}
         public string FormTrustImprovementApprovedSponsor {get; set;}
-        
-        public string ApplicationStatus {get; set;}
-    }
-
-    public class A2BApplicationAccount
-    {
-        public string Name { get; set; }
-        public string Urn { get; set; }
-        public string AccountId { get; set; }
-        public string Address1Composite { get; set; }
-        public string TrustCompanyNumber { get; set; }
-        public string TrustReferenceNumber { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/ApplyToBecome/A2BApplicationResponse.cs
+++ b/TramsDataApi/ResponseModels/ApplyToBecome/A2BApplicationResponse.cs
@@ -1,0 +1,52 @@
+using System;
+using TramsDataApi.DatabaseModels;
+
+namespace TramsDataApi.ResponseModels.ApplyToBecome
+{
+    public class A2BApplicationResponse
+    {
+        public string Name {get; set;}
+        public string ApplicationId {get; set;}
+        public string ApplicationType {get; set;}
+        public string TrustId { get; set; }
+        public A2BApplicationAccount Account { get; set; }
+        public string FormTrustProposedNameOfTrust {get; set;}
+        public bool ApplicationSubmitted {get; set;}
+        public string ApplicationLeadAuthorId {get; set;}
+        public string ApplicationVersion {get; set;}
+        public string ApplicationLeadAuthorName {get; set;}
+        public string ApplicationRole {get; set;}
+        public string ApplicationRoleOtherDescription {get; set;}
+        public int? ChangesToTrust {get; set;}
+        public string ChangesToTrustExplained {get; set;}
+        public int? ChangesToLaGovernance {get; set;}
+        public string ChangesToLaGovernanceExplained {get; set;}
+        public DateTime? FormTrustOpeningDate {get; set;}
+        public string TrustApproverName {get; set;}
+        public string TrustApproverEmail {get; set;}
+        public int? FormTrustReasonApprovalToConvertAsSat {get; set;}
+        public string FormTrustReasonApprovedPerson {get; set;}
+        public string FormTrustReasonForming {get; set;}
+        public string FormTrustReasonVision {get; set;}
+        public string FormTrustReasonGeoAreas {get; set;}
+        public string FormTrustReasonFreedom {get; set;}
+        public string FormTrustReasonImproveTeaching {get; set;}
+        public string FormTrustPlanForGrowth {get; set;}
+        public string FormTrustPlansForNoGrowth {get; set;}
+        public int? FormTrustGrowthPlansYesNo {get; set;}
+        public string FormTrustImprovementSupport {get; set;}
+        public string FormTrustImprovementStrategy {get; set;}
+        public string FormTrustImprovementApprovedSponsor {get; set;}
+        public string ApplicationStatus {get; set;}
+    }
+
+    public class A2BApplicationAccount
+    {
+        public string Name { get; set; }
+        public string Urn { get; set; }
+        public string AccountId { get; set; }
+        public string Address1Composite { get; set; }
+        public string TrustCompanyNumber { get; set; }
+        public string TrustReferenceNumber { get; set; }
+    }
+}

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -69,6 +69,8 @@ namespace TramsDataApi
             services.AddScoped<IIndexConcernsTypes, IndexConcernsTypes>();
             services.AddScoped<IUpdateConcernsRecord, UpdateConcernsRecord>();
             services.AddScoped<IA2BApplicationGateway, A2BApplicationGateway>();
+            services.AddScoped<IGetA2BApplication, GetA2BApplication>();
+            services.AddScoped<ICreateA2BApplication, CreateA2BApplication>();
 
             
             // this is a temporary solution to move academy conversion projects from mstr.IfdPipeline to sdd.AcademyConversionProject

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -68,6 +68,7 @@ namespace TramsDataApi
             services.AddScoped<IUpdateConcernsCase, UpdateConcernsCase>();
             services.AddScoped<IIndexConcernsTypes, IndexConcernsTypes>();
             services.AddScoped<IUpdateConcernsRecord, UpdateConcernsRecord>();
+            services.AddScoped<IA2BApplicationGateway, A2BApplicationGateway>();
 
             
             // this is a temporary solution to move academy conversion projects from mstr.IfdPipeline to sdd.AcademyConversionProject

--- a/TramsDataApi/UseCases/CreateA2BApplication.cs
+++ b/TramsDataApi/UseCases/CreateA2BApplication.cs
@@ -1,0 +1,27 @@
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+
+namespace TramsDataApi.UseCases
+{
+    public class CreateA2BApplication : ICreateA2BApplication
+    {
+        private readonly IA2BApplicationGateway _gateway;
+
+        public CreateA2BApplication(IA2BApplicationGateway gateway)
+        {
+            _gateway = gateway;
+        }
+
+        public A2BApplicationResponse Execute(A2BApplicationCreateRequest request)
+        {
+            var applicationToCreate = A2BApplicationFactory.Create(request);
+            var createdApplication = _gateway.CreateA2BApplication(applicationToCreate);
+            return A2BApplicationResponseFactory.Create(createdApplication, null);
+        }
+        
+    }
+}

--- a/TramsDataApi/UseCases/GetA2BApplication.cs
+++ b/TramsDataApi/UseCases/GetA2BApplication.cs
@@ -1,0 +1,32 @@
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+
+namespace TramsDataApi.UseCases
+{
+    public class GetA2BApplication : IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>
+    {
+        private readonly IA2BApplicationGateway _applicationGateway;
+
+        public GetA2BApplication(IA2BApplicationGateway applicationGateway)
+        {
+            _applicationGateway = applicationGateway;
+        }
+
+
+        public A2BApplicationResponse Execute(A2BApplicationByIdRequest request)
+        {
+            if (request == null) return null;
+            
+            var application = _applicationGateway.GetByApplicationId(request.ApplicationId);
+            A2BApplicationAccount account = null;
+            
+            //Need to pass in A2BAccountDetails once we know how to source this data
+            return application != null 
+                ? A2BApplicationResponseFactory.Create(application , account) 
+                : null;
+        }
+    }
+}

--- a/TramsDataApi/UseCases/GetA2BApplication.cs
+++ b/TramsDataApi/UseCases/GetA2BApplication.cs
@@ -6,7 +6,7 @@ using TramsDataApi.ResponseModels.ApplyToBecome;
 
 namespace TramsDataApi.UseCases
 {
-    public class GetA2BApplication : IUseCase<A2BApplicationByIdRequest, A2BApplicationResponse>
+    public class GetA2BApplication : IGetA2BApplication
     {
         private readonly IA2BApplicationGateway _applicationGateway;
 

--- a/TramsDataApi/UseCases/ICreateA2BApplication.cs
+++ b/TramsDataApi/UseCases/ICreateA2BApplication.cs
@@ -1,0 +1,10 @@
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+
+namespace TramsDataApi.UseCases
+{
+    public interface ICreateA2BApplication
+    {
+        A2BApplicationResponse Execute(A2BApplicationCreateRequest request);
+    }
+}

--- a/TramsDataApi/UseCases/IGetA2BApplication.cs
+++ b/TramsDataApi/UseCases/IGetA2BApplication.cs
@@ -1,0 +1,10 @@
+using TramsDataApi.RequestModels.ApplyToBecome;
+using TramsDataApi.ResponseModels.ApplyToBecome;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IGetA2BApplication
+    {
+        A2BApplicationResponse Execute(A2BApplicationByIdRequest request);
+    }
+}


### PR DESCRIPTION
In this PR:

Add the `apply-to-become/application/{ApplicationId}` route to get A2B applications by ApplicationId
Add the `apply-to-become/application` POST route to create A2B applications
Add the gateway methods to Create / Retrieve applications
Add the use case to get A2B applications by Application Id
Add the use case to create A2B Applications from request
Add Factory methods to create the associated models for Create / Retrieve applications

Add Migration to change table `sdd.A2BApplication` to an identity column

Add Associated unit / integration tests for the changes detailed above