### PR TITLE
Changed SRMA to case reference, from case id to case URN

### DIFF
--- a/TramsDataApi.Test/Controllers/SRMAControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/SRMAControllerTests.cs
@@ -71,45 +71,45 @@ namespace TramsDataApi.Test.Controllers
         [Fact]
         public void GetSRMAsByCaseId_ReturnsMatchingSRMA_WhenGivenCaseId()
         {
-            var caseId = 123;
+            var caseUrn = 123;
 
             var matchingSRMA = new SRMACase
             {
-                CaseId = caseId,
+                CaseUrn = caseUrn,
                 Notes = "match"
             };
 
             var srmas = new List<SRMACase> {
                 matchingSRMA,
                 new SRMACase {
-                    CaseId = 222,
+                    CaseUrn = 222,
                     Notes = "SRMA 1"
                 },
                 new SRMACase {
-                    CaseId = 456,
+                    CaseUrn = 456,
                     Notes = "SRMA 2"
                 }
             };
 
             var srmaResponse = Builder<SRMAResponse>
                 .CreateNew()
-                .With(r => r.CaseId = matchingSRMA.CaseId)
+                .With(r => r.CaseUrn = matchingSRMA.CaseUrn)
                 .With(r => r.Notes = matchingSRMA.Notes)
                 .Build();
 
             var collection = new List<SRMAResponse> { srmaResponse };
 
             _mockGetSRMAsByCaseId
-                .Setup(x => x.Execute(caseId))
+                .Setup(x => x.Execute(caseUrn))
                 .Returns(collection);
 
-            OkObjectResult controllerResponse = controllerSUT.GetSRMAsByCaseId(caseId).Result as OkObjectResult;
+            OkObjectResult controllerResponse = controllerSUT.GetSRMAsByCase(caseUrn).Result as OkObjectResult;
 
             var  actualResult = controllerResponse.Value as ApiSingleResponseV2<ICollection<SRMAResponse>>;
 
             actualResult.Data.Should().NotBeNull();
             actualResult.Data.Count.Should().Be(1);
-            actualResult.Data.First().CaseId.Should().Be(caseId);
+            actualResult.Data.First().CaseUrn.Should().Be(caseUrn);
         }
 
         [Fact]

--- a/TramsDataApi.Test/Factories/SRMAFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/SRMAFactoryTests.cs
@@ -35,7 +35,7 @@ namespace TramsDataApi.Test.Factories
 
             var createSRMARequest = Builder<CreateSRMARequest>.CreateNew()
                 .With(r => r.Id = details.Id)
-                .With(r => r.CaseId = details.CaseId)
+                .With(r => r.CaseUrn = details.CaseId)
                 .With(r => r.DateOffered = details.DateOffered)
                 .With(r => r.DateReportSentToTrust = details.DateReportSentToTrust)
                 .With(r => r.DateVisitStart = details.DateVisitStart)
