### PR TITLE
Feature/87757 remove redundant columns AB#87757

### DIFF
--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -74,7 +74,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = null,
                 BenefitsSectionIsCompleted = null,
                 RationaleSectionIsCompleted = null,
-                AcademyPerformanceAdditionalInformation = null,
                 TransferringAcademies = createRequest.TransferringAcademies
                     .Select(t => new TransferringAcademies
                     {
@@ -179,7 +178,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = createRequest.Features?.IsCompleted,
                 BenefitsSectionIsCompleted = createRequest.Benefits?.IsCompleted,
                 RationaleSectionIsCompleted = createRequest.Rationale?.IsCompleted,
-                AcademyPerformanceAdditionalInformation = createRequest.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits = createRequest.Benefits.IntendedTransferBenefits
                     .SelectedBenefits
                     .Select(b => new AcademyTransferProjectIntendedTransferBenefits {SelectedBenefit = b}).ToList(),
@@ -261,8 +259,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = academyTransferProject.FeatureSectionIsCompleted,
                 BenefitsSectionIsCompleted = academyTransferProject.BenefitsSectionIsCompleted,
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
@@ -350,8 +346,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = academyTransferProject.FeatureSectionIsCompleted,
                 BenefitsSectionIsCompleted = academyTransferProject.BenefitsSectionIsCompleted,
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
@@ -432,8 +426,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = academyTransferProject.FeatureSectionIsCompleted,
                 BenefitsSectionIsCompleted = academyTransferProject.BenefitsSectionIsCompleted,
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits = expectedBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
@@ -498,8 +490,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = academyTransferProject.FeatureSectionIsCompleted,
                 BenefitsSectionIsCompleted = academyTransferProject.BenefitsSectionIsCompleted,
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,
@@ -572,8 +562,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = academyTransferProject.FeatureSectionIsCompleted,
                 BenefitsSectionIsCompleted = academyTransferProject.BenefitsSectionIsCompleted,
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProject.AcademyPerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectFactoryTests.cs
@@ -75,11 +75,6 @@ namespace TramsDataApi.Test.Factories
                 BenefitsSectionIsCompleted = null,
                 RationaleSectionIsCompleted = null,
                 AcademyPerformanceAdditionalInformation = null,
-                PupilNumbersAdditionalInformation = null,
-                LatestOfstedJudgementAdditionalInformation = null,
-                KeyStage2PerformanceAdditionalInformation = null,
-                KeyStage4PerformanceAdditionalInformation = null,
-                KeyStage5PerformanceAdditionalInformation = null,
                 TransferringAcademies = createRequest.TransferringAcademies
                     .Select(t => new TransferringAcademies
                     {
@@ -185,11 +180,6 @@ namespace TramsDataApi.Test.Factories
                 BenefitsSectionIsCompleted = createRequest.Benefits?.IsCompleted,
                 RationaleSectionIsCompleted = createRequest.Rationale?.IsCompleted,
                 AcademyPerformanceAdditionalInformation = createRequest.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = createRequest.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = createRequest.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = createRequest.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = createRequest.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = createRequest.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits = createRequest.Benefits.IntendedTransferBenefits
                     .SelectedBenefits
                     .Select(b => new AcademyTransferProjectIntendedTransferBenefits {SelectedBenefit = b}).ToList(),
@@ -273,15 +263,6 @@ namespace TramsDataApi.Test.Factories
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
                 AcademyPerformanceAdditionalInformation =
                     academyTransferProject.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
@@ -371,15 +352,6 @@ namespace TramsDataApi.Test.Factories
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
                 AcademyPerformanceAdditionalInformation =
                     academyTransferProject.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
@@ -462,15 +434,6 @@ namespace TramsDataApi.Test.Factories
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
                 AcademyPerformanceAdditionalInformation =
                     academyTransferProject.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits = expectedBenefits,
                 HasHtbDate = academyTransferProject.HasHtbDate,
                 HasTransferFirstDiscussedDate = academyTransferProject.HasTransferFirstDiscussedDate,
@@ -537,15 +500,6 @@ namespace TramsDataApi.Test.Factories
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
                 AcademyPerformanceAdditionalInformation =
                     academyTransferProject.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,
@@ -620,15 +574,6 @@ namespace TramsDataApi.Test.Factories
                 RationaleSectionIsCompleted = academyTransferProject.RationaleSectionIsCompleted,
                 AcademyPerformanceAdditionalInformation =
                     academyTransferProject.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProject.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProject.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProject.KeyStage5PerformanceAdditionalInformation,
                 AcademyTransferProjectIntendedTransferBenefits =
                     academyTransferProject.AcademyTransferProjectIntendedTransferBenefits,
                 HasTransferFirstDiscussedDate = false,

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
@@ -48,7 +48,6 @@ namespace TramsDataApi.Test.Factories
                 FeatureSectionIsCompleted = null,
                 BenefitsSectionIsCompleted = null,
                 RationaleSectionIsCompleted = null,
-                AcademyPerformanceAdditionalInformation = null,
                 AcademyTransferProjectIntendedTransferBenefits = null,
                 TransferringAcademies = Builder<TransferringAcademies>
                     .CreateListOfSize(1).All()
@@ -89,9 +88,7 @@ namespace TramsDataApi.Test.Factories
                 Rationale = new AcademyTransferProjectRationaleResponse(),
                 GeneralInformation = new AcademyTransferProjectGeneralInformationResponse(),
                 State = null,
-                Status = null,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation
+                Status = null
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);
@@ -199,9 +196,7 @@ namespace TramsDataApi.Test.Factories
                     Recommendation = academyTransferProjectModel.Recommendation
                 },
                 State = academyTransferProjectModel.State,
-                Status = academyTransferProjectModel.Status,
-                AcademyPerformanceAdditionalInformation =
-                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation
+                Status = academyTransferProjectModel.Status
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);

--- a/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/AcademyTransferProjectResponseFactoryTests.cs
@@ -49,11 +49,6 @@ namespace TramsDataApi.Test.Factories
                 BenefitsSectionIsCompleted = null,
                 RationaleSectionIsCompleted = null,
                 AcademyPerformanceAdditionalInformation = null,
-                PupilNumbersAdditionalInformation = null,
-                LatestOfstedJudgementAdditionalInformation = null,
-                KeyStage2PerformanceAdditionalInformation = null,
-                KeyStage4PerformanceAdditionalInformation = null,
-                KeyStage5PerformanceAdditionalInformation = null,
                 AcademyTransferProjectIntendedTransferBenefits = null,
                 TransferringAcademies = Builder<TransferringAcademies>
                     .CreateListOfSize(1).All()
@@ -96,16 +91,7 @@ namespace TramsDataApi.Test.Factories
                 State = null,
                 Status = null,
                 AcademyPerformanceAdditionalInformation =
-                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProjectModel.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation,
+                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);
@@ -215,16 +201,7 @@ namespace TramsDataApi.Test.Factories
                 State = academyTransferProjectModel.State,
                 Status = academyTransferProjectModel.Status,
                 AcademyPerformanceAdditionalInformation =
