### PR TITLE
Add obsolete and deprecated flags to concerns casework code that is planned to be moved into the Concerns Casework API

### DIFF
--- a/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-cases")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseController: ControllerBase
     { 
         private readonly ILogger<ConcernsCaseController> _logger;

--- a/TramsDataApi/Controllers/V2/ConcernsMeansOfReferralController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsMeansOfReferralController.cs
@@ -1,13 +1,15 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.UseCases;
 
 namespace TramsDataApi.Controllers.V2
 {
-    [ApiVersion("2.0")]
+    [ApiVersion("2.0", Deprecated = true)]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-meansofreferral")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsMeansOfReferralController: ControllerBase
     {
         

--- a/TramsDataApi/Controllers/V2/ConcernsRatingController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsRatingController.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TramsDataApi.ResponseModels;
@@ -8,6 +9,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-ratings")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRatingController: ControllerBase
     {
         private readonly ILogger<ConcernsRatingController> _logger;

--- a/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsRecordController.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -11,6 +12,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-records")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     
     public class ConcernsRecordController : ControllerBase
     {

--- a/TramsDataApi/Controllers/V2/ConcernsStatusController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsStatusController.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TramsDataApi.ResponseModels;
@@ -8,6 +9,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-statuses")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsStatusController: ControllerBase
     {
         private ILogger<ConcernsStatusController> _logger;

--- a/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTeamCaseworkController.cs
@@ -14,6 +14,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-team-casework")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
 
     public class ConcernsTeamCaseworkController : ControllerBase
     {

--- a/TramsDataApi/Controllers/V2/ConcernsTypeController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsTypeController.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TramsDataApi.ResponseModels;
@@ -8,6 +9,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-types")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsTypeController: ControllerBase
     {
         

--- a/TramsDataApi/Controllers/V2/FinancialPlanController.cs
+++ b/TramsDataApi/Controllers/V2/FinancialPlanController.cs
@@ -13,6 +13,7 @@ namespace TramsDataApi.Controllers.V2
 {
     [ApiVersion("2.0")]
     [Route("v{version:apiVersion}/case-actions/financial-plan")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [ApiController]
     public class FinancialPlanController : Controller
     {

--- a/TramsDataApi/Controllers/V2/NTIUnderConsiderationController.cs
+++ b/TramsDataApi/Controllers/V2/NTIUnderConsiderationController.cs
@@ -13,6 +13,7 @@ namespace TramsDataApi.Controllers.V2
 {
     [ApiVersion("2.0")]
     [Route("v{version:apiVersion}/case-actions/nti-under-consideration")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [ApiController]
     public class NTIUnderConsiderationController : Controller
     {

--- a/TramsDataApi/Controllers/V2/NTIWarningLetterController.cs
+++ b/TramsDataApi/Controllers/V2/NTIWarningLetterController.cs
@@ -13,6 +13,7 @@ namespace TramsDataApi.Controllers.V2
 {
     [ApiVersion("2.0")]
     [Route("v{version:apiVersion}/case-actions/nti-warning-letter")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [ApiController]
     public class NTIWarningLetterController : Controller
     {

--- a/TramsDataApi/Controllers/V2/NoticeToImproveController.cs
+++ b/TramsDataApi/Controllers/V2/NoticeToImproveController.cs
@@ -13,6 +13,7 @@ namespace TramsDataApi.Controllers.V2
 {
     [ApiVersion("2.0")]
     [Route("v{version:apiVersion}/case-actions/notice-to-improve")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [ApiController]
     public class NoticeToImproveController : Controller
     {

--- a/TramsDataApi/Controllers/V2/SRMAController.cs
+++ b/TramsDataApi/Controllers/V2/SRMAController.cs
@@ -15,6 +15,7 @@ namespace TramsDataApi.Controllers.V2
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/case-actions/srma")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class SRMAController : Controller
     {
         private readonly ILogger<SRMAController> _logger;

--- a/TramsDataApi/DatabaseModels/Concerns/TeamCasework/ConcernsCaseworkTeam.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/TeamCasework/ConcernsCaseworkTeam.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels.Concerns.TeamCasework
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("ConcernsCaseworkTeam", Schema = "sdd")]
     public class ConcernsCaseworkTeam
     {

--- a/TramsDataApi/DatabaseModels/Concerns/TeamCasework/ConcernsCaseworkTeamMember.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/TeamCasework/ConcernsCaseworkTeamMember.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels.Concerns.TeamCasework
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("ConcernsCaseworkTeamMember", Schema = "sdd")]
     public class ConcernsCaseworkTeamMember
     {

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCase
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/ConcernsMeansOfReferral.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsMeansOfReferral.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsMeansOfReferral
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/ConcernsRating.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsRating.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRating
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/ConcernsRecord.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsRecord.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRecord
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/ConcernsStatus.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsStatus.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsStatus
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/ConcernsType.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsType.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsType
     {
         public int Id { get; set; }

--- a/TramsDataApi/DatabaseModels/FinancialPlanCase.cs
+++ b/TramsDataApi/DatabaseModels/FinancialPlanCase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("FinancialPlanCase", Schema = "sdd")]
     public class FinancialPlanCase
     {

--- a/TramsDataApi/DatabaseModels/FinancialPlanStatus.cs
+++ b/TramsDataApi/DatabaseModels/FinancialPlanStatus.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("FinancialPlanStatus", Schema = "sdd")]
     public class FinancialPlanStatus
     {

--- a/TramsDataApi/DatabaseModels/NTIUnderConsideration.cs
+++ b/TramsDataApi/DatabaseModels/NTIUnderConsideration.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIUnderConsiderationCase", Schema = "sdd")]
     public class NTIUnderConsideration
     {

--- a/TramsDataApi/DatabaseModels/NTIUnderConsiderationReason.cs
+++ b/TramsDataApi/DatabaseModels/NTIUnderConsiderationReason.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIUnderConsiderationReason", Schema = "sdd")]
     public class NTIUnderConsiderationReason
     {

--- a/TramsDataApi/DatabaseModels/NTIUnderConsiderationReasonMapping.cs
+++ b/TramsDataApi/DatabaseModels/NTIUnderConsiderationReasonMapping.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIUnderConsiderationReasonMapping", Schema = "sdd")]
 	public class NTIUnderConsiderationReasonMapping
 	{

--- a/TramsDataApi/DatabaseModels/NTIUnderConsiderationStatus.cs
+++ b/TramsDataApi/DatabaseModels/NTIUnderConsiderationStatus.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIUnderConsiderationStatus", Schema = "sdd")]
     public class NTIUnderConsiderationStatus
     {

--- a/TramsDataApi/DatabaseModels/NTIWarningLetter.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetter.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterCase", Schema = "sdd")]
     public class NTIWarningLetter
     {

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterCondition.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterCondition.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterCondition", Schema = "sdd")]
     public class NTIWarningLetterCondition
     {

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterConditionMapping.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterConditionMapping.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterConditionMapping", Schema = "sdd")]
 	public class NTIWarningLetterConditionMapping
 	{

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterConditionType.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterConditionType.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterConditionType", Schema = "sdd")]
     public class NTIWarningLetterConditionType
     {

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterReason.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterReason.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterReason", Schema = "sdd")]
     public class NTIWarningLetterReason
     {

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterReasonMapping.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterReasonMapping.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterReasonMapping", Schema = "sdd")]
 	public class NTIWarningLetterReasonMapping
 	{

--- a/TramsDataApi/DatabaseModels/NTIWarningLetterStatus.cs
+++ b/TramsDataApi/DatabaseModels/NTIWarningLetterStatus.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NTIWarningLetterStatus", Schema = "sdd")]
     public class NTIWarningLetterStatus
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImprove.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImprove.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveCase", Schema = "sdd")]
     public class NoticeToImprove
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveCondition.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveCondition.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveCondition", Schema = "sdd")]
     public class NoticeToImproveCondition
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveConditionMapping.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveConditionMapping.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveConditionMapping", Schema = "sdd")]
 	public class NoticeToImproveConditionMapping
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveConditionType.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveConditionType.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveConditionType", Schema = "sdd")]
     public class NoticeToImproveConditionType
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveReason.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveReason.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveReason", Schema = "sdd")]
     public class NoticeToImproveReason
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveReasonMapping.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveReasonMapping.cs
@@ -1,8 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveReasonMapping", Schema = "sdd")]
 	public class NoticeToImproveReasonMapping
     {

--- a/TramsDataApi/DatabaseModels/NoticeToImproveStatus.cs
+++ b/TramsDataApi/DatabaseModels/NoticeToImproveStatus.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("NoticeToImproveStatus", Schema = "sdd")]
     public class NoticeToImproveStatus
     {

--- a/TramsDataApi/DatabaseModels/SRMACase.cs
+++ b/TramsDataApi/DatabaseModels/SRMACase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("SRMACase", Schema = "sdd")]
     public class SRMACase
     {

--- a/TramsDataApi/DatabaseModels/SRMAReason.cs
+++ b/TramsDataApi/DatabaseModels/SRMAReason.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("SRMAReason", Schema = "sdd")]
     public class SRMAReason
     {

--- a/TramsDataApi/DatabaseModels/SRMAStatus.cs
+++ b/TramsDataApi/DatabaseModels/SRMAStatus.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TramsDataApi.DatabaseModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     [Table("SRMAStatus", Schema = "sdd")]
     public class SRMAStatus
     {

--- a/TramsDataApi/Factories/CaseActionFactories/FinancialPlanFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/FinancialPlanFactory.cs
@@ -1,10 +1,12 @@
-﻿using TramsDataApi.DatabaseModels;
+﻿using System;
+using TramsDataApi.DatabaseModels;
 using TramsDataApi.Enums;
 using TramsDataApi.RequestModels.CaseActions.FinancialPlan;
 using TramsDataApi.ResponseModels.CaseActions.FinancialPlan;
 
 namespace TramsDataApi.Factories.CaseActionFactories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class FinancialPlanFactory
     {
         public static FinancialPlanCase CreateDBModel(CreateFinancialPlanRequest createFinancialPlanRequest)

--- a/TramsDataApi/Factories/CaseActionFactories/NTIUnderConsiderationFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/NTIUnderConsiderationFactory.cs
@@ -6,6 +6,7 @@ using TramsDataApi.ResponseModels.CaseActions.NTI.UnderConsideration;
 
 namespace TramsDataApi.Factories.CaseActionFactories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class NTIUnderConsiderationFactory
     {
         public static NTIUnderConsideration CreateDBModel(CreateNTIUnderConsiderationRequest createNTIUnderConsiderationRequest)

--- a/TramsDataApi/Factories/CaseActionFactories/NTIWarningLetterFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/NTIWarningLetterFactory.cs
@@ -6,6 +6,7 @@ using TramsDataApi.ResponseModels.CaseActions.NTI.WarningLetter;
 
 namespace TramsDataApi.Factories.CaseActionFactories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class NTIWarningLetterFactory
     {
         public static NTIWarningLetter CreateDBModel(CreateNTIWarningLetterRequest createNTIWarningLetterRequest)

--- a/TramsDataApi/Factories/CaseActionFactories/NoticeToImproveFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/NoticeToImproveFactory.cs
@@ -7,6 +7,7 @@ using TramsDataApi.ResponseModels.CaseActions.NTI.WarningLetter;
 
 namespace TramsDataApi.Factories.CaseActionFactories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class NoticeToImproveFactory
     {
         public static NoticeToImprove CreateDBModel(CreateNoticeToImproveRequest createNoticeToImproveRequest)

--- a/TramsDataApi/Factories/CaseActionFactories/SRMAFactory.cs
+++ b/TramsDataApi/Factories/CaseActionFactories/SRMAFactory.cs
@@ -1,10 +1,12 @@
-﻿using TramsDataApi.DatabaseModels;
+﻿using System;
+using TramsDataApi.DatabaseModels;
 using TramsDataApi.Enums;
 using TramsDataApi.RequestModels.CaseActions.SRMA;
 using TramsDataApi.ResponseModels.CaseActions.SRMA;
 
 namespace TramsDataApi.Factories.CaseActionFactories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class SRMAFactory
     {
         public static SRMACase CreateDBModel(CreateSRMARequest createSRMARequest)

--- a/TramsDataApi/Factories/ConcernsCaseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.RequestModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseFactory
     {
         public static ConcernsCase Create(ConcernCaseRequest request)

--- a/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsCaseResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseResponseFactory
     {
         public static ConcernsCaseResponse Create(ConcernsCase concernsCase)

--- a/TramsDataApi/Factories/ConcernsMeansOfReferralResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsMeansOfReferralResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class ConcernsMeansOfReferralResponseFactory
     {
         public static ConcernsMeansOfReferralResponse Create(ConcernsMeansOfReferral concernsMeansOfReferral)

--- a/TramsDataApi/Factories/ConcernsRatingResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRatingResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRatingResponseFactory
     {
         public static ConcernsRatingResponse Create(ConcernsRating concernsRating)

--- a/TramsDataApi/Factories/ConcernsRecordFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.RequestModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public static class ConcernsRecordFactory
     {
         public static ConcernsRecord Create(

--- a/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsRecordResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRecordResponseFactory
     {
         public static ConcernsRecordResponse Create(ConcernsRecord concernsRecord)

--- a/TramsDataApi/Factories/ConcernsStatusResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsStatusResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsStatusResponseFactory
     {
         public  static ConcernsStatusResponse Create(ConcernsStatus concernsStatus)

--- a/TramsDataApi/Factories/ConcernsTypeResponseFactory.cs
+++ b/TramsDataApi/Factories/ConcernsTypeResponseFactory.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Factories
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsTypeResponseFactory
     {
         public static ConcernsTypeResponse Create(ConcernsType concernsType)

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
@@ -5,6 +6,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseGateway : IConcernsCaseGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsMeansOfReferralGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsMeansOfReferralGateway.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsMeansOfReferralGateway : IConcernsMeansOfReferralGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsRatingsGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsRatingsGateway.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRatingsGateway : IConcernsRatingGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsRecordGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsRecordGateway.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRecordGateway : IConcernsRecordGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsStatusGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsStatusGateway.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsStatusGateway : IConcernsStatusGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsTeamCaseworkGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsTeamCaseworkGateway.cs
@@ -8,6 +8,7 @@ using static Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsTeamCaseworkGateway : IConcernsTeamCaseworkGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/ConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsTypeGateway.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsTypeGateway : IConcernsTypeGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/FinancialPlanGateway.cs
+++ b/TramsDataApi/Gateways/FinancialPlanGateway.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class FinancialPlanGateway : IFinancialPlanGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/IConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsCaseGateway.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsCaseGateway
     {
         ConcernsCase SaveConcernsCase(ConcernsCase concernsCase);

--- a/TramsDataApi/Gateways/IConcernsMeansOfReferralGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsMeansOfReferralGateway.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsMeansOfReferralGateway
     {
         IList<ConcernsMeansOfReferral> GetMeansOfReferrals();

--- a/TramsDataApi/Gateways/IConcernsRatingGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsRatingGateway.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsRatingGateway
     {
         IList<ConcernsRating> GetRatings();

--- a/TramsDataApi/Gateways/IConcernsRecordGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsRecordGateway.cs
@@ -1,7 +1,9 @@
+using System;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsRecordGateway
     {
         ConcernsRecord SaveConcernsCase(ConcernsRecord concernsRecord);

--- a/TramsDataApi/Gateways/IConcernsStatusGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsStatusGateway.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsStatusGateway
     {
         IList<ConcernsStatus> GetStatuses();

--- a/TramsDataApi/Gateways/IConcernsTeamCaseworkGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsTeamCaseworkGateway.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using TramsDataApi.DatabaseModels.Concerns.TeamCasework;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsTeamCaseworkGateway
     {
         Task<ConcernsCaseworkTeam> GetByOwnerId(string ownerId, CancellationToken cancellationToken);

--- a/TramsDataApi/Gateways/IConcernsTypeGateway.cs
+++ b/TramsDataApi/Gateways/IConcernsTypeGateway.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IConcernsTypeGateway
     {
         ConcernsType GetConcernsTypeByUrn(int urn);

--- a/TramsDataApi/Gateways/IFinancialPlanGateway.cs
+++ b/TramsDataApi/Gateways/IFinancialPlanGateway.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IFinancialPlanGateway
     {
         Task<FinancialPlanCase> CreateFinancialPlan(FinancialPlanCase request);

--- a/TramsDataApi/Gateways/INTIUnderConsiderationGateway.cs
+++ b/TramsDataApi/Gateways/INTIUnderConsiderationGateway.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface INTIUnderConsiderationGateway
     {
         Task<NTIUnderConsideration> CreateNTIUnderConsideration(NTIUnderConsideration request);

--- a/TramsDataApi/Gateways/INTIWarningLetterGateway.cs
+++ b/TramsDataApi/Gateways/INTIWarningLetterGateway.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface INTIWarningLetterGateway
     {
         Task<NTIWarningLetter> CreateNTIWarningLetter(NTIWarningLetter request);

--- a/TramsDataApi/Gateways/INoticeToImproveGateway.cs
+++ b/TramsDataApi/Gateways/INoticeToImproveGateway.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface INoticeToImproveGateway
     {
         Task<NoticeToImprove> CreateNoticeToImprove(NoticeToImprove request);

--- a/TramsDataApi/Gateways/ISRMAGateway.cs
+++ b/TramsDataApi/Gateways/ISRMAGateway.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface ISRMAGateway
     {
         Task<SRMACase> CreateSRMA(SRMACase request);

--- a/TramsDataApi/Gateways/NTIUnderConsiderationGateway.cs
+++ b/TramsDataApi/Gateways/NTIUnderConsiderationGateway.cs
@@ -8,6 +8,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
 	public class NTIUnderConsiderationGateway : INTIUnderConsiderationGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/NTIWarningLetterGateway.cs
+++ b/TramsDataApi/Gateways/NTIWarningLetterGateway.cs
@@ -8,6 +8,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
 	public class NTIWarningLetterGateway : INTIWarningLetterGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/NoticeToImproveGateway.cs
+++ b/TramsDataApi/Gateways/NoticeToImproveGateway.cs
@@ -8,6 +8,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
 	public class NoticeToImproveGateway : INoticeToImproveGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/Gateways/SRMAGateway.cs
+++ b/TramsDataApi/Gateways/SRMAGateway.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 
 namespace TramsDataApi.Gateways
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class SRMAGateway : ISRMAGateway
     {
         private readonly TramsDbContext _tramsDbContext;

--- a/TramsDataApi/RequestModels/CaseActions/FinancialPlan/CreateFinancialPlanRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/FinancialPlan/CreateFinancialPlanRequest.cs
@@ -4,6 +4,7 @@ using TramsDataApi.Enums;
 
 namespace TramsDataApi.RequestModels.CaseActions.FinancialPlan
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateFinancialPlanRequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/CaseActions/FinancialPlan/PatchFinancialPlanRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/FinancialPlan/PatchFinancialPlanRequest.cs
@@ -4,6 +4,7 @@ using TramsDataApi.Enums;
 
 namespace TramsDataApi.RequestModels.CaseActions.FinancialPlan
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class PatchFinancialPlanRequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/NoticeToImprove/CreateNoticeToImproveRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/NoticeToImprove/CreateNoticeToImproveRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.NoticeToImprove
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateNoticeToImproveRequest
     {
 		[Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/NoticeToImprove/PatchNoticeToImproveRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/NoticeToImprove/PatchNoticeToImproveRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.NoticeToImprove
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class PatchNoticeToImproveRequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/UnderConsideration/CreateNTIUnderConsiderationRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/UnderConsideration/CreateNTIUnderConsiderationRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.UnderConsideration
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateNTIUnderConsiderationRequest
 	{
 		[Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/UnderConsideration/PatchNTIUnderConsiderationRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/UnderConsideration/PatchNTIUnderConsiderationRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.UnderConsideration
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class PatchNTIUnderConsiderationRequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/WarningLetter/CreateNTIWarningLetterRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/WarningLetter/CreateNTIWarningLetterRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.WarningLetter
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateNTIWarningLetterRequest
     {
 		[Required]

--- a/TramsDataApi/RequestModels/CaseActions/NTI/WarningLetter/PatchNTIWarningLetterRequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/NTI/WarningLetter/PatchNTIWarningLetterRequest.cs
@@ -5,6 +5,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.NTI.WarningLetter
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class PatchNTIWarningLetterRequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/CaseActions/SRMA/CreateSRMARequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/SRMA/CreateSRMARequest.cs
@@ -4,6 +4,7 @@ using TramsDataApi.Enums;
 
 namespace TramsDataApi.RequestModels.CaseActions.SRMA
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateSRMARequest
     {
 		[Required]

--- a/TramsDataApi/RequestModels/CaseActions/SRMA/PatchSRMARequest.cs
+++ b/TramsDataApi/RequestModels/CaseActions/SRMA/PatchSRMARequest.cs
@@ -4,6 +4,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels.CaseActions.SRMA
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class PatchSRMARequest
     {
         [Required]

--- a/TramsDataApi/RequestModels/ConcernCaseRequest.cs
+++ b/TramsDataApi/RequestModels/ConcernCaseRequest.cs
@@ -4,6 +4,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.RequestModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernCaseRequest
     {
         public DateTime CreatedAt { get; set; }

--- a/TramsDataApi/RequestModels/Concerns/TeamCasework/ConcernsCaseworkTeamUpdateRequest.cs
+++ b/TramsDataApi/RequestModels/Concerns/TeamCasework/ConcernsCaseworkTeamUpdateRequest.cs
@@ -1,5 +1,8 @@
-﻿namespace TramsDataApi.RequestModels.Concerns.TeamCasework
+﻿using System;
+
+namespace TramsDataApi.RequestModels.Concerns.TeamCasework
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseworkTeamUpdateRequest
     {
         public string OwnerId { get; set; }

--- a/TramsDataApi/RequestModels/ConcernsRecordRequest.cs
+++ b/TramsDataApi/RequestModels/ConcernsRecordRequest.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.RequestModels
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRecordRequest
     {
         public DateTime CreatedAt { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/FinancialPlan/FinancialPlanResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/FinancialPlan/FinancialPlanResponse.cs
@@ -4,6 +4,7 @@ using TramsDataApi.Enums;
 
 namespace TramsDataApi.ResponseModels.CaseActions.FinancialPlan
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class FinancialPlanResponse
     {
         public long Id { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/NTI/NoticeToImprove/NoticeToImproveResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/NTI/NoticeToImprove/NoticeToImproveResponse.cs
@@ -4,6 +4,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.ResponseModels.CaseActions.NTI.NoticeToImprove
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class NoticeToImproveResponse
     {
 		public long Id { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/NTI/UnderConsideration/NTIUnderConsiderationResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/NTI/UnderConsideration/NTIUnderConsiderationResponse.cs
@@ -4,6 +4,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.ResponseModels.CaseActions.NTI.UnderConsideration
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class NTIUnderConsiderationResponse
 	{
 		public long Id { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/NTI/WarningLetter/NTIWarningLetterResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/NTI/WarningLetter/NTIWarningLetterResponse.cs
@@ -4,6 +4,7 @@ using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.ResponseModels.CaseActions.NTI.WarningLetter
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class NTIWarningLetterResponse
 	{
 		public long Id { get; set; }

--- a/TramsDataApi/ResponseModels/CaseActions/SRMA/SRMAResponse.cs
+++ b/TramsDataApi/ResponseModels/CaseActions/SRMA/SRMAResponse.cs
@@ -3,6 +3,7 @@ using TramsDataApi.Enums;
 
 namespace TramsDataApi.ResponseModels.CaseActions.SRMA
 {
+	[Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class SRMAResponse
     {
 		public int Id { get; set; }

--- a/TramsDataApi/ResponseModels/Concerns/TeamCasework/ConcernsCaseworkTeamResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/TeamCasework/ConcernsCaseworkTeamResponse.cs
@@ -1,5 +1,8 @@
-﻿namespace TramsDataApi.ResponseModels.Concerns.TeamCasework
+﻿using System;
+
+namespace TramsDataApi.ResponseModels.Concerns.TeamCasework
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseworkTeamResponse
     {
         public string OwnerId { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsCaseResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsCaseResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseResponse
     {
         public DateTime CreatedAt { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsMeansOfReferralResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsMeansOfReferralResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsMeansOfReferralResponse
     {
         public string Name { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsRatingResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsRatingResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRatingResponse
     {
         public string Name { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsRecordResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsRecordResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsRecordResponse
     {
         public DateTime CreatedAt { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsStatusResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsStatusResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsStatusResponse
     {
         public string Name { get; set; }

--- a/TramsDataApi/ResponseModels/ConcernsTypeResponse.cs
+++ b/TramsDataApi/ResponseModels/ConcernsTypeResponse.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace TramsDataApi.ResponseModels
 {
+    [Obsolete("This class is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsTypeResponse
     {
         public string Name { get; set; }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -113,7 +113,6 @@ namespace TramsDataApi
             services.AddSwaggerGen();
             services.ConfigureOptions<SwaggerOptions>();
             services.AddUseCases();
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TramsDataApi/UseCases/ICreateConcernsCase.cs
+++ b/TramsDataApi/UseCases/ICreateConcernsCase.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface ICreateConcernsCase
     {
         public ConcernsCaseResponse Execute(ConcernCaseRequest request);

--- a/TramsDataApi/UseCases/ICreateConcernsRecord.cs
+++ b/TramsDataApi/UseCases/ICreateConcernsRecord.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface ICreateConcernsRecord
     {
         public ConcernsRecordResponse Execute(ConcernsRecordRequest request);

--- a/TramsDataApi/UseCases/IGetConcernsCaseByTrustUkprn.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseByTrustUkprn.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsCaseByTrustUkprn
     {
         public IList<ConcernsCaseResponse> Execute(string trustUkprn, int page, int count);

--- a/TramsDataApi/UseCases/IGetConcernsCaseByUrn.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseByUrn.cs
@@ -1,7 +1,9 @@
+using System;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsCaseByUrn
     {
         public ConcernsCaseResponse Execute(int urn);

--- a/TramsDataApi/UseCases/IGetConcernsCasesByOwnerId.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCasesByOwnerId.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsCasesByOwnerId
     {
         IList<ConcernsCaseResponse> Execute(string ownerId, int? statusUrn, int page, int count);

--- a/TramsDataApi/UseCases/IGetConcernsCaseworkTeam.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseworkTeam.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using TramsDataApi.ResponseModels.Concerns.TeamCasework;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsCaseworkTeam
     {
         public Task<ConcernsCaseworkTeamResponse> Execute(string ownerId, CancellationToken cancellationToken);

--- a/TramsDataApi/UseCases/IGetConcernsCaseworkTeamOwners.cs
+++ b/TramsDataApi/UseCases/IGetConcernsCaseworkTeamOwners.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsCaseworkTeamOwners
     {
         public Task<string[]> Execute(CancellationToken cancellationToken);

--- a/TramsDataApi/UseCases/IGetConcernsRecordsByCaseUrn.cs
+++ b/TramsDataApi/UseCases/IGetConcernsRecordsByCaseUrn.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IGetConcernsRecordsByCaseUrn
     {
         public IList<ConcernsRecordResponse> Execute(int caseUrn);

--- a/TramsDataApi/UseCases/IIndexConcernsMeansOfReferrals.cs
+++ b/TramsDataApi/UseCases/IIndexConcernsMeansOfReferrals.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IIndexConcernsMeansOfReferrals
     {
         public IList<ConcernsMeansOfReferralResponse> Execute();

--- a/TramsDataApi/UseCases/IIndexConcernsRatings.cs
+++ b/TramsDataApi/UseCases/IIndexConcernsRatings.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IIndexConcernsRatings
     {
         public IList<ConcernsRatingResponse> Execute();

--- a/TramsDataApi/UseCases/IIndexConcernsStatuses.cs
+++ b/TramsDataApi/UseCases/IIndexConcernsStatuses.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IIndexConcernsStatuses
     {
         public IList<ConcernsStatusResponse> Execute();

--- a/TramsDataApi/UseCases/IIndexConcernsTypes.cs
+++ b/TramsDataApi/UseCases/IIndexConcernsTypes.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IIndexConcernsTypes
     {
         public IList<ConcernsTypeResponse> Execute();

--- a/TramsDataApi/UseCases/IUpdateConcernsCase.cs
+++ b/TramsDataApi/UseCases/IUpdateConcernsCase.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IUpdateConcernsCase
     {
        ConcernsCaseResponse Execute(int urn, ConcernCaseRequest request);

--- a/TramsDataApi/UseCases/IUpdateConcernsCaseworkTeam.cs
+++ b/TramsDataApi/UseCases/IUpdateConcernsCaseworkTeam.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using TramsDataApi.RequestModels.Concerns.TeamCasework;
 using TramsDataApi.ResponseModels.Concerns.TeamCasework;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IUpdateConcernsCaseworkTeam
     {
         public Task<ConcernsCaseworkTeamResponse> Execute(ConcernsCaseworkTeamUpdateRequest updateRequest, CancellationToken cancellationToken);

--- a/TramsDataApi/UseCases/IUpdateConcernsRecord.cs
+++ b/TramsDataApi/UseCases/IUpdateConcernsRecord.cs
@@ -1,8 +1,10 @@
+using System;
 using TramsDataApi.RequestModels;
 using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IUpdateConcernsRecord
     {
         ConcernsRecordResponse Execute(int urn, ConcernsRecordRequest request);

--- a/TramsDataApi/UseCases/IndexConcernsMeansOfReferrals.cs
+++ b/TramsDataApi/UseCases/IndexConcernsMeansOfReferrals.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
@@ -6,6 +7,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class IndexConcernsMeansOfReferrals : IIndexConcernsMeansOfReferrals
     {
         private IConcernsMeansOfReferralGateway _concernsMeansOfReferralGateway;

--- a/TramsDataApi/UseCases/IndexConcernsRatings.cs
+++ b/TramsDataApi/UseCases/IndexConcernsRatings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.Factories;
@@ -6,6 +7,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class IndexConcernsRatings : IIndexConcernsRatings
     {
         private readonly IConcernsRatingGateway _concernsRatingGateway;

--- a/TramsDataApi/UseCases/IndexConcernsStatuses.cs
+++ b/TramsDataApi/UseCases/IndexConcernsStatuses.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.Factories;
@@ -6,6 +7,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class IndexConcernsStatuses : IIndexConcernsStatuses
     {
         private IConcernsStatusGateway _concernsStatusGateway;

--- a/TramsDataApi/UseCases/IndexConcernsTypes.cs
+++ b/TramsDataApi/UseCases/IndexConcernsTypes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.Factories;
@@ -6,6 +7,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class IndexConcernsTypes : IIndexConcernsTypes
     {
         private IConcernsTypeGateway _concernsTypeGateway;

--- a/TramsDataApi/UseCases/UpdateConcernsCase.cs
+++ b/TramsDataApi/UseCases/UpdateConcernsCase.cs
@@ -1,3 +1,4 @@
+using System;
 using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
 using TramsDataApi.RequestModels;
@@ -5,6 +6,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class UpdateConcernsCase : IUpdateConcernsCase
     {
         private readonly IConcernsCaseGateway _concernsCaseGateway;

--- a/TramsDataApi/UseCases/UpdateConcernsCaseworkTeam.cs
+++ b/TramsDataApi/UseCases/UpdateConcernsCaseworkTeam.cs
@@ -9,6 +9,7 @@ using TramsDataApi.ResponseModels.Concerns.TeamCasework;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class UpdateConcernsCaseworkTeam : IUpdateConcernsCaseworkTeam
     {
         private readonly IConcernsTeamCaseworkGateway _gateway;

--- a/TramsDataApi/UseCases/UpdateConcernsRecord.cs
+++ b/TramsDataApi/UseCases/UpdateConcernsRecord.cs
@@ -1,3 +1,4 @@
+using System;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
@@ -6,6 +7,7 @@ using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.UseCases
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class UpdateConcernsRecord : IUpdateConcernsRecord
     {
         private readonly IConcernsRecordGateway _concernsRecordGateway;

--- a/TramsDataApi/Validators/ConcernsCaseRequestValidator.cs
+++ b/TramsDataApi/Validators/ConcernsCaseRequestValidator.cs
@@ -1,8 +1,10 @@
+using System;
 using FluentValidation;
 using TramsDataApi.RequestModels;
 
 namespace TramsDataApi.Validators
 {
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseRequestValidator : AbstractValidator<ConcernCaseRequest>
     {
         public ConcernsCaseRequestValidator()


### PR DESCRIPTION
There are plans to move endpoints and management of database tables which are specific to Concerns Casework into the Concerns Casework API. 

These endpoints, and their associated classes and interfaces, have been flagged as deprecated  / obsolete in this PR. 

If anyone thinks that anything so flagged is actually needed by another team, please let someone in the Concerns team know (Emma Whitcroft, Chris Dexter, or Elijah Aremu) and we can discuss further. 

I'm leaving this as a draft PR for now as a discussion point, and will look to convert it to a full PR if there are no concerns raised. 