@@ -50,7 +50,7 @@ namespace TramsDataApi.Test.Factories
             var expectedSRMAModel = new SRMACase
             {
                 Id = details.Id,
-                CaseId = details.CaseId,
+                CaseUrn = details.CaseId,
                 DateOffered = details.DateOffered,
                 DateReportSentToTrust = details.DateReportSentToTrust,
                 StartDateOfVisit = details.DateVisitStart,
@@ -89,7 +89,7 @@ namespace TramsDataApi.Test.Factories
 
             var srmaModel = Builder<SRMACase>.CreateNew()
                 .With(r => r.Id = details.Id)
-                .With(r => r.CaseId = details.CaseId)
+                .With(r => r.CaseUrn = details.CaseId)
                 .With(r => r.DateOffered = details.DateOffered)
                 .With(r => r.DateReportSentToTrust = details.DateReportSentToTrust)
                 .With(r => r.StartDateOfVisit = details.DateVisitStart)
@@ -104,7 +104,7 @@ namespace TramsDataApi.Test.Factories
             var expectedCreateSRMAResponse = new SRMAResponse
             {
                 Id = details.Id,
-                CaseId = details.CaseId,
+                CaseUrn = details.CaseId,
                 DateOffered = details.DateOffered,
                 DateReportSentToTrust = details.DateReportSentToTrust,
                 DateVisitStart = details.DateVisitStart,

--- a/TramsDataApi.Test/UseCases/GetSRMAsByCaseIdTests.cs
+++ b/TramsDataApi.Test/UseCases/GetSRMAsByCaseIdTests.cs
@@ -20,18 +20,18 @@ namespace TramsDataApi.Test.UseCases
 
             var matchingSRMA = new SRMACase
             {
-                CaseId = caseId,
+                CaseUrn = caseId,
                 Notes = "match"
             };
 
             var srmas = new List<SRMACase> {
                 matchingSRMA,
                 new SRMACase {
-                    CaseId = 222,
+                    CaseUrn = 222,
                     Notes = "SRMA 1"
                 },
                 new SRMACase {
-                    CaseId = 456,
+                    CaseUrn = 456,
                     Notes = "SRMA 2"
                 }
             };
@@ -39,7 +39,7 @@ namespace TramsDataApi.Test.UseCases
             var expectedResult = SRMAFactory.CreateResponse(matchingSRMA);
 
             var mockSRMAGateway = new Mock<ISRMAGateway>();
-            mockSRMAGateway.Setup(g => g.GetSRMAsByCaseId(caseId)).Returns(Task.FromResult((ICollection<SRMACase>)srmas.Where(s => s.CaseId == caseId).ToList()));
+            mockSRMAGateway.Setup(g => g.GetSRMAsByCaseId(caseId)).Returns(Task.FromResult((ICollection<SRMACase>)srmas.Where(s => s.CaseUrn == caseId).ToList()));
 
             var useCase = new GetSRMAsByCaseId(mockSRMAGateway.Object);
 

--- a/TramsDataApi/Controllers/V2/SRMAController.cs
+++ b/TramsDataApi/Controllers/V2/SRMAController.cs
@@ -58,11 +58,11 @@ namespace TramsDataApi.Controllers.V2
         }
 
         [HttpGet]
-        [Route("case/{caseId}")]
+        [Route("case/{caseUrn}")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiSingleResponseV2<ICollection<SRMAResponse>>> GetSRMAsByCaseId(int caseId)
+        public ActionResult<ApiSingleResponseV2<ICollection<SRMAResponse>>> GetSRMAsByCase(int caseUrn)
         {
-            var srmas = _getSRMAsByCaseIdUseCase.Execute(caseId);
+            var srmas = _getSRMAsByCaseIdUseCase.Execute(caseUrn);
             var response = new ApiSingleResponseV2<ICollection<SRMAResponse>>(srmas);
 
             return Ok(response);

--- a/TramsDataApi/DatabaseModels/SRMACase.cs
+++ b/TramsDataApi/DatabaseModels/SRMACase.cs
@@ -11,7 +11,7 @@ namespace TramsDataApi.DatabaseModels
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
         public long? Urn { get; set; }
-        public int CaseId { get; set; }
+        public int CaseUrn { get; set; }
         public int StatusId { get; set; }
         public int? CloseStatusId { get; set; }
         public int? ReasonId { get; set; }
@@ -27,9 +27,6 @@ namespace TramsDataApi.DatabaseModels
 
         [StringLength(500)]
         public string Notes { get; set; }
-
-        [ForeignKey(nameof(CaseId))]
-        public virtual ConcernsCase ConcernsCase { get; set; }
 
         [ForeignKey(nameof(ReasonId))]
         public virtual SRMAReason Reason { get; set; }

--- a/TramsDataApi/Factories/CaseActionFactories/SRMAFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/SRMAFactory.cs
@@ -12,7 +12,7 @@ namespace TramsDataApi.Factories.CaseActionFactories
             return new SRMACase
             {
                 Id = createSRMARequest.Id,
-                CaseId = createSRMARequest.CaseId,
+                CaseUrn = createSRMARequest.CaseUrn,
                 CreatedAt = createSRMARequest.CreatedAt,
                 DateOffered = createSRMARequest.DateOffered,
                 DateReportSentToTrust = createSRMARequest.DateReportSentToTrust,
@@ -30,7 +30,7 @@ namespace TramsDataApi.Factories.CaseActionFactories
             return new SRMAResponse
             {
                 Id = model.Id,
-                CaseId = model.CaseId,
+                CaseUrn = model.CaseUrn,
                 CreatedAt = model.CreatedAt,
                 DateOffered = model.DateOffered,
                 DateReportSentToTrust = model.DateReportSentToTrust,

--- a/TramsDataApi/Gateways/SRMAGateway.cs
+++ b/TramsDataApi/Gateways/SRMAGateway.cs
@@ -41,7 +41,7 @@ namespace TramsDataApi.Gateways
 
         public async Task<ICollection<SRMACase>> GetSRMAsByCaseId(int caseId)
         {
-            return await _tramsDbContext.SRMACases.Where(s => s.CaseId == caseId).ToListAsync();
+            return await _tramsDbContext.SRMACases.Where(s => s.CaseUrn == caseId).ToListAsync();
         }
 
         public async Task<SRMACase> GetSRMAById(int srmaId)

--- a/TramsDataApi/Migrations/TramsDb/20220531151943_Change_caseID_to_CaseURN.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220531151943_Change_caseID_to_CaseURN.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220531151943_Change_caseID_to_CaseURN")]
+    partial class Change_caseID_to_CaseURN
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20220531151943_Change_caseID_to_CaseURN.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220531151943_Change_caseID_to_CaseURN.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class Change_caseID_to_CaseURN : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SRMACase_ConcernsCase_CaseId",
+                schema: "sdd",
+                table: "SRMACase");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SRMACase_CaseId",
+                schema: "sdd",
+                table: "SRMACase");
+
+            migrationBuilder.DropColumn(
+                name: "CaseId",
+                schema: "sdd",
+                table: "SRMACase");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CaseUrn",
+                schema: "sdd",
+                table: "SRMACase",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CaseUrn",
+                schema: "sdd",
+                table: "SRMACase");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CaseId",
+                schema: "sdd",
+                table: "SRMACase",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SRMACase_CaseId",
+                schema: "sdd",
+                table: "SRMACase",
+                column: "CaseId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SRMACase_ConcernsCase_CaseId",
+                schema: "sdd",
+                table: "SRMACase",
+                column: "CaseId",
+                principalSchema: "sdd",
+                principalTable: "ConcernsCase",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/CaseActions/SRMA/CreateSRMARequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/SRMA/CreateSRMARequest.cs
@@ -9,7 +9,7 @@ namespace TramsDataApi.RequestModels.CaseActions.SRMA
 		[Required]
 		public int Id { get; set; }
 		[Required]
-        public int CaseId { get; set; }
+        public int CaseUrn { get; set; }
 		public DateTime CreatedAt { get; set; }
 		public DateTime DateOffered { get; set; }
 		public DateTime? DateAccepted { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/SRMA/SRMAResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/SRMA/SRMAResponse.cs
@@ -6,7 +6,7 @@ namespace TramsDataApi.ResponseModels.CaseActions.SRMA
     public class SRMAResponse
     {
 		public int Id { get; set; }
-		public int CaseId { get; set; }
+		public int CaseUrn { get; set; }
 		public DateTime CreatedAt { get; set; }
 		public DateTime DateOffered { get; set; }
 		public DateTime? DateAccepted { get; set; }


### PR DESCRIPTION
What is the change?
Changed SRMA to case reference, from case id to case URN

Why do we need the change?
The initial implementation followed the database design but the front end (concerns casework) and the rest of the system use URN to identify cases.

What is the impact?
Localised impact on previous SRMA development 

Azure DevOps Ticket
94850