-                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = academyTransferProjectModel.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation =
-                    academyTransferProjectModel.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation =
-                    academyTransferProjectModel.KeyStage5PerformanceAdditionalInformation
+                    academyTransferProjectModel.AcademyPerformanceAdditionalInformation
             };
 
             var result = AcademyTransferProjectResponseFactory.Create(academyTransferProjectModel);

--- a/TramsDataApi/DatabaseModels/AcademyTransferProjects.cs
+++ b/TramsDataApi/DatabaseModels/AcademyTransferProjects.cs
@@ -56,7 +56,6 @@ namespace TramsDataApi.DatabaseModels
         public bool? FeatureSectionIsCompleted { get; set; }
         public bool? BenefitsSectionIsCompleted { get; set; }
         public bool? RationaleSectionIsCompleted { get; set; }
-        public string AcademyPerformanceAdditionalInformation { get; set; }
 
         public virtual ICollection<AcademyTransferProjectIntendedTransferBenefits>
             AcademyTransferProjectIntendedTransferBenefits { get; set; }

--- a/TramsDataApi/DatabaseModels/AcademyTransferProjects.cs
+++ b/TramsDataApi/DatabaseModels/AcademyTransferProjects.cs
@@ -57,11 +57,6 @@ namespace TramsDataApi.DatabaseModels
         public bool? BenefitsSectionIsCompleted { get; set; }
         public bool? RationaleSectionIsCompleted { get; set; }
         public string AcademyPerformanceAdditionalInformation { get; set; }
