### PR TITLE
Remove unneeded request models from A2BApplication and A2BApplicationKeyPersons

### DIFF
--- a/TramsDataApi.Test/Controllers/A2BApplicationControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/A2BApplicationControllerTests.cs
@@ -25,7 +25,7 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetApplicationByApplicationId_ReturnsApiSingleResponseWithApplicationWhenApplicationExists()
         {
-            var applicationId = 10001;
+            const int applicationId = 10001;
             var mockUseCase = new Mock<IGetA2BApplication>();
 
             var response = Builder<A2BApplicationResponse>
@@ -36,7 +36,7 @@ namespace TramsDataApi.Test.Controllers
             var expectedResponse = new ApiSingleResponseV2<A2BApplicationResponse>(response);
 
             mockUseCase
-                .Setup(x => x.Execute(It.IsAny<A2BApplicationByIdRequest>()))
+                .Setup(x => x.Execute(It.IsAny<int>()))
                 .Returns(response);
 
             var controller = new A2BApplicationController(_mockLogger.Object, mockUseCase.Object, new Mock<ICreateA2BApplication>().Object);

--- a/TramsDataApi.Test/Controllers/A2BApplicationKeyPersonsControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/A2BApplicationKeyPersonsControllerTests.cs
@@ -36,7 +36,7 @@ namespace TramsDataApi.Test.Controllers
             var expectedResponse = new ApiSingleResponseV2<A2BApplicationKeyPersonsResponse>(response);
 
             mockUseCase
-                .Setup(x => x.Execute(It.IsAny<A2BApplicationKeyPersonsByIdRequest>()))
+                .Setup(x => x.Execute(It.IsAny<int>()))
                 .Returns(response);
 
             var controller = new A2BApplicationKeyPersonsController(_mockLogger.Object, mockUseCase.Object,new Mock<ICreateA2BApplicationKeyPersons>().Object);

--- a/TramsDataApi.Test/UseCases/GetA2BApplicationKeyPersonsTests.cs
+++ b/TramsDataApi.Test/UseCases/GetA2BApplicationKeyPersonsTests.cs
@@ -13,26 +13,15 @@ namespace TramsDataApi.Test.UseCases
     public class GetA2BApplicationKeyPersonsTests
     {
         [Fact]
-        public void GetA2BApplicationKeyPersons_ShouldReturnNull_WhenA2BApplicationKeyPersonsRequestByIdIsNull()
-        {
-            var mockGateway = new Mock<IA2BApplicationKeyPersonsGateway>();
-            
-            var useCase = new GetA2BApplicationKeyPersons(mockGateway.Object);
-            var result = useCase.Execute(null);
-
-            result.Should().BeNull();
-        }
-        
-        [Fact]
         public void GetA2BApplicationKeyPersons_ShouldReturnNull_WhenKeyPersonsIdIsNotFound()
         {
-            var applicationId = 10001;
+            const int applicationId = 10001;
             var mockGateway = new Mock<IA2BApplicationKeyPersonsGateway>();
 
             mockGateway.Setup(g => g.GetByKeyPersonsId(applicationId));
            
             var useCase = new GetA2BApplicationKeyPersons(mockGateway.Object);
-            var result = useCase.Execute(null);
+            var result = useCase.Execute(applicationId);
 
             result.Should().BeNull();
         }
@@ -40,23 +29,20 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetA2BApplicationKeyPersons_ShouldReturnA2BApplicationKeyPersonsResponse_WhenKeyPersonsIdIsFound()
         {
-            var keyPersonsId = 10001;
+            const int keyPersonsId = 10001;
             var mockGateway = new Mock<IA2BApplicationKeyPersonsGateway>();
             var keyPersons = Builder<A2BApplicationKeyPersons>
                 .CreateNew()
                 .With(a => a.KeyPersonId == keyPersonsId)
                 .Build();
 
-            var request = new A2BApplicationKeyPersonsByIdRequest
-            {
-                KeyPersonId = keyPersonsId
-            };
+           
             var expected = A2BApplicationKeyPersonsResponseFactory.Create(keyPersons);
 
             mockGateway.Setup(g => g.GetByKeyPersonsId(keyPersonsId)).Returns(keyPersons);
             
             var useCase = new GetA2BApplicationKeyPersons(mockGateway.Object);
-            var result = useCase.Execute(request);
+            var result = useCase.Execute(keyPersonsId);
             
             result.Should().BeEquivalentTo(expected);
         }

--- a/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
+++ b/TramsDataApi.Test/UseCases/GetA2BApplicationTests.cs
@@ -15,26 +15,15 @@ namespace TramsDataApi.Test.UseCases
     public class GetA2BApplicationTests
     {
         [Fact]
-        public void GetA2BApplication_ShouldReturnNull_WhenA2BApplicationRequestByIdIsNull()
-        {
-            var mockGateway = new Mock<IA2BApplicationGateway>();
-            
-            var useCase = new GetA2BApplication(mockGateway.Object);
-            var result = useCase.Execute(null);
-
-            result.Should().BeNull();
-        }
-        
-        [Fact]
         public void GetA2BApplication_ShouldReturnNull_WhenApplicationIdIsNotFound()
         {
-            var applicationId = 10001;
+            const int applicationId = 10001;
             var mockGateway = new Mock<IA2BApplicationGateway>();
 
             mockGateway.Setup(g => g.GetByApplicationId(applicationId));
            
             var useCase = new GetA2BApplication(mockGateway.Object);
-            var result = useCase.Execute(null);
+            var result = useCase.Execute(applicationId);
 
             result.Should().BeNull();
         }
@@ -42,23 +31,19 @@ namespace TramsDataApi.Test.UseCases
         [Fact]
         public void GetA2BApplication_ShouldReturnA2BApplicationResponse_WhenApplicationIdIsFound()
         {
-            var applicationId = 10001;
+            const int applicationId = 10001;
             var mockGateway = new Mock<IA2BApplicationGateway>();
             var application = Builder<A2BApplication>
                 .CreateNew()
                 .With(a => a.ApplicationId == applicationId)
                 .Build();
 
-            var request = new A2BApplicationByIdRequest
-            {
-                ApplicationId = applicationId
-            };
             var expected = A2BApplicationResponseFactory.Create(application, null);
 
             mockGateway.Setup(g => g.GetByApplicationId(applicationId)).Returns(application);
             
             var useCase = new GetA2BApplication(mockGateway.Object);
-            var result = useCase.Execute(request);
+            var result = useCase.Execute(applicationId);
             
             result.Should().BeEquivalentTo(expected);
         }

--- a/TramsDataApi/Controllers/V2/A2BApplicationController.cs
+++ b/TramsDataApi/Controllers/V2/A2BApplicationController.cs
@@ -34,8 +34,7 @@ namespace TramsDataApi.Controllers.V2
         public ActionResult<ApiSingleResponseV2<A2BApplicationResponse>> GetApplicationByApplicationId(int applicationId)
         {
             _logger.LogInformation("Attempting to get ApplyToBecome Application by ApplicationId {applicationId}", applicationId);
-            var request = new A2BApplicationByIdRequest {ApplicationId = applicationId};
-            var application = _getA2BApplicationById.Execute(request);
+            var application = _getA2BApplicationById.Execute(applicationId);
             
             if (application == null)
             {

--- a/TramsDataApi/Controllers/V2/A2BApplicationKeyPersonsController.cs
+++ b/TramsDataApi/Controllers/V2/A2BApplicationKeyPersonsController.cs
@@ -34,9 +34,8 @@ namespace TramsDataApi.Controllers.V2
         public ActionResult<ApiSingleResponseV2<A2BApplicationKeyPersonsResponse>> GetApplicationKeyPersonByKeyPersonId(int keyPersonId)
         {
             _logger.LogInformation("Attempting to get ApplyToBecome ApplicationKeyPerson by KeyPersonId {keyPersonId}", keyPersonId);
-            var request = new A2BApplicationKeyPersonsByIdRequest() {KeyPersonId = keyPersonId};
-            
-            var keyPerson = _getA2BApplicationKeyPersons.Execute(request);
+             
+            var keyPerson = _getA2BApplicationKeyPersons.Execute(keyPersonId);
             
             if (keyPerson == null)
             {

--- a/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
+++ b/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationByIdRequest.cs
@@ -1,7 +1,0 @@
-namespace TramsDataApi.RequestModels.ApplyToBecome
-{
-    public class A2BApplicationByIdRequest
-    {
-        public int ApplicationId { get; set; }
-    }
-}

--- a/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationKeyPersonsByIdRequest.cs
+++ b/TramsDataApi/RequestModels/ApplyToBecome/A2BApplicationKeyPersonsByIdRequest.cs
@@ -1,7 +1,0 @@
-namespace TramsDataApi.RequestModels.ApplyToBecome
-{
-    public class A2BApplicationKeyPersonsByIdRequest
-    {
-        public int KeyPersonId { get; set; }
-    }
-}

--- a/TramsDataApi/UseCases/GetA2BApplication.cs
+++ b/TramsDataApi/UseCases/GetA2BApplication.cs
@@ -16,11 +16,9 @@ namespace TramsDataApi.UseCases
         }
 
 
-        public A2BApplicationResponse Execute(A2BApplicationByIdRequest request)
+        public A2BApplicationResponse Execute(int applicationId)
         {
-            if (request == null) return null;
-            
-            var application = _applicationGateway.GetByApplicationId(request.ApplicationId);
+            var application = _applicationGateway.GetByApplicationId(applicationId);
             A2BApplicationAccount account = null;
             
             //Need to pass in A2BAccountDetails once we know how to source this data

--- a/TramsDataApi/UseCases/GetA2BApplicationKeyPersons.cs
+++ b/TramsDataApi/UseCases/GetA2BApplicationKeyPersons.cs
@@ -14,11 +14,9 @@ namespace TramsDataApi.UseCases
             _keyPersonsGateway = keyPersonsGateway;
         }
 
-        public A2BApplicationKeyPersonsResponse Execute(A2BApplicationKeyPersonsByIdRequest request)
+        public A2BApplicationKeyPersonsResponse Execute(int keyPersonId)
         {
-            if (request == null) return null;
-            
-            var keyPersons = _keyPersonsGateway.GetByKeyPersonsId(request.KeyPersonId);
+            var keyPersons = _keyPersonsGateway.GetByKeyPersonsId(keyPersonId);
 
             return keyPersons != null 
                 ? A2BApplicationKeyPersonsResponseFactory.Create(keyPersons) 

--- a/TramsDataApi/UseCases/IGetA2BApplication.cs
+++ b/TramsDataApi/UseCases/IGetA2BApplication.cs
@@ -5,6 +5,6 @@ namespace TramsDataApi.UseCases
 {
     public interface IGetA2BApplication
     {
-        A2BApplicationResponse Execute(A2BApplicationByIdRequest request);
+        A2BApplicationResponse Execute(int applicationId);
     }
 }

--- a/TramsDataApi/UseCases/IGetA2BApplicationKeyPersons.cs
+++ b/TramsDataApi/UseCases/IGetA2BApplicationKeyPersons.cs
@@ -5,6 +5,6 @@ namespace TramsDataApi.UseCases
 {
     public interface IGetA2BApplicationKeyPersons
     {
-        A2BApplicationKeyPersonsResponse Execute(A2BApplicationKeyPersonsByIdRequest request);
+        A2BApplicationKeyPersonsResponse Execute(int keyPersonsId);
     }
 }


### PR DESCRIPTION
Delete A2BApplicationByIdRequest.cs and A2BApplicationKeyPersonsByIdRequest
Adjust code to use int Id rather than request model