### PR TITLE
Feature/102286 financial plan filter available status options

### DIFF
--- a/TramsDataApi/Controllers/V2/FinancialPlanController.cs
+++ b/TramsDataApi/Controllers/V2/FinancialPlanController.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.RequestModels.CaseActions.FinancialPlan;
 using TramsDataApi.ResponseModels;
@@ -76,6 +76,28 @@ namespace TramsDataApi.Controllers.V2
         public ActionResult<ApiSingleResponseV2<List<FinancialPlanStatus>>> GetAllStatuses()
         {
             var statuses = _getAllStatuses.Execute(null);
+            var response = new ApiSingleResponseV2<List<FinancialPlanStatus>>(statuses);
+
+            return Ok(response);
+        }
+        
+        [HttpGet]
+        [Route("closure-statuses")]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<List<FinancialPlanStatus>>> GetClosureStatuses()
+        {
+            var statuses = _getAllStatuses.Execute(null).Where(s => s.IsClosedStatus).ToList();
+            var response = new ApiSingleResponseV2<List<FinancialPlanStatus>>(statuses);
+
+            return Ok(response);
+        }
+        
+        [HttpGet]
+        [Route("open-statuses")]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<List<FinancialPlanStatus>>> GetOpenStatuses()
+        {
+            var statuses = _getAllStatuses.Execute(null).Where(s => !s.IsClosedStatus).ToList();
             var response = new ApiSingleResponseV2<List<FinancialPlanStatus>>(statuses);
 
             return Ok(response);

--- a/TramsDataApi/DatabaseModels/FinancialPlanStatus.cs
+++ b/TramsDataApi/DatabaseModels/FinancialPlanStatus.cs
@@ -11,7 +11,9 @@ namespace TramsDataApi.DatabaseModels
         public long Id { get; set;  }
         [StringLength(255)]
         public string Name { get; set; }
+        public string Description { get; set; }
         public DateTime CreatedAt { get; set;  }
         public DateTime UpdatedAt { get; set; }
+        public bool IsClosedStatus { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -424,10 +424,10 @@ namespace TramsDataApi.DatabaseModels
                 entity.HasData(
                      new FinancialPlanStatus[]
                     {
-                        new FinancialPlanStatus{ Id = 1, Name = "AwaitingPlan", CreatedAt = createdAt, UpdatedAt = createdAt },
-                        new FinancialPlanStatus{ Id = 2, Name = "ReturnToTrust", CreatedAt = createdAt, UpdatedAt = createdAt },
-                        new FinancialPlanStatus{ Id = 3, Name = "ViablePlanReceived", CreatedAt = createdAt, UpdatedAt = createdAt },
-                        new FinancialPlanStatus{ Id = 4, Name = "Abandoned", CreatedAt = createdAt, UpdatedAt = createdAt },
+                        new FinancialPlanStatus{ Id = 1, Name = "AwaitingPlan", Description = "Awaiting Plan", CreatedAt = createdAt, UpdatedAt = createdAt, IsClosedStatus = false },
+                        new FinancialPlanStatus{ Id = 2, Name = "ReturnToTrust", Description = "Return To Trust", CreatedAt = createdAt, UpdatedAt = createdAt, IsClosedStatus = false },
+                        new FinancialPlanStatus{ Id = 3, Name = "ViablePlanReceived", Description = "Viable Plan Received", CreatedAt = createdAt, UpdatedAt = createdAt, IsClosedStatus = true },
+                        new FinancialPlanStatus{ Id = 4, Name = "Abandoned", Description = "Abandoned", CreatedAt = createdAt, UpdatedAt = createdAt, IsClosedStatus = true }
                     });
             });
 

--- a/TramsDataApi/Gateways/FinancialPlanGateway.cs
+++ b/TramsDataApi/Gateways/FinancialPlanGateway.cs
@@ -41,12 +41,16 @@ namespace TramsDataApi.Gateways
 
         public async Task<FinancialPlanCase> GetFinancialPlanById(long financialPlanId)
         {
-            return await _tramsDbContext.FinancialPlanCases.Include(fp => fp.Status).SingleOrDefaultAsync(fp => fp.Id == financialPlanId);
+            return await _tramsDbContext.FinancialPlanCases
+                .Include(fp => fp.Status)
+                .SingleOrDefaultAsync(fp => fp.Id == financialPlanId);
         }
 
         public async Task<ICollection<FinancialPlanCase>> GetFinancialPlansByCaseUrn(int caseUrn)
         {
-            return await _tramsDbContext.FinancialPlanCases.Include(fp => fp.Status).Where(s => s.CaseUrn == caseUrn).ToListAsync();
+            return await _tramsDbContext.FinancialPlanCases
+                .Include(fp => fp.Status)
+                .Where(s => s.CaseUrn == caseUrn).ToListAsync();
         }
 
         public async Task<FinancialPlanCase> PatchFinancialPlan(FinancialPlanCase patchedFinancialPlan)

--- a/TramsDataApi/Migrations/TramsDb/20220802144645_IsClosedStatusAndDescriptionToConcernsFinancialPlan.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220802144645_IsClosedStatusAndDescriptionToConcernsFinancialPlan.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220802144645_IsClosedStatusToConcernsFinancialPlan")]
+    partial class IsClosedStatusAndDescriptionToConcernsFinancialPlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20220802144645_IsClosedStatusAndDescriptionToConcernsFinancialPlan.cs
+++ b/TramsDataApi/Migrations/TramsDb/20220802144645_IsClosedStatusAndDescriptionToConcernsFinancialPlan.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class IsClosedStatusAndDescriptionToConcernsFinancialPlan : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsClosedStatus",
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                keyColumn: "Id",
+                keyValue: 1L,
+                column: "Description",
+                value: "Awaiting Plan");
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                keyColumn: "Id",
+                keyValue: 2L,
+                column: "Description",
+                value: "Return To Trust");
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                keyColumn: "Id",
+                keyValue: 3L,
+                columns: new[] { "Description", "IsClosedStatus" },
+                values: new object[] { "Viable Plan Received", true });
+
+            migrationBuilder.UpdateData(
+                schema: "sdd",
+                table: "FinancialPlanStatus",
+                keyColumn: "Id",
+                keyValue: 4L,
+                columns: new[] { "Description", "IsClosedStatus" },
+                values: new object[] { "Abandoned", true });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                schema: "sdd",
+                table: "FinancialPlanStatus");
+
+            migrationBuilder.DropColumn(
+                name: "IsClosedStatus",
+                schema: "sdd",
+                table: "FinancialPlanStatus");
+        }
+    }
+}

--- a/TramsDataApi/UseCases/CaseActions/FinancialPlan/GetFinancialPlanByCaseId.cs
+++ b/TramsDataApi/UseCases/CaseActions/FinancialPlan/GetFinancialPlanByCaseId.cs
@@ -20,7 +20,6 @@ namespace TramsDataApi.UseCases.CaseActions
         {
             return ExecuteAsync(caseUrn).Result;
         }
-
         public async Task<List<FinancialPlanResponse>> ExecuteAsync(int caseUrn)
         {
             var fps = await _gateway.GetFinancialPlansByCaseUrn(caseUrn);


### PR DESCRIPTION
Adding additional status options to Concerns Casework Financial Plan status - some statuses are applicable to financial plan actions which are being edited, and some are applicable to actions which are being closed. 
I've taken a light approach of putting more controller endpoints in and filtering the resultset there as there are only 4 available statuses, so the memory overhead should be light. It should mean the db only needs a queryplan for one query which gets all statuses and then filters in memory, so I can't see it being a performance concern.