### PR TITLE
Feature/87756 add additional information fields for Academy Transfers

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -81,7 +81,12 @@ namespace TramsDataApi.Test.Factories
                     .Select(t => new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = t.OutgoingAcademyUkprn,
-                        IncomingTrustUkprn = null
+                        IncomingTrustUkprn = null,
+                        LatestOfstedReportAdditionalInformation = null,
+                        PupilNumbersAdditionalInformation = null,
+                        KeyStage2PerformanceAdditionalInformation = null,
+                        KeyStage4PerformanceAdditionalInformation = null,
+                        KeyStage5PerformanceAdditionalInformation = null
                     })
                     .ToList()
             };
@@ -281,7 +286,13 @@ namespace TramsDataApi.Test.Factories
                 new TransferringAcademiesRequest
                 {
                     OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
-                    IncomingTrustUkprn = ta.IncomingTrustUkprn
+                    IncomingTrustUkprn = ta.IncomingTrustUkprn,
+                    LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                    PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                    KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                    KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                    KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
+                    
                 }).ToList();
             transferringAcademiesRequests.ElementAt(0).OutgoingAcademyUkprn = "12385731";
 

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -13,13 +13,12 @@ namespace TramsDataApi.Test.Factories
 {
     public class AcademyTransferProjectFactoryTests
     {
-
         [Fact]
         public void ReturnsAnAcademyTransferProject_WhenGivenAnInitialAcademyTransferProjectRequest()
         {
             var randomGenerator = new RandomGenerator();
             var createRequest = Builder<AcademyTransferProjectRequest>.CreateNew()
-                .With(c => c.OutgoingTrustUkprn = randomGenerator.NextString(8,8))
+                .With(c => c.OutgoingTrustUkprn = randomGenerator.NextString(8, 8))
                 .With(c => c.Status = null)
                 .With(c => c.State = null)
                 .With(c => c.GeneralInformation = null)
@@ -33,13 +32,19 @@ namespace TramsDataApi.Test.Factories
                 .With(c => c.KeyStage2PerformanceAdditionalInformation = null)
                 .With(c => c.KeyStage4PerformanceAdditionalInformation = null)
                 .With(c => c.KeyStage5PerformanceAdditionalInformation = null)
-                .With(c => c.TransferringAcademies = (List<TransferringAcademiesRequest>) Builder<TransferringAcademiesRequest>
-                    .CreateListOfSize(5)
-                    .All()
-                    .With(t => t.OutgoingAcademyUkprn = randomGenerator.NextString(8,8))
-                    .With(t => t.IncomingTrustUkprn = null).Build())
+                .With(c => c.TransferringAcademies =
+                    (List<TransferringAcademiesRequest>) Builder<TransferringAcademiesRequest>
+                        .CreateListOfSize(5)
+                        .All()
+                        .With(t => t.OutgoingAcademyUkprn = randomGenerator.NextString(8, 8))
+                        .With(t => t.IncomingTrustUkprn = null)
+                        .With(t => t.PupilNumbersAdditionalInformation = null)
+                        .With(t => t.LatestOfstedReportAdditionalInformation = null)
+                        .With(t => t.KeyStage2PerformanceAdditionalInformation = null)
+                        .With(t => t.KeyStage4PerformanceAdditionalInformation = null)
+                        .With(t => t.KeyStage5PerformanceAdditionalInformation = null).Build())
                 .Build();
-            
+
             var expected = new AcademyTransferProjects
             {
                 ProjectReference = createRequest.ProjectReference,
@@ -73,10 +78,14 @@ namespace TramsDataApi.Test.Factories
                 KeyStage4PerformanceAdditionalInformation = null,
                 KeyStage5PerformanceAdditionalInformation = null,
                 TransferringAcademies = createRequest.TransferringAcademies
-                    .Select(t => new TransferringAcademies { OutgoingAcademyUkprn = t.OutgoingAcademyUkprn, IncomingTrustUkprn = null })
+                    .Select(t => new TransferringAcademies
+                    {
+                        OutgoingAcademyUkprn = t.OutgoingAcademyUkprn,
+                        IncomingTrustUkprn = null
+                    })
                     .ToList()
             };
-            
+
             var result = AcademyTransferProjectFactory.Create(createRequest);
 
             result.Should().BeEquivalentTo(expected);
@@ -89,13 +98,13 @@ namespace TramsDataApi.Test.Factories
 
             var benefitsRequest = Builder<AcademyTransferProjectBenefitsRequest>.CreateNew()
                 .With(b => b.IntendedTransferBenefits = Builder<IntendedTransferBenefitRequest>.CreateNew()
-                    .With(i => i.SelectedBenefits =  new List<string>()).Build())
+                    .With(i => i.SelectedBenefits = new List<string>()).Build())
                 .With(b => b.OtherFactorsToConsider = Builder<OtherFactorsToConsiderRequest>.CreateNew()
                     .With(o => o.ComplexLandAndBuilding = Builder<BenefitConsideredFactorRequest>.CreateNew().Build())
                     .With(o => o.FinanceAndDebt = Builder<BenefitConsideredFactorRequest>.CreateNew().Build())
                     .With(o => o.HighProfile = Builder<BenefitConsideredFactorRequest>.CreateNew().Build()).Build())
                 .Build();
-            
+
             var datesRequest = Builder<AcademyTransferProjectDatesRequest>.CreateNew()
                 .With(d => d.TransferFirstDiscussed =
                     randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture))
@@ -106,16 +115,18 @@ namespace TramsDataApi.Test.Factories
                 .With(d => d.HasHtbDate = true)
                 .With(d => d.HasTargetDateForTransfer = true)
                 .Build();
-            
+
             var createRequest = Builder<AcademyTransferProjectRequest>.CreateNew()
-                .With(c => c.OutgoingTrustUkprn = randomGenerator.NextString(8,8))
+                .With(c => c.OutgoingTrustUkprn = randomGenerator.NextString(8, 8))
                 .With(c => c.Benefits = benefitsRequest)
                 .With(c => c.Dates = datesRequest)
                 .With(c => c.Rationale = Builder<AcademyTransferProjectRationaleRequest>.CreateNew().Build())
-                .With(c => c.GeneralInformation = Builder<AcademyTransferProjectGeneralInformationRequest>.CreateNew().Build())
+                .With(c => c.GeneralInformation =
+                    Builder<AcademyTransferProjectGeneralInformationRequest>.CreateNew().Build())
                 .With(c => c.Features = Builder<AcademyTransferProjectFeaturesRequest>.CreateNew().Build())
-                .With(c => c.TransferringAcademies = (List<TransferringAcademiesRequest>) Builder<TransferringAcademiesRequest>
-                    .CreateListOfSize(5).Build())
+                .With(c => c.TransferringAcademies =
+                    (List<TransferringAcademiesRequest>) Builder<TransferringAcademiesRequest>
+                        .CreateListOfSize(5).Build())
                 .Build();
 
             var expected = new AcademyTransferProjects
@@ -127,8 +138,10 @@ namespace TramsDataApi.Test.Factories
                 RddOrEsfaInterventionDetail = createRequest.Features.RddOrEsfaInterventionDetail,
                 TypeOfTransfer = createRequest.Features.TypeOfTransfer,
                 OtherTransferTypeDescription = createRequest.Features.OtherTransferTypeDescription,
-                TransferFirstDiscussed = DateTime.ParseExact(createRequest.Dates.TransferFirstDiscussed, "dd/MM/yyyy", CultureInfo.InvariantCulture),
-                TargetDateForTransfer = DateTime.ParseExact(createRequest.Dates.TargetDateForTransfer, "dd/MM/yyyy", CultureInfo.InvariantCulture),
+                TransferFirstDiscussed = DateTime.ParseExact(createRequest.Dates.TransferFirstDiscussed, "dd/MM/yyyy",
+                    CultureInfo.InvariantCulture),
+                TargetDateForTransfer = DateTime.ParseExact(createRequest.Dates.TargetDateForTransfer, "dd/MM/yyyy",
+                    CultureInfo.InvariantCulture),
                 HtbDate = DateTime.ParseExact(createRequest.Dates.HtbDate, "dd/MM/yyyy", CultureInfo.InvariantCulture),
                 HasHtbDate = createRequest.Dates.HasHtbDate,
                 HasTransferFirstDiscussedDate = createRequest.Dates.HasTransferFirstDiscussedDate,
@@ -139,12 +152,18 @@ namespace TramsDataApi.Test.Factories
                 Status = createRequest.Status,
                 Author = createRequest.GeneralInformation.Author,
                 Recommendation = createRequest.GeneralInformation.Recommendation,
-                HighProfileShouldBeConsidered = createRequest.Benefits.OtherFactorsToConsider.HighProfile.ShouldBeConsidered,
-                HighProfileFurtherSpecification = createRequest.Benefits.OtherFactorsToConsider.HighProfile.FurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = createRequest.Benefits.OtherFactorsToConsider.ComplexLandAndBuilding.ShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = createRequest.Benefits.OtherFactorsToConsider.ComplexLandAndBuilding.FurtherSpecification,
-                FinanceAndDebtShouldBeConsidered = createRequest.Benefits.OtherFactorsToConsider.FinanceAndDebt.ShouldBeConsidered,
-                FinanceAndDebtFurtherSpecification = createRequest.Benefits.OtherFactorsToConsider.FinanceAndDebt.FurtherSpecification,
+                HighProfileShouldBeConsidered =
+                    createRequest.Benefits.OtherFactorsToConsider.HighProfile.ShouldBeConsidered,
+                HighProfileFurtherSpecification =
+                    createRequest.Benefits.OtherFactorsToConsider.HighProfile.FurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered = createRequest.Benefits.OtherFactorsToConsider
+                    .ComplexLandAndBuilding.ShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification = createRequest.Benefits.OtherFactorsToConsider
+                    .ComplexLandAndBuilding.FurtherSpecification,
+                FinanceAndDebtShouldBeConsidered =
+                    createRequest.Benefits.OtherFactorsToConsider.FinanceAndDebt.ShouldBeConsidered,
+                FinanceAndDebtFurtherSpecification =
+                    createRequest.Benefits.OtherFactorsToConsider.FinanceAndDebt.FurtherSpecification,
                 OtherBenefitValue = createRequest.Benefits.IntendedTransferBenefits.OtherBenefitValue,
                 AcademyPerformanceAdditionalInformation = createRequest.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = createRequest.PupilNumbersAdditionalInformation,
@@ -152,10 +171,20 @@ namespace TramsDataApi.Test.Factories
                 KeyStage2PerformanceAdditionalInformation = createRequest.KeyStage2PerformanceAdditionalInformation,
                 KeyStage4PerformanceAdditionalInformation = createRequest.KeyStage4PerformanceAdditionalInformation,
                 KeyStage5PerformanceAdditionalInformation = createRequest.KeyStage5PerformanceAdditionalInformation,
-                AcademyTransferProjectIntendedTransferBenefits = createRequest.Benefits.IntendedTransferBenefits.SelectedBenefits
-                    .Select(b => new AcademyTransferProjectIntendedTransferBenefits { SelectedBenefit = b }).ToList(),
+                AcademyTransferProjectIntendedTransferBenefits = createRequest.Benefits.IntendedTransferBenefits
+                    .SelectedBenefits
+                    .Select(b => new AcademyTransferProjectIntendedTransferBenefits {SelectedBenefit = b}).ToList(),
                 TransferringAcademies = createRequest.TransferringAcademies
-                    .Select(t => new TransferringAcademies { OutgoingAcademyUkprn = t.OutgoingAcademyUkprn, IncomingTrustUkprn = t.IncomingTrustUkprn })
+                    .Select(t => new TransferringAcademies
+                    {
+                        OutgoingAcademyUkprn = t.OutgoingAcademyUkprn,
+                        IncomingTrustUkprn = t.IncomingTrustUkprn,
+                        PupilNumbersAdditionalInformation = t.PupilNumbersAdditionalInformation,
+                        LatestOfstedReportAdditionalInformation = t.LatestOfstedReportAdditionalInformation,
+                        KeyStage2PerformanceAdditionalInformation = t.KeyStage2PerformanceAdditionalInformation,
+                        KeyStage4PerformanceAdditionalInformation = t.KeyStage4PerformanceAdditionalInformation,
+                        KeyStage5PerformanceAdditionalInformation = t.KeyStage5PerformanceAdditionalInformation
+                    })
                     .ToList()
             };
 
