### PR TITLE
Feature/105360 cd remove hard coded user lists

### DIFF
--- a/TramsDataApi.Test/Controllers/ConcernsTeamCaseworkControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsTeamCaseworkControllerTests.cs
@@ -25,7 +25,7 @@ namespace TramsDataApi.Test.Controllers
         private Mock<ILogger<ConcernsTeamCaseworkController>> _mockLogger = new Mock<ILogger<ConcernsTeamCaseworkController>>();
 
         [Fact]
-        public async Task Get_Returns200WhenSuccessfullyFetchedData()
+        public async Task Get_Returns200_When_Successfully_Fetched_Data()
         {
             // arrange
             var expectedOwnerId = "john.smith";
@@ -57,7 +57,7 @@ namespace TramsDataApi.Test.Controllers
 
 
         [Fact]
-        public async Task Get_ReturnsNoContentWhenNoDataAvailable()
+        public async Task Get_ReturnsNoContent_When_No_Data_Available()
         {
             // arrange
             var expectedOwnerId = "john.smith";
@@ -80,6 +80,59 @@ namespace TramsDataApi.Test.Controllers
             // act
             var actionResult = await controller.GetTeam("john.smith", CancellationToken.None);
             Assert.IsType<NoContentResult>(actionResult.Result);
+        }
+
+        [Fact]
+        public async Task GetTeamOwners_Returns_200_And_Data_When_Data_Exists()
+        {
+            // arrange
+            var expectedData = new[] { "john.doe", "jane.doe", "fred.flintstone" };
+
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
+            getTeamOwnersCommand.Setup(x => x.Execute(CancellationToken.None)).ReturnsAsync(expectedData);
+
+
+            var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+
+            var controller = new ConcernsTeamCaseworkController(
+                _mockLogger.Object,
+                Mock.Of<IGetConcernsCaseworkTeam>(),
+                getTeamOwnersCommand.Object,
+                updateCommand.Object
+            );
+
+            // act
+            var actionResult = await controller.GetTeamOwners(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            okResult.StatusCode.Value.Should().Be(StatusCodes.Status200OK);
+            (okResult.Value as ApiSingleResponseV2<string[]>).Should().NotBeNull();
+            ((ApiSingleResponseV2<string[]>)okResult.Value).Data.Should().BeEquivalentTo(expectedData);
+        }
+
+        [Fact]
+        public async Task GetTeamOwners_Returns_200_When_No_Data_Exists()
+        {
+            // arrange
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
+            getTeamOwnersCommand.Setup(x => x.Execute(CancellationToken.None)).ReturnsAsync(default(string[]));
+
+            var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+
+            var controller = new ConcernsTeamCaseworkController(
+                _mockLogger.Object,
+                Mock.Of<IGetConcernsCaseworkTeam>(),
+                getTeamOwnersCommand.Object,
+                updateCommand.Object
+            );
+
+            // act
+            var actionResult = await controller.GetTeamOwners(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            okResult.StatusCode.Value.Should().Be(StatusCodes.Status200OK);
+            (okResult.Value as ApiSingleResponseV2<string[]>).Should().NotBeNull();
+            ((ApiSingleResponseV2<string[]>)okResult.Value).Data.Should().BeEquivalentTo(Array.Empty<string>());
         }
 
         [Fact]

--- a/TramsDataApi.Test/Controllers/ConcernsTeamCaseworkControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsTeamCaseworkControllerTests.cs
@@ -31,19 +31,22 @@ namespace TramsDataApi.Test.Controllers
             var expectedOwnerId = "john.smith";
             var expectedData = new ConcernsCaseworkTeamResponse() { OwnerId = expectedOwnerId, TeamMembers = new[] { "john.doe", "jane.doe", "fred.flintstone" } };
             
-            var getCommand = new Mock<IGetConcernsCaseworkTeam>();
-            getCommand.Setup(x => x.Execute(expectedOwnerId, It.IsAny<CancellationToken>())).ReturnsAsync(expectedData);
+            var getTeamCommand = new Mock<IGetConcernsCaseworkTeam>();
+            getTeamCommand.Setup(x => x.Execute(expectedOwnerId, It.IsAny<CancellationToken>())).ReturnsAsync(expectedData);
+
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
 
             var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
 
             var controller = new ConcernsTeamCaseworkController(
                 _mockLogger.Object,
-                getCommand.Object,
+                getTeamCommand.Object,
+                getTeamOwnersCommand.Object,
                 updateCommand.Object
             );
 
             // act
-            var actionResult = await controller.Get("john.smith", CancellationToken.None);
+            var actionResult = await controller.GetTeam("john.smith", CancellationToken.None);
             var expectedResponse = new ApiSingleResponseV2<ConcernsCaseworkTeamResponse>(expectedData);
 
             var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -60,19 +63,22 @@ namespace TramsDataApi.Test.Controllers
             var expectedOwnerId = "john.smith";
             var expectedData = new ConcernsCaseworkTeamResponse() { OwnerId = expectedOwnerId, TeamMembers = new[] { "john.doe", "jane.doe", "fred.flintstone" } };
 
-            var getCommand = new Mock<IGetConcernsCaseworkTeam>();
-            getCommand.Setup(x => x.Execute(expectedOwnerId, It.IsAny<CancellationToken>())).ReturnsAsync(default(ConcernsCaseworkTeamResponse));
+            var getTeamCommand = new Mock<IGetConcernsCaseworkTeam>();
+            getTeamCommand.Setup(x => x.Execute(expectedOwnerId, It.IsAny<CancellationToken>())).ReturnsAsync(default(ConcernsCaseworkTeamResponse));
+
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
 
             var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
 
             var controller = new ConcernsTeamCaseworkController(
                 _mockLogger.Object,
-                getCommand.Object,
+                getTeamCommand.Object,
+                getTeamOwnersCommand.Object,
                 updateCommand.Object
             );
 
             // act
-            var actionResult = await controller.Get("john.smith", CancellationToken.None);
+            var actionResult = await controller.GetTeam("john.smith", CancellationToken.None);
             Assert.IsType<NoContentResult>(actionResult.Result);
         }
 
@@ -80,13 +86,15 @@ namespace TramsDataApi.Test.Controllers
         public async Task Put_ReturnsBadRequest_When_OwnerId_Differs_From_Model()
         {
             // arrange            
-            var getCommand = new Mock<IGetConcernsCaseworkTeam>();
-            var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+            var getTeamCommand = new Mock<IGetConcernsCaseworkTeam>();
+            var updateTeamCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
 
             var controller = new ConcernsTeamCaseworkController(
                 _mockLogger.Object,
-                getCommand.Object,
-                updateCommand.Object
+                getTeamCommand.Object,
+                getTeamOwnersCommand.Object,
+                updateTeamCommand.Object
             );
 
             var updateModel = new ConcernsCaseworkTeamUpdateRequest
@@ -104,14 +112,15 @@ namespace TramsDataApi.Test.Controllers
         public async Task Put_ReturnsBadRequest_When_Model_IsNull()
         {
             // arrange
-            var getCommand = new Mock<IGetConcernsCaseworkTeam>();
-
-            var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+            var getTeamCommand = new Mock<IGetConcernsCaseworkTeam>();
+            var updateTeamCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
 
             var controller = new ConcernsTeamCaseworkController(
                 _mockLogger.Object,
-                getCommand.Object,
-                updateCommand.Object
+                getTeamCommand.Object,
+                getTeamOwnersCommand.Object,
+                updateTeamCommand.Object
             );
 
             // act
@@ -126,15 +135,18 @@ namespace TramsDataApi.Test.Controllers
             var expectedOwnerId = "john.smith";
             var expectedModel = new ConcernsCaseworkTeamUpdateRequest() { OwnerId = expectedOwnerId, TeamMembers = new[] { "john.doe", "jane.doe", "fred.flintstone" } };
 
-            var getCommand = new Mock<IGetConcernsCaseworkTeam>();
-            var updateCommand = new Mock<IUpdateConcernsCaseworkTeam>();
-            updateCommand.Setup(x => x.Execute(expectedModel, It.IsAny<CancellationToken>()))
+            var getTeamCommand = new Mock<IGetConcernsCaseworkTeam>();
+            var updateTeamCommand = new Mock<IUpdateConcernsCaseworkTeam>();
+            var getTeamOwnersCommand = new Mock<IGetConcernsCaseworkTeamOwners>();
+
+            updateTeamCommand.Setup(x => x.Execute(expectedModel, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConcernsCaseworkTeamResponse { OwnerId = expectedModel.OwnerId, TeamMembers = expectedModel.TeamMembers });
 
             var controller = new ConcernsTeamCaseworkController(
                 _mockLogger.Object,
-                getCommand.Object,
-                updateCommand.Object
+                getTeamCommand.Object,
+                getTeamOwnersCommand.Object,
+                updateTeamCommand.Object
             );
 
             // act

--- a/TramsDataApi.Test/UseCases/GetConcernsCaseworkTeamOwnersTests.cs
+++ b/TramsDataApi.Test/UseCases/GetConcernsCaseworkTeamOwnersTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TramsDataApi.Gateways;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class GetConcernsCaseworkTeamOwnersTests
+    {
+        [Fact]
+        public async Task Execute_Calls_Gateway()
+        {
+            var expectedData = new[] { "user.1", "user.2", "user.3" };
+            var mockGateway = new Mock<IConcernsTeamCaseworkGateway>();
+            mockGateway.Setup(x => x.GetTeamOwners(It.IsAny<CancellationToken>())).ReturnsAsync(expectedData);
+            var sut = new GetConcernsCaseworkTeamOwners(mockGateway.Object);
+
+            var result = await sut.Execute(CancellationToken.None);
+            result.Should().BeEquivalentTo(expectedData);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
@@ -35,7 +35,7 @@ namespace TramsDataApi.Controllers.V2
 
         [HttpGet("owners/{ownerId}")]
         [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<ConcernsCaseworkTeamResponse>>> Get(string ownerId, CancellationToken cancellationToken)
+        public async Task<ActionResult<ApiSingleResponseV2<ConcernsCaseworkTeamResponse>>> GetTeam(string ownerId, CancellationToken cancellationToken)
         {
             return await LogAndInvoke(async () =>
             {

--- a/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
@@ -53,15 +53,14 @@ namespace TramsDataApi.Controllers.V2
 
         [HttpGet("owners")]
         [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<string[]>>> Get(CancellationToken cancellationToken)
+        public async Task<ActionResult<ApiSingleResponseV2<string[]>>> GetTeamOwners(CancellationToken cancellationToken)
         {
             return await LogAndInvoke(async () =>
             {
                 var result = await _getTeamOwnersCommand.Execute(cancellationToken);
                 if (result is null)
                 {
-                    // successful, but nothing to return as no team created yet.
-                    return NoContent();
+                    return Ok(new ApiSingleResponseV2<string[]>(Array.Empty<string>()));
                 }
 
                 var responseData = new ApiSingleResponseV2<string[]>(result);

--- a/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
@@ -19,17 +19,21 @@ namespace TramsDataApi.Controllers.V2
     {
         private ILogger<ConcernsTeamCaseworkController> _logger;
         private readonly IGetConcernsCaseworkTeam _getCommand;
+        private readonly IGetConcernsCaseworkTeamOwners _getTeamOwnersCommand;
         private readonly IUpdateConcernsCaseworkTeam _updateCommand;
 
-        public ConcernsTeamCaseworkController(ILogger<ConcernsTeamCaseworkController> logger, IGetConcernsCaseworkTeam getCommand,
+        public ConcernsTeamCaseworkController(ILogger<ConcernsTeamCaseworkController> logger, 
+            IGetConcernsCaseworkTeam getTeamCommand,
+            IGetConcernsCaseworkTeamOwners getTeamOwnersCommand,
             IUpdateConcernsCaseworkTeam updateCommand)
         {
             _logger=logger ?? throw new ArgumentNullException(nameof(logger));
-            _getCommand = getCommand ?? throw new ArgumentNullException(nameof(getCommand));
+            _getCommand = getTeamCommand ?? throw new ArgumentNullException(nameof(getTeamCommand));
+            _getTeamOwnersCommand = getTeamOwnersCommand ?? throw  new ArgumentNullException(nameof(getTeamOwnersCommand));
             _updateCommand = updateCommand ?? throw new ArgumentNullException(nameof(updateCommand));
         }
 
-        [HttpGet("owner/{ownerId}")]
+        [HttpGet("owners/{ownerId}")]
         [MapToApiVersion("2.0")]
         public async Task<ActionResult<ApiSingleResponseV2<ConcernsCaseworkTeamResponse>>> Get(string ownerId, CancellationToken cancellationToken)
         {
@@ -47,7 +51,25 @@ namespace TramsDataApi.Controllers.V2
             });
         }
 
-        [HttpPut("owner/{ownerId}")]
+        [HttpGet("owners")]
+        [MapToApiVersion("2.0")]
+        public async Task<ActionResult<ApiSingleResponseV2<string[]>>> Get(CancellationToken cancellationToken)
+        {
+            return await LogAndInvoke(async () =>
+            {
+                var result = await _getTeamOwnersCommand.Execute(cancellationToken);
+                if (result is null)
+                {
+                    // successful, but nothing to return as no team created yet.
+                    return NoContent();
+                }
+
+                var responseData = new ApiSingleResponseV2<string[]>(result);
+                return Ok(responseData);
+            });
+        }
+
+        [HttpPut("owners/{ownerId}")]
         [MapToApiVersion("2.0")]
         public async Task<ActionResult<ApiSingleResponseV2<ConcernsCaseworkTeamResponse>>> Put(
             string ownerId,

--- a/TramsDataApi/Gateways/ConcernsTeamCaseworkGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsTeamCaseworkGateway.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.ChangeTracking;
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,9 +19,9 @@ namespace TramsDataApi.Gateways
 
         public async Task AddCaseworkTeam(ConcernsCaseworkTeam team, CancellationToken cancellationToken)
         {
-            _ = team ?? throw new ArgumentNullException(nameof(team));            
+            _ = team ?? throw new ArgumentNullException(nameof(team));
             _ = team.TeamMembers ?? throw new ArgumentNullException(nameof(team.TeamMembers));
-            
+
             _tramsDbContext.ConcernsTeamCaseworkTeam.Add(team);
             await _tramsDbContext.SaveChangesAsync(cancellationToken);
         }
@@ -34,11 +33,9 @@ namespace TramsDataApi.Gateways
                 throw new ArgumentNullException(nameof(ownerId));
             }
 
-            var team = await _tramsDbContext.ConcernsTeamCaseworkTeam
+            return await _tramsDbContext.ConcernsTeamCaseworkTeam
                 .Include(t => t.TeamMembers)
-                .FirstOrDefaultAsync(x => x.Id == ownerId);
-
-            return team;
+                .FirstOrDefaultAsync(x => x.Id == ownerId, cancellationToken);
         }
 
         public async Task UpdateCaseworkTeam(ConcernsCaseworkTeam team, CancellationToken cancellationToken)
@@ -49,9 +46,16 @@ namespace TramsDataApi.Gateways
                 throw new ArgumentNullException(nameof(team.Id));
             }
             _ = team.TeamMembers ?? throw new ArgumentNullException(nameof(team.TeamMembers));
-            
+
             _tramsDbContext.ConcernsTeamCaseworkTeam.Update(team);
             await _tramsDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        public async Task<string[]> GetTeamOwners(CancellationToken cancellationToken)
+        {
+            return await _tramsDbContext.ConcernsTeamCaseworkTeam
+                .Select(x => x.Id)
+                .ToArrayAsync(cancellationToken);
         }
     }
 }

--- a/TramsDataApi/Gateways/IConcernsTeamCaseworkGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsTeamCaseworkGateway.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using TramsDataApi.DatabaseModels.Concerns.TeamCasework;
 
@@ -10,5 +9,6 @@ namespace TramsDataApi.Gateways
         Task<ConcernsCaseworkTeam> GetByOwnerId(string ownerId, CancellationToken cancellationToken);
         Task UpdateCaseworkTeam(ConcernsCaseworkTeam team, CancellationToken cancellationToken);
         Task AddCaseworkTeam(ConcernsCaseworkTeam team, CancellationToken cancellationToken);
+        Task<string[]> GetTeamOwners(CancellationToken cancellationToken);
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -95,6 +95,7 @@ namespace TramsDataApi
             services.AddScoped<ISearchAcademyConversionProjects, SearchAcademyConversionProjects>();
 
             services.AddScoped<IGetConcernsCaseworkTeam, GetConcernsCaseworkTeam>();
+            services.AddScoped<IGetConcernsCaseworkTeamOwners, GetConcernsCaseworkTeamOwners>();
             services.AddScoped<IUpdateConcernsCaseworkTeam, UpdateConcernsCaseworkTeam>();
             services.AddScoped<IConcernsTeamCaseworkGateway, ConcernsTeamCaseworkGateway>();
 

--- a/TramsDataApi/UseCases/GetConcernsCaseworkTeamOwners.cs
+++ b/TramsDataApi/UseCases/GetConcernsCaseworkTeamOwners.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TramsDataApi.Gateways;
+
+namespace TramsDataApi.UseCases
+{
+    public class GetConcernsCaseworkTeamOwners : IGetConcernsCaseworkTeamOwners
+    {
+        private readonly IConcernsTeamCaseworkGateway _gateway;
+
+        public GetConcernsCaseworkTeamOwners(IConcernsTeamCaseworkGateway gateway)
+        {
+            _gateway = gateway ?? throw new ArgumentNullException(nameof(gateway));
+        }
+        public async Task<string[]> Execute(CancellationToken cancellationToken)
+        {
+            return await _gateway.GetTeamOwners(cancellationToken);
+        }
+    }
+}

--- a/TramsDataApi/UseCases/IGetConcernsCaseworkTeamOwners.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseworkTeamOwners.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IGetConcernsCaseworkTeamOwners
+    {
+        public Task<string[]> Execute(CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
What is the change?
To return a list of concerns casework team owners, via a new /owners endpoint

Why do we need the change?
Concerns casework will use this list to identify users who have at some point logged into concerns casework

What is the impact?
No impact on existing endpoints. Needed for requirements

Azure DevOps Ticket
105360