-        public string PupilNumbersAdditionalInformation { get; set; }
-        public string LatestOfstedJudgementAdditionalInformation { get; set; }
-        public string KeyStage2PerformanceAdditionalInformation { get; set; }
-        public string KeyStage4PerformanceAdditionalInformation { get; set; }
-        public string KeyStage5PerformanceAdditionalInformation { get; set; }
 
         public virtual ICollection<AcademyTransferProjectIntendedTransferBenefits>
             AcademyTransferProjectIntendedTransferBenefits { get; set; }

--- a/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
@@ -49,7 +49,6 @@ namespace TramsDataApi.Factories
                 FeatureSectionIsCompleted = request.Features?.IsCompleted,
                 BenefitsSectionIsCompleted = request.Benefits?.IsCompleted,
                 RationaleSectionIsCompleted = request.Rationale?.IsCompleted,
-                AcademyPerformanceAdditionalInformation = request.AcademyPerformanceAdditionalInformation,
                 HasHtbDate = request.Dates?.HasHtbDate,
                 HasTransferFirstDiscussedDate = request.Dates?.HasTransferFirstDiscussedDate,
                 HasTargetDateForTransfer = request.Dates?.HasTargetDateForTransfer
@@ -154,9 +153,6 @@ namespace TramsDataApi.Factories
             original.FeatureSectionIsCompleted = toMerge.FeatureSectionIsCompleted ?? original.FeatureSectionIsCompleted;
             original.BenefitsSectionIsCompleted = toMerge.BenefitsSectionIsCompleted ?? original.BenefitsSectionIsCompleted;
             original.RationaleSectionIsCompleted = toMerge.RationaleSectionIsCompleted ?? original.RationaleSectionIsCompleted;
-
-            original.AcademyPerformanceAdditionalInformation = toMerge.AcademyPerformanceAdditionalInformation ?? 
-                                                         original.AcademyPerformanceAdditionalInformation;
 
             original.AcademyTransferProjectIntendedTransferBenefits =
                 toMerge.AcademyTransferProjectIntendedTransferBenefits ??

--- a/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectFactory.cs
@@ -50,11 +50,6 @@ namespace TramsDataApi.Factories
                 BenefitsSectionIsCompleted = request.Benefits?.IsCompleted,
                 RationaleSectionIsCompleted = request.Rationale?.IsCompleted,
                 AcademyPerformanceAdditionalInformation = request.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = request.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = request.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = request.KeyStage2PerformanceAdditionalInformation, 
-                KeyStage4PerformanceAdditionalInformation = request.KeyStage4PerformanceAdditionalInformation, 
-                KeyStage5PerformanceAdditionalInformation = request.KeyStage5PerformanceAdditionalInformation,
                 HasHtbDate = request.Dates?.HasHtbDate,
                 HasTransferFirstDiscussedDate = request.Dates?.HasTransferFirstDiscussedDate,
                 HasTargetDateForTransfer = request.Dates?.HasTargetDateForTransfer
@@ -162,17 +157,7 @@ namespace TramsDataApi.Factories
 
             original.AcademyPerformanceAdditionalInformation = toMerge.AcademyPerformanceAdditionalInformation ?? 
                                                          original.AcademyPerformanceAdditionalInformation;