@@ -181,7 +210,8 @@ namespace TramsDataApi.Test.Factories
             var updateRequest = new AcademyTransferProjectRequest
             {
                 OutgoingTrustUkprn = "12312354",
-                Rationale = new AcademyTransferProjectRationaleRequest {
+                Rationale = new AcademyTransferProjectRationaleRequest
+                {
                     ProjectRationale = "A new rationale for the project"
                 }
             };
@@ -189,7 +219,7 @@ namespace TramsDataApi.Test.Factories
             var expected = new AcademyTransferProjects
             {
                 Id = academyTransferProject.Id,
-                Urn = academyTransferProject.Urn, 
+                Urn = academyTransferProject.Urn,
                 ProjectReference = academyTransferProject.ProjectReference,
                 OutgoingTrustUkprn = updateRequest.OutgoingTrustUkprn,
                 ProjectRationale = updateRequest.Rationale.ProjectRationale,
@@ -209,25 +239,33 @@ namespace TramsDataApi.Test.Factories
                 Recommendation = academyTransferProject.Recommendation,
                 HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
                 HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered =
+                    academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification =
+                    academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
                 FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
                 FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
                 OtherBenefitValue = academyTransferProject.OtherBenefitValue,
-                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
-                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits =
+                    academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
                 HasHtbDate = academyTransferProject.HasHtbDate,
                 HasTargetDateForTransfer = academyTransferProject.HasTargetDateForTransfer
             };
 
             var result = AcademyTransferProjectFactory.Update(academyTransferProject, updateRequest);
-            
+
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -239,13 +277,14 @@ namespace TramsDataApi.Test.Factories
                 .With(atp => atp.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(5).Build())
                 .Build();
 
-            var transferringAcademiesRequests = academyTransferProject.TransferringAcademies.Select(ta => new TransferringAcademiesRequest
-            {
-                OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
-                IncomingTrustUkprn = ta.IncomingTrustUkprn
-            }).ToList();
+            var transferringAcademiesRequests = academyTransferProject.TransferringAcademies.Select(ta =>
+                new TransferringAcademiesRequest
+                {
+                    OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
+                    IncomingTrustUkprn = ta.IncomingTrustUkprn
+                }).ToList();
             transferringAcademiesRequests.ElementAt(0).OutgoingAcademyUkprn = "12385731";
-            
+
             var updateRequest = new AcademyTransferProjectRequest
             {
                 OutgoingTrustUkprn = "12387123",
@@ -261,7 +300,7 @@ namespace TramsDataApi.Test.Factories
             var expected = new AcademyTransferProjects
             {
                 Id = academyTransferProject.Id,
-                Urn = academyTransferProject.Urn,  
+                Urn = academyTransferProject.Urn,
                 ProjectReference = academyTransferProject.ProjectReference,
                 OutgoingTrustUkprn = updateRequest.OutgoingTrustUkprn,
                 ProjectRationale = academyTransferProject.ProjectRationale,
@@ -281,18 +320,26 @@ namespace TramsDataApi.Test.Factories
                 Recommendation = academyTransferProject.Recommendation,
                 HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
                 HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered =
+                    academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification =
+                    academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
                 FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
                 FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
                 OtherBenefitValue = academyTransferProject.OtherBenefitValue,
-                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
-                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits =
+                    academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
                 HasTargetDateForTransfer = academyTransferProject.HasTargetDateForTransfer
@@ -309,12 +356,13 @@ namespace TramsDataApi.Test.Factories
             var academyTransferProject = Builder<AcademyTransferProjects>
                 .CreateNew()
                 .With(atp =>
-                    atp.AcademyTransferProjectIntendedTransferBenefits = Builder<AcademyTransferProjectIntendedTransferBenefits>.CreateListOfSize(5).Build())
+                    atp.AcademyTransferProjectIntendedTransferBenefits =
+                        Builder<AcademyTransferProjectIntendedTransferBenefits>.CreateListOfSize(5).Build())
                 .Build();
 
             var updatedBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits
-                            .Select(benefit => benefit.SelectedBenefit)
-                            .ToList();
+                .Select(benefit => benefit.SelectedBenefit)
+                .ToList();
             updatedBenefits.Insert(0, "A completely new benefit");
 
             var updateRequest = new AcademyTransferProjectRequest
@@ -330,13 +378,14 @@ namespace TramsDataApi.Test.Factories
             };
 
             var expectedBenefits = updateRequest.Benefits.IntendedTransferBenefits.SelectedBenefits
-                .Select(selectedBenefit => new AcademyTransferProjectIntendedTransferBenefits { SelectedBenefit = selectedBenefit })
+                .Select(selectedBenefit => new AcademyTransferProjectIntendedTransferBenefits
+                    {SelectedBenefit = selectedBenefit})
                 .ToList();
 
-             var expected = new AcademyTransferProjects
+            var expected = new AcademyTransferProjects
             {
                 Id = academyTransferProject.Id,
-                Urn = academyTransferProject.Urn, 
+                Urn = academyTransferProject.Urn,
                 ProjectReference = academyTransferProject.ProjectReference,
                 OutgoingTrustUkprn = academyTransferProject.OutgoingTrustUkprn,
                 ProjectRationale = academyTransferProject.ProjectRationale,
@@ -356,17 +405,24 @@ namespace TramsDataApi.Test.Factories
                 Recommendation = academyTransferProject.Recommendation,
                 HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
                 HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered =
+                    academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification =
+                    academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
                 FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
                 FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
                 OtherBenefitValue = academyTransferProject.OtherBenefitValue,
-                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits = expectedBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
@@ -377,7 +433,7 @@ namespace TramsDataApi.Test.Factories
 
             result.Should().BeEquivalentTo(expected);
         }
-        
+
         [Fact]
         public void ReturnsUpdatedAcademyTransferProject_WhenUpdating_IfRequestIsToSetDatesBackToNull()
         {
@@ -398,7 +454,7 @@ namespace TramsDataApi.Test.Factories
             var expected = new AcademyTransferProjects
             {
                 Id = academyTransferProject.Id,
-                Urn = academyTransferProject.Urn,  
+                Urn = academyTransferProject.Urn,
                 ProjectReference = academyTransferProject.ProjectReference,
                 OutgoingTrustUkprn = academyTransferProject.OutgoingTrustUkprn,
                 ProjectRationale = academyTransferProject.ProjectRationale,
@@ -418,18 +474,26 @@ namespace TramsDataApi.Test.Factories
                 Recommendation = academyTransferProject.Recommendation,
                 HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
                 HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered =
+                    academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification =
+                    academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
                 FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
                 FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
                 OtherBenefitValue = academyTransferProject.OtherBenefitValue,
-                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
-                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits =
+                    academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,
                 HasHtbDate = false,
                 HasTargetDateForTransfer = false
@@ -439,12 +503,12 @@ namespace TramsDataApi.Test.Factories
 
             result.Should().BeEquivalentTo(expected);
         }
-        
+
         [Fact]
         public void ReturnsOriginalAcademyTransferProjectWithDatesSetToNull_WhenUpdating_IfHasDateFieldsAreFalse()
         {
             var randomGenerator = new RandomGenerator();
-            
+
             var academyTransferProject = Builder<AcademyTransferProjects>
                 .CreateNew()
                 .Build();
@@ -453,8 +517,10 @@ namespace TramsDataApi.Test.Factories
             {
                 Dates = new AcademyTransferProjectDatesRequest
                 {
-                    TargetDateForTransfer = randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
-                    TransferFirstDiscussed = randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+                    TargetDateForTransfer =
+                        randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+                    TransferFirstDiscussed =
+                        randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                     HtbDate = randomGenerator.DateTime().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                     HasHtbDate = false,
                     HasTargetDateForTransfer = false,
@@ -465,7 +531,7 @@ namespace TramsDataApi.Test.Factories
             var expected = new AcademyTransferProjects
             {
                 Id = academyTransferProject.Id,
-                Urn = academyTransferProject.Urn, 
+                Urn = academyTransferProject.Urn,
                 ProjectReference = academyTransferProject.ProjectReference,
                 OutgoingTrustUkprn = academyTransferProject.OutgoingTrustUkprn,
                 ProjectRationale = academyTransferProject.ProjectRationale,
@@ -485,18 +551,26 @@ namespace TramsDataApi.Test.Factories
                 Recommendation = academyTransferProject.Recommendation,
                 HighProfileShouldBeConsidered = academyTransferProject.HighProfileShouldBeConsidered,
                 HighProfileFurtherSpecification = academyTransferProject.HighProfileFurtherSpecification,
-                ComplexLandAndBuildingShouldBeConsidered = academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
-                ComplexLandAndBuildingFurtherSpecification = academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
+                ComplexLandAndBuildingShouldBeConsidered =
+                    academyTransferProject.ComplexLandAndBuildingShouldBeConsidered,
+                ComplexLandAndBuildingFurtherSpecification =
+                    academyTransferProject.ComplexLandAndBuildingFurtherSpecification,
                 FinanceAndDebtShouldBeConsidered = academyTransferProject.FinanceAndDebtShouldBeConsidered,
                 FinanceAndDebtFurtherSpecification = academyTransferProject.FinanceAndDebtFurtherSpecification,
                 OtherBenefitValue = academyTransferProject.OtherBenefitValue,
-                AcademyPerformanceAdditionalInformation = academyTransferProject.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProject.KeyStage5PerformanceAdditionalInformation,
-                AcademyTransferProjectIntendedTransferBenefits = academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
+                AcademyTransferProjectIntendedTransferBenefits =
+                    academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,
                 HasHtbDate = false,
                 HasTargetDateForTransfer = false

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -305,7 +305,12 @@ namespace TramsDataApi.Test.Factories
             var expectedTransferringAcademies = transferringAcademiesRequests.Select(ta => new TransferringAcademies
             {
                 OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
-                IncomingTrustUkprn = ta.IncomingTrustUkprn
+                IncomingTrustUkprn = ta.IncomingTrustUkprn,
+                PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
             }).ToList();
 
             var expected = new AcademyTransferProjects

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
@@ -12,7 +12,6 @@ namespace TramsDataApi.Test.Factories
 {
     public class AcademyTransferProjectResponseFactoryTests
     {
-
         [Fact]
         public void ReturnsAnAcademyTransferProjectResponse_WhenGivenAnInitialAcademyTransferProject()
         {
@@ -56,14 +55,22 @@ namespace TramsDataApi.Test.Factories
                     .With(ta => ta.IncomingTrustUkprn = null)
                     .Build()
             };
-            
+
             var expected = new AcademyTransferProjectResponse
             {
                 ProjectUrn = academyTransferProjectModel.Urn.ToString(),
                 OutgoingTrustUkprn = academyTransferProjectModel.OutgoingTrustUkprn,
                 TransferringAcademies = academyTransferProjectModel.TransferringAcademies.Select(ta =>
                     new TransferringAcademiesResponse
-                        {IncomingTrustUkprn = null, OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn}).ToList(),
+                    {
+                        IncomingTrustUkprn = null,
+                        OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
+                        PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                        LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                        KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                        KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                        KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
+                    }).ToList(),
                 Features = new AcademyTransferProjectFeaturesResponse(),
                 Dates = new AcademyTransferProjectDatesResponse(),
                 Benefits = new AcademyTransferProjectBenefitsResponse
@@ -80,16 +87,21 @@ namespace TramsDataApi.Test.Factories
                 GeneralInformation = new AcademyTransferProjectGeneralInformationResponse(),
                 State = null,
                 Status = null,
-                AcademyPerformanceAdditionalInformation = academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProjectModel.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation,
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation,
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);
-            
+
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -114,13 +126,16 @@ namespace TramsDataApi.Test.Factories
 
             var expectedDates = new AcademyTransferProjectDatesResponse
             {
-                TransferFirstDiscussed = academyTransferProjectModel.TransferFirstDiscussed?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
-                TargetDateForTransfer = academyTransferProjectModel.TargetDateForTransfer?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+                TransferFirstDiscussed =
+                    academyTransferProjectModel.TransferFirstDiscussed?.ToString("dd/MM/yyyy",
+                        CultureInfo.InvariantCulture),
+                TargetDateForTransfer =
+                    academyTransferProjectModel.TargetDateForTransfer?.ToString("dd/MM/yyyy",
+                        CultureInfo.InvariantCulture),
                 HtbDate = academyTransferProjectModel.HtbDate?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                 HasHtbDate = academyTransferProjectModel.HasHtbDate,
                 HasTransferFirstDiscussedDate = academyTransferProjectModel.HasTransferFirstDiscussedDate,
                 HasTargetDateForTransfer = academyTransferProjectModel.HasTargetDateForTransfer
-                
             };
 
             var expectedIntendedTransferBenefits = new IntendedTransferBenefitResponse
@@ -159,8 +174,8 @@ namespace TramsDataApi.Test.Factories
                 Dates = expectedDates,
                 Benefits = new AcademyTransferProjectBenefitsResponse
                 {
-                IntendedTransferBenefits = expectedIntendedTransferBenefits,
-                OtherFactorsToConsider = expectedOtherFactorsToConsider
+                    IntendedTransferBenefits = expectedIntendedTransferBenefits,
+                    OtherFactorsToConsider = expectedOtherFactorsToConsider
                 },
                 Rationale = new AcademyTransferProjectRationaleResponse
                 {
@@ -174,16 +189,21 @@ namespace TramsDataApi.Test.Factories
                 },
                 State = academyTransferProjectModel.State,
                 Status = academyTransferProjectModel.Status,
-                AcademyPerformanceAdditionalInformation = academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
+                AcademyPerformanceAdditionalInformation =
+                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
                 PupilNumbersAdditionalInformation = academyTransferProjectModel.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation
+                LatestOfstedJudgementAdditionalInformation =
+                    academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
+                KeyStage2PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
+                KeyStage4PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
+                KeyStage5PerformanceAdditionalInformation =
+                    academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);
-            
+
             result.Should().BeEquivalentTo(expected);
         }
 

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
@@ -112,7 +112,15 @@ namespace TramsDataApi.Test.Factories
 
             var expectedTransferringAcademies = academyTransferProjectModel.TransferringAcademies
                 .Select(a => new TransferringAcademiesResponse
-                    {IncomingTrustUkprn = a.IncomingTrustUkprn, OutgoingAcademyUkprn = a.OutgoingAcademyUkprn})
+                {
+                    IncomingTrustUkprn = a.IncomingTrustUkprn,
+                    OutgoingAcademyUkprn = a.OutgoingAcademyUkprn,
+                    PupilNumbersAdditionalInformation = a.PupilNumbersAdditionalInformation,
+                    LatestOfstedReportAdditionalInformation = a.LatestOfstedReportAdditionalInformation,
+                    KeyStage2PerformanceAdditionalInformation = a.KeyStage2PerformanceAdditionalInformation,
+                    KeyStage4PerformanceAdditionalInformation = a.KeyStage4PerformanceAdditionalInformation,
+                    KeyStage5PerformanceAdditionalInformation = a.KeyStage5PerformanceAdditionalInformation
+                })
                 .ToList();
 
             var expectedFeatures = new AcademyTransferProjectFeaturesResponse

--- a/TramsDataApi.Test/Integration/AcademyTransferProjectIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyTransferProjectIntegrationTests.cs
@@ -362,7 +362,8 @@ namespace TramsDataApi.Test.Integration
                     (List<TransferringAcademiesRequest>) Builder<TransferringAcademiesRequest>
                         .CreateListOfSize(2).All()
                         .With(ta => ta.IncomingTrustUkprn = randomGenerator.NextString(8, 8))
-                        .With(ta => ta.OutgoingAcademyUkprn = randomGenerator.NextString(8, 8)).Build())
+                        .With(ta => ta.OutgoingAcademyUkprn = randomGenerator.NextString(8, 8))
+                        .Build())
                 .Build();
 
             _tramsDbContext.TransferringAcademies.Count().Should().Be(0);
@@ -455,6 +456,11 @@ namespace TramsDataApi.Test.Integration
                     .With(ta => ta.OutgoingAcademyUkprn = randomGenerator.NextString(8, 8))
                     .With(ta => ta.IncomingTrustUkprn = incomingTrustUkprn)
                     .With(ta => ta.FkAcademyTransferProjectId = null)
+                    .With(ta => ta.PupilNumbersAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.LatestOfstedReportAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage2PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage4PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage5PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
                     .Build()
                 )
                 .With(atp => atp.AcademyTransferProjectIntendedTransferBenefits =
@@ -525,7 +531,12 @@ namespace TramsDataApi.Test.Integration
                     {
                         OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
                         IncomingTrustUkprn = ta.IncomingTrustUkprn,
-                        IncomingTrustName = incomingTrustName
+                        IncomingTrustName = incomingTrustName,
+                        PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                        LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                        KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                        KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                        KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
                     }).ToList()
                 }).ToList();
             indexProjectResponse.Count().Should().Be(10);
