### PR TITLE
fix a migration script now that table columns are removed

### DIFF
--- a/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220218144346_AdditionalInformationPerAcademy.cs
@@ -37,13 +37,13 @@ namespace TramsDataApi.Migrations.TramsDb
                 nullable: true);
 
             migrationBuilder.Sql(
-                @"Update a set a.PupilNumbersAdditionalInformation = p.PupilNumbersAdditionalInformation, a.LatestOfstedReportAdditionalInformation = p.LatestOfstedJudgementAdditionalInformation, a.KeyStage2PerformanceAdditionalInformation = p.KeyStage2PerformanceAdditionalInformation, a.KeyStage4PerformanceAdditionalInformation = p.KeyStage4PerformanceAdditionalInformation, a.KeyStage5PerformanceAdditionalInformation = p.KeyStage5PerformanceAdditionalInformation from sdd.AcademyTransferProjects p inner join sdd.TransferringAcademies a on a.fk_AcademyTransferProjectId = p.id");
+                @"Exec ('Update a set a.PupilNumbersAdditionalInformation = p.PupilNumbersAdditionalInformation, a.LatestOfstedReportAdditionalInformation = p.LatestOfstedJudgementAdditionalInformation, a.KeyStage2PerformanceAdditionalInformation = p.KeyStage2PerformanceAdditionalInformation, a.KeyStage4PerformanceAdditionalInformation = p.KeyStage4PerformanceAdditionalInformation, a.KeyStage5PerformanceAdditionalInformation = p.KeyStage5PerformanceAdditionalInformation from sdd.AcademyTransferProjects p inner join sdd.TransferringAcademies a on a.fk_AcademyTransferProjectId = p.id')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql(
-                @"Update sdd.TransferringAcademies set PupilNumbersAdditionalInformation = null, LatestOfstedReportAdditionalInformation = null, KeyStage2PerformanceAdditionalInformation = null, KeyStage4PerformanceAdditionalInformation = null, KeyStage5PerformanceAdditionalInformation = null");
+                @"Exec ('Update sdd.TransferringAcademies set PupilNumbersAdditionalInformation = null, LatestOfstedReportAdditionalInformation = null, KeyStage2PerformanceAdditionalInformation = null, KeyStage4PerformanceAdditionalInformation = null, KeyStage5PerformanceAdditionalInformation = null')");
             
             migrationBuilder.DropColumn(
                 name: "KeyStage2PerformanceAdditionalInformation",


### PR DESCRIPTION
Added the EXEC function to work around parser error in a previous migration script (occurs because referenced columns don't currently exist on the table.)