-            original.PupilNumbersAdditionalInformation = toMerge.PupilNumbersAdditionalInformation ?? 
-                                                         original.PupilNumbersAdditionalInformation;
-            original.LatestOfstedJudgementAdditionalInformation = toMerge.LatestOfstedJudgementAdditionalInformation ??
-                                                                  original.LatestOfstedJudgementAdditionalInformation;
-            original.KeyStage2PerformanceAdditionalInformation = toMerge.KeyStage2PerformanceAdditionalInformation ?? 
-                                                                 original.KeyStage2PerformanceAdditionalInformation;
-            original.KeyStage4PerformanceAdditionalInformation = toMerge.KeyStage4PerformanceAdditionalInformation ?? 
-                                                                 original.KeyStage4PerformanceAdditionalInformation;
-            original.KeyStage5PerformanceAdditionalInformation = toMerge.KeyStage5PerformanceAdditionalInformation ??
-                                                                 original.KeyStage5PerformanceAdditionalInformation;
-            
+
             original.AcademyTransferProjectIntendedTransferBenefits =
                 toMerge.AcademyTransferProjectIntendedTransferBenefits ??
                 original.AcademyTransferProjectIntendedTransferBenefits;

--- a/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
@@ -107,8 +107,7 @@ namespace TramsDataApi.Factories
                     Recommendation = model.Recommendation
                 },
                 State = model.State,
-                Status = model.Status,
-                AcademyPerformanceAdditionalInformation = model.AcademyPerformanceAdditionalInformation
+                Status = model.Status
             };
         }
     }

--- a/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
+++ b/TramsDataApi/Factories/AcademyTransferProjectResponseFactory.cs
@@ -108,12 +108,7 @@ namespace TramsDataApi.Factories
                 },
                 State = model.State,
                 Status = model.Status,
-                AcademyPerformanceAdditionalInformation = model.AcademyPerformanceAdditionalInformation,
-                PupilNumbersAdditionalInformation = model.PupilNumbersAdditionalInformation,
-                LatestOfstedJudgementAdditionalInformation = model.LatestOfstedJudgementAdditionalInformation,
-                KeyStage2PerformanceAdditionalInformation = model.KeyStage2PerformanceAdditionalInformation,
-                KeyStage4PerformanceAdditionalInformation = model.KeyStage4PerformanceAdditionalInformation,
-                KeyStage5PerformanceAdditionalInformation = model.KeyStage5PerformanceAdditionalInformation
+                AcademyPerformanceAdditionalInformation = model.AcademyPerformanceAdditionalInformation
             };
         }
     }

--- a/TramsDataApi/Migrations/TramsDb/20220511110620_RemoveRedundantColumnsForTransfers.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220511110620_RemoveRedundantColumnsForTransfers.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220511110620_RemoveRedundantColumnsForTransfers")]
+    partial class RemoveRedundantColumnsForTransfers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20220511110620_RemoveRedundantColumnsForTransfers.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220511110620_RemoveRedundantColumnsForTransfers.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class RemoveRedundantColumnsForTransfers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+
+            migrationBuilder.DropColumn(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+
+            migrationBuilder.DropColumn(
+                name: "KeyStage5PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+
+            migrationBuilder.DropColumn(
+                name: "LatestOfstedJudgementAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+
+            migrationBuilder.DropColumn(
+                name: "PupilNumbersAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage2PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage4PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KeyStage5PerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LatestOfstedJudgementAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PupilNumbersAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/20220511142948_RemoveRedundantColumnAcademyPerformanceForTransfers.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220511142948_RemoveRedundantColumnAcademyPerformanceForTransfers.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220511142948_RemoveRedundantColumnAcademyPerformanceForTransfers")]
+    partial class RemoveRedundantColumnAcademyPerformanceForTransfers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20220511142948_RemoveRedundantColumnAcademyPerformanceForTransfers.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220511142948_RemoveRedundantColumnAcademyPerformanceForTransfers.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class RemoveRedundantColumnAcademyPerformanceForTransfers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AcademyPerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AcademyPerformanceAdditionalInformation",
+                schema: "sdd",
+                table: "AcademyTransferProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Missed other redundant column Academy Performance. This is not used in Academy Transfers.
All data in the column in Production is NULL