@@ -567,6 +578,11 @@ namespace TramsDataApi.Test.Integration
                     .With(ta => ta.OutgoingAcademyUkprn = randomGenerator.NextString(8, 8))
                     .With(ta => ta.IncomingTrustUkprn = incomingTrustUkprn)
                     .With(ta => ta.FkAcademyTransferProjectId = null)
+                    .With(ta => ta.PupilNumbersAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.LatestOfstedReportAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage2PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage4PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
+                    .With(ta => ta.KeyStage5PerformanceAdditionalInformation = randomGenerator.NextString(0,1000))
                     .Build()
                 )
                 .With(atp => atp.AcademyTransferProjectIntendedTransferBenefits =
@@ -638,7 +654,12 @@ namespace TramsDataApi.Test.Integration
                         {
                             OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
                             IncomingTrustUkprn = ta.IncomingTrustUkprn,
-                            IncomingTrustName = incomingTrustName
+                            IncomingTrustName = incomingTrustName,
+                            PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                            LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                            KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                            KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                            KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
                         }).ToList()
                     }).ToList();
             indexProjectResponse.Count().Should().Be(10);

--- a/TramsDataApi.Test/Integration/AcademyTransferProjectIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/AcademyTransferProjectIntegrationTests.cs
@@ -389,12 +389,22 @@ namespace TramsDataApi.Test.Integration
                 new TransferringAcademiesRequest
                 {
                     OutgoingAcademyUkprn = "12345678",
-                    IncomingTrustUkprn = "12345678"
+                    IncomingTrustUkprn = "12345678",
+                    PupilNumbersAdditionalInformation = "pupil info",
+                    LatestOfstedReportAdditionalInformation = "ofsted info",
+                    KeyStage2PerformanceAdditionalInformation = "ks2",
+                    KeyStage4PerformanceAdditionalInformation = "ks4",
+                    KeyStage5PerformanceAdditionalInformation = "ks5"
                 },
                 new TransferringAcademiesRequest
                 {
                     OutgoingAcademyUkprn = "87654321",
-                    IncomingTrustUkprn = "87654321"
+                    IncomingTrustUkprn = "87654321",
+                    PupilNumbersAdditionalInformation = "pupil info 2",
+                    LatestOfstedReportAdditionalInformation = "ofsted info 2",
+                    KeyStage2PerformanceAdditionalInformation = "ks2 2",
+                    KeyStage4PerformanceAdditionalInformation = "ks4 2",
+                    KeyStage5PerformanceAdditionalInformation = "ks5 2"
                 }
             };
 
@@ -421,12 +431,25 @@ namespace TramsDataApi.Test.Integration
             updatedProject?.TransferringAcademies.Count.Should().Be(2);
             _tramsDbContext.TransferringAcademies.Count().Should().Be(2);
 
-            updatedProject?.TransferringAcademies.ElementAt(0).IncomingTrustUkprn.Should().Be("12345678");
-            updatedProject?.TransferringAcademies.ElementAt(0).OutgoingAcademyUkprn.Should().Be("12345678");
+            var firstCreateAcademy = createRequest.TransferringAcademies.ElementAt(0);
+            var secondCreateAcademy = createRequest.TransferringAcademies.ElementAt(1);
+           
+            updatedProject?.TransferringAcademies.ElementAt(0).IncomingTrustUkprn.Should().Be(firstCreateAcademy.IncomingTrustUkprn);
+            updatedProject?.TransferringAcademies.ElementAt(0).OutgoingAcademyUkprn.Should().Be(firstCreateAcademy.OutgoingAcademyUkprn);
+            updatedProject?.TransferringAcademies.ElementAt(0).LatestOfstedReportAdditionalInformation.Should().Be(firstCreateAcademy.LatestOfstedReportAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(0).PupilNumbersAdditionalInformation.Should().Be(firstCreateAcademy.PupilNumbersAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(0).KeyStage2PerformanceAdditionalInformation.Should().Be(firstCreateAcademy.KeyStage2PerformanceAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(0).KeyStage4PerformanceAdditionalInformation.Should().Be(firstCreateAcademy.KeyStage4PerformanceAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(0).KeyStage5PerformanceAdditionalInformation.Should().Be(firstCreateAcademy.KeyStage5PerformanceAdditionalInformation);
 
-            updatedProject?.TransferringAcademies.ElementAt(1).IncomingTrustUkprn.Should().Be("87654321");
-            updatedProject?.TransferringAcademies.ElementAt(1).OutgoingAcademyUkprn.Should().Be("87654321");
-
+            updatedProject?.TransferringAcademies.ElementAt(1).IncomingTrustUkprn.Should().Be(secondCreateAcademy.IncomingTrustUkprn);
+            updatedProject?.TransferringAcademies.ElementAt(1).OutgoingAcademyUkprn.Should().Be(secondCreateAcademy.OutgoingAcademyUkprn);
+            updatedProject?.TransferringAcademies.ElementAt(1).LatestOfstedReportAdditionalInformation.Should().Be(secondCreateAcademy.LatestOfstedReportAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(1).PupilNumbersAdditionalInformation.Should().Be(secondCreateAcademy.PupilNumbersAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(1).KeyStage2PerformanceAdditionalInformation.Should().Be(secondCreateAcademy.KeyStage2PerformanceAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(1).KeyStage4PerformanceAdditionalInformation.Should().Be(secondCreateAcademy.KeyStage4PerformanceAdditionalInformation);
+            updatedProject?.TransferringAcademies.ElementAt(1).KeyStage5PerformanceAdditionalInformation.Should().Be(secondCreateAcademy.KeyStage5PerformanceAdditionalInformation);
+            
             _tramsDbContext.TransferringAcademies.RemoveRange(_tramsDbContext.TransferringAcademies);
             _tramsDbContext.AcademyTransferProjects.RemoveRange(_tramsDbContext.AcademyTransferProjects);
             _tramsDbContext.SaveChanges();

--- a/TramsDataApi.Test/UseCases/IndexAcademyTransferProjectTests.cs
+++ b/TramsDataApi.Test/UseCases/IndexAcademyTransferProjectTests.cs
@@ -19,15 +19,15 @@ namespace TramsDataApi.Test.UseCases
             var incomingTrust = "incomingTrust";
             var expectedAcademyTransferProjects = Builder<AcademyTransferProjects>.CreateListOfSize(5).All()
                 .With(p => p.OutgoingTrustUkprn = outgoingTrust)
-                .With(p => p.TransferringAcademies =  Builder<TransferringAcademies>.CreateListOfSize(5).All()
+                .With(p => p.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(5).All()
                     .With(a => a.IncomingTrustUkprn = incomingTrust).Build())
                 .Build();
-            
+
             var expectedOutgoingGroup = Builder<Group>.CreateNew().Build();
             var expectedOutgoingTrust = Builder<Trust>.CreateNew().Build();
             var expectedIncomingGroup = Builder<Group>.CreateNew().Build();
             var expectedIncomingTrust = Builder<Trust>.CreateNew().Build();
-            
+
             var academyTransferProjectsGateway = new Mock<IAcademyTransferProjectGateway>();
 
             academyTransferProjectsGateway.Setup(atGateway => atGateway.IndexAcademyTransferProjects(1))
@@ -36,8 +36,10 @@ namespace TramsDataApi.Test.UseCases
             var trustGateway = new Mock<ITrustGateway>();
             trustGateway.Setup(tg => tg.GetGroupByUkPrn(outgoingTrust)).Returns(expectedOutgoingGroup);
             trustGateway.Setup(tg => tg.GetGroupByUkPrn(incomingTrust)).Returns(expectedIncomingGroup);
-            trustGateway.Setup(tg => tg.GetIfdTrustByGroupId(expectedOutgoingGroup.GroupId)).Returns(expectedOutgoingTrust);
-            trustGateway.Setup(tg => tg.GetIfdTrustByGroupId(expectedIncomingGroup.GroupId)).Returns(expectedIncomingTrust);
+            trustGateway.Setup(tg => tg.GetIfdTrustByGroupId(expectedOutgoingGroup.GroupId))
+                .Returns(expectedOutgoingTrust);
+            trustGateway.Setup(tg => tg.GetIfdTrustByGroupId(expectedIncomingGroup.GroupId))
+                .Returns(expectedIncomingTrust);
 
             var expectedIndexResponse = expectedAcademyTransferProjects
                 .Select(atp => new AcademyTransferProjectSummaryResponse
@@ -52,11 +54,16 @@ namespace TramsDataApi.Test.UseCases
                         OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
                         IncomingTrustUkprn = ta.IncomingTrustUkprn,
                         IncomingTrustName = expectedIncomingGroup.GroupName,
-                        IncomingTrustLeadRscRegion = expectedIncomingTrust.LeadRscRegion
+                        IncomingTrustLeadRscRegion = expectedIncomingTrust.LeadRscRegion,
+                        PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                        LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                        KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                        KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                        KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
                     }).ToList()
                 }).ToList();
 
-            
+
             var useCase = new IndexAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
             var result = useCase.Execute(1);
 

--- a/TramsDataApi.Test/UseCases/IndexAcademyTransferProjectTests.cs
+++ b/TramsDataApi.Test/UseCases/IndexAcademyTransferProjectTests.cs
@@ -20,7 +20,13 @@ namespace TramsDataApi.Test.UseCases
             var expectedAcademyTransferProjects = Builder<AcademyTransferProjects>.CreateListOfSize(5).All()
                 .With(p => p.OutgoingTrustUkprn = outgoingTrust)
                 .With(p => p.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(5).All()
-                    .With(a => a.IncomingTrustUkprn = incomingTrust).Build())
+                    .With(a => a.IncomingTrustUkprn = incomingTrust)
+                    .With(a => a.PupilNumbersAdditionalInformation = "pupil numbers")
+                    .With(a => a.LatestOfstedReportAdditionalInformation = "ofsted")
+                    .With(a => a.KeyStage2PerformanceAdditionalInformation = "ks2")
+                    .With(a => a.KeyStage4PerformanceAdditionalInformation = "ks4")
+                    .With(a => a.KeyStage5PerformanceAdditionalInformation = "ks5")
+                    .Build())
                 .Build();
 
             var expectedOutgoingGroup = Builder<Group>.CreateNew().Build();
@@ -66,8 +72,7 @@ namespace TramsDataApi.Test.UseCases
 
             var useCase = new IndexAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
             var result = useCase.Execute(1);
-
-
+            
             result.Count.Should().Be(5);
             result.Should().BeEquivalentTo(expectedIndexResponse);
         }

--- a/TramsDataApi/DatabaseModels/TransferringAcademies.cs
+++ b/TramsDataApi/DatabaseModels/TransferringAcademies.cs
@@ -13,6 +13,12 @@ namespace TramsDataApi.DatabaseModels
         public int? FkAcademyTransferProjectId { get; set; }
         public string OutgoingAcademyUkprn { get; set; }
         public string IncomingTrustUkprn { get; set; }
+        
+        public string PupilNumbersAdditionalInformation { get; set; }
+        public string LatestOfstedReportAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
+        public string KeyStage5PerformanceAdditionalInformation { get; set; }
 
         public virtual AcademyTransferProjects FkAcademyTransferProject { get; set; }
     }

--- a/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
@@ -63,7 +63,16 @@ namespace TramsDataApi.Factories
             }
 
             return transferringAcademiesRequests
-                    .Select(t => new TransferringAcademies {OutgoingAcademyUkprn = t.OutgoingAcademyUkprn, IncomingTrustUkprn = t.IncomingTrustUkprn})
+                    .Select(t => new TransferringAcademies
+                    {
+                        OutgoingAcademyUkprn = t.OutgoingAcademyUkprn, 
+                        IncomingTrustUkprn = t.IncomingTrustUkprn,
+                        PupilNumbersAdditionalInformation = t.PupilNumbersAdditionalInformation,
+                        LatestOfstedReportAdditionalInformation = t.LatestOfstedReportAdditionalInformation,
+                        KeyStage2PerformanceAdditionalInformation = t.KeyStage2PerformanceAdditionalInformation,
+                        KeyStage4PerformanceAdditionalInformation = t.KeyStage4PerformanceAdditionalInformation,
+                        KeyStage5PerformanceAdditionalInformation = t.KeyStage5PerformanceAdditionalInformation
+                    })
                     .ToList();
         }
 

--- a/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
@@ -9,14 +9,22 @@ namespace TramsDataApi.Factories
     {
         public static AcademyTransferProjectResponse Create(AcademyTransferProjects model)
         {
-            if (model == null) 
+            if (model == null)
             {
                 return null;
             }
-            
+
             var transferringAcademies = model.TransferringAcademies
                 .Select(a => new TransferringAcademiesResponse
-                    {IncomingTrustUkprn = a.IncomingTrustUkprn, OutgoingAcademyUkprn = a.OutgoingAcademyUkprn})
+                {
+                    IncomingTrustUkprn = a.IncomingTrustUkprn,
+                    OutgoingAcademyUkprn = a.OutgoingAcademyUkprn,
+                    PupilNumbersAdditionalInformation = a.PupilNumbersAdditionalInformation,
+                    LatestOfstedReportAdditionalInformation = a.LatestOfstedReportAdditionalInformation,
+                    KeyStage2PerformanceAdditionalInformation = a.KeyStage2PerformanceAdditionalInformation,
+                    KeyStage4PerformanceAdditionalInformation = a.KeyStage4PerformanceAdditionalInformation,
+                    KeyStage5PerformanceAdditionalInformation = a.KeyStage5PerformanceAdditionalInformation
+                })
                 .ToList();
 
             var features = new AcademyTransferProjectFeaturesResponse
@@ -30,8 +38,10 @@ namespace TramsDataApi.Factories
 
             var dates = new AcademyTransferProjectDatesResponse
             {
-                TransferFirstDiscussed = model.TransferFirstDiscussed?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
-                TargetDateForTransfer = model.TargetDateForTransfer?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+                TransferFirstDiscussed =
+                    model.TransferFirstDiscussed?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+                TargetDateForTransfer =
+                    model.TargetDateForTransfer?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                 HtbDate = model.HtbDate?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                 HasHtbDate = model.HasHtbDate,
                 HasTargetDateForTransfer = model.HasTargetDateForTransfer,

--- a/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220218144346_AdditionalInformationPerAcademy")]
+    partial class AdditionalInformationPerAcademy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
@@ -11,30 +11,33 @@ namespace TramsDataApi.Migrations.TramsDb
                 schema: "sdd",
                 table: "TransferringAcademies",
                 nullable: true);
-
+            
             migrationBuilder.AddColumn<string>(
                 name: "KeyStage4PerformanceAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies",
                 nullable: true);
-
+            
             migrationBuilder.AddColumn<string>(
                 name: "KeyStage5PerformanceAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies",
                 nullable: true);
-
+            
             migrationBuilder.AddColumn<string>(
                 name: "LatestOfstedReportAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies",
                 nullable: true);
-
+            
             migrationBuilder.AddColumn<string>(
                 name: "PupilNumbersAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies",
                 nullable: true);
+
+            migrationBuilder.Sql(
+                @"Update a set  a.PupilNumbersAdditionalInformation = p.PupilNumbersAdditionalInformation, a.LatestOfstedReportAdditionalInformation = p.LatestOfstedJudgementAdditionalInformation, a.KeyStage2PerformanceAdditionalInformation = p.KeyStage2PerformanceAdditionalInformation, a.KeyStage4PerformanceAdditionalInformation = p.KeyStage4PerformanceAdditionalInformation, a.KeyStage5PerformanceAdditionalInformation = p.KeyStage5PerformanceAdditionalInformation from sdd.AcademyTransferProjects p inner join [sip].[sdd].[TransferringAcademies] a on a.fk_AcademyTransferProjectId = p.id");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -63,6 +66,9 @@ namespace TramsDataApi.Migrations.TramsDb
                 name: "PupilNumbersAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies");
+            
+            migrationBuilder.Sql(
+                @"Update p set p.PupilNumbersAdditionalInformation = a.PupilNumbersAdditionalInformation, p.LatestOfstedReportAdditionalInformation = a.LatestOfstedJudgementAdditionalInformation, p.KeyStage2PerformanceAdditionalInformation = a.KeyStage2PerformanceAdditionalInformation, p.KeyStage4PerformanceAdditionalInformation = a.KeyStage4PerformanceAdditionalInformation, p.KeyStage5PerformanceAdditionalInformation = a.KeyStage5PerformanceAdditionalInformation from sdd.AcademyTransferProjects p inner join [sip].[sdd].[TransferringAcademies] a on a.fk_AcademyTransferProjectId = p.id");
         }
     }
 }

--- a/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
@@ -42,6 +42,9 @@ namespace TramsDataApi.Migrations.TramsDb
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql(
+                @"Update [sip].[sdd].[TransferringAcademies]  set PupilNumbersAdditionalInformation = null, LatestOfstedReportAdditionalInformation = null, KeyStage2PerformanceAdditionalInformation = null, KeyStage4PerformanceAdditionalInformation = null, KeyStage5PerformanceAdditionalInformation = null");
+            
             migrationBuilder.DropColumn(
                 name: "KeyStage2PerformanceAdditionalInformation",
                 schema: "sdd",
@@ -66,9 +69,6 @@ namespace TramsDataApi.Migrations.TramsDb
                 name: "PupilNumbersAdditionalInformation",
                 schema: "sdd",
                 table: "TransferringAcademies");
-            
-            migrationBuilder.Sql(
-                @"Update p set p.PupilNumbersAdditionalInformation = a.PupilNumbersAdditionalInformation, p.LatestOfstedReportAdditionalInformation = a.LatestOfstedJudgementAdditionalInformation, p.KeyStage2PerformanceAdditionalInformation = a.KeyStage2PerformanceAdditionalInformation, p.KeyStage4PerformanceAdditionalInformation = a.KeyStage4PerformanceAdditionalInformation, p.KeyStage5PerformanceAdditionalInformation = a.KeyStage5PerformanceAdditionalInformation from sdd.AcademyTransferProjects p inner join [sip].[sdd].[TransferringAcademies] a on a.fk_AcademyTransferProjectId = p.id");
         }
     }
 }

--- a/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class AdditionalInformationPerAcademy : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage5PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LatestOfstedReportAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PupilNumbersAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies");
+
+            migrationBuilder.DropColumn(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies");
+
+            migrationBuilder.DropColumn(
+                name: "KeyStage5PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies");
+
+            migrationBuilder.DropColumn(
+                name: "LatestOfstedReportAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies");
+
+            migrationBuilder.DropColumn(
+                name: "PupilNumbersAdditionalInformation",
+                schema: "sdd",
+                table: "TransferringAcademies");
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/TransferringAcademiesRequest.cs
+++ b/TramsDataApi/RequestModels/TransferringAcademiesRequest.cs
@@ -4,5 +4,10 @@ namespace TramsDataApi.RequestModels
     {
         public string OutgoingAcademyUkprn { get; set; }
         public string IncomingTrustUkprn { get; set; }
+        public string PupilNumbersAdditionalInformation { get; set; }
+        public string LatestOfstedReportAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
+        public string KeyStage5PerformanceAdditionalInformation { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/TransferringAcademiesResponse.cs
+++ b/TramsDataApi/ResponseModels/TransferringAcademiesResponse.cs
@@ -8,5 +8,11 @@ namespace TramsDataApi.ResponseModels
         public string IncomingTrustUkprn { get; set; }
         public string IncomingTrustName { get; set; }
         public string IncomingTrustLeadRscRegion { get; set; }
+        
+        public string PupilNumbersAdditionalInformation { get; set; }
+        public string LatestOfstedReportAdditionalInformation { get; set; }
+        public string KeyStage2PerformanceAdditionalInformation { get; set; }
+        public string KeyStage4PerformanceAdditionalInformation { get; set; }
+        public string KeyStage5PerformanceAdditionalInformation { get; set; }
     }
 }

--- a/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
+++ b/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
@@ -42,7 +42,12 @@ namespace TramsDataApi.UseCases
                             OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
                             IncomingTrustUkprn = ta.IncomingTrustUkprn,
                             IncomingTrustName = group.GroupName,
-                            IncomingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(group.GroupId).LeadRscRegion
+                            IncomingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(group.GroupId).LeadRscRegion,
+                            PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                            LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                            KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                            KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                            KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
                         };
                     }).ToList()
                 };


### PR DESCRIPTION
Add additional information fields to the Academies level.
POST, PATCH and GET updated with the new fields
Data copied to academy level from project (Project additional information can be removed post Transfers deployment)
