### PR TITLE
Feature/102795 select decision item

### DIFF
--- a/TramsDataApi.Test/Controllers/ConcernsCaseDecisionControllerTests.cs
+++ b/TramsDataApi.Test/Controllers/ConcernsCaseDecisionControllerTests.cs
@@ -1,0 +1,62 @@
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TramsDataApi.Controllers.V2;
+using TramsDataApi.Enums.Concerns;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.Controllers
+{
+    public class ConcernsCaseDecisionControllerTests
+    {
+        private readonly Mock<ILogger<ConcernsCaseDecisionController>> _mockLogger = new Mock<ILogger<ConcernsCaseDecisionController>>();
+
+        [Fact]
+        public async Task CreateConcernsCaseDecision_Returns201WhenSuccessfullyCreatesAConcernsCase()
+        {
+            var fixture = new Fixture();
+            var createDecisionUseCase = new Mock<IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse>>();
+            var createDecisionRequest = fixture.Create<CreateDecisionRequest>();
+            var createDecisionResponse = fixture.Create<CreateDecisionResponse>();
+
+            createDecisionUseCase.Setup(a => a.Execute(createDecisionRequest, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createDecisionResponse);
+
+            var controller = new ConcernsCaseDecisionController(_mockLogger.Object, createDecisionUseCase.Object);
+
+            var result = await controller.Create(123, createDecisionRequest, CancellationToken.None);
+
+            var expected = new ApiSingleResponseV2<CreateDecisionResponse>(createDecisionResponse);
+
+            result.Result.Should().BeEquivalentTo(new ObjectResult(expected) { StatusCode = StatusCodes.Status201Created });
+        }
+
+        [Fact]
+        public async Task CreateConcernsCaseDecision_ReturnsBadRequest_When_CreateDecisionRequest_IsInvalid()
+        {
+            var fixture = new Fixture();
+            var createDecisionUseCase = new Mock<IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse>>();
+            var createDecisionRequest = fixture.Build<CreateDecisionRequest>()
+                .With(x => x.DecisionTypes, () => new DecisionType[] { 0 })
+                .Create();
+            var createDecisionResponse = fixture.Create<CreateDecisionResponse>();
+
+            createDecisionUseCase.Setup(a => a.Execute(createDecisionRequest, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createDecisionResponse);
+
+            var controller = new ConcernsCaseDecisionController(_mockLogger.Object, createDecisionUseCase.Object);
+
+            var result = await controller.Create(123, createDecisionRequest, CancellationToken.None);
+            result.Result.Should().BeEquivalentTo(new BadRequestResult());
+        }
+    }
+}

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -22,7 +22,7 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
 
             var fixture = new Fixture();
             var decisionId = fixture.Create<int>();
-            
+
             var decisionTypes = new[]
             {
                 new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove, decisionId),
@@ -32,7 +32,6 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             var expectation = new
             {
                 ConcernsCaseId = fixture.Create<int>(),
-                DecisionId = decisionId,
                 CrmCaseNumber = fixture.Create<string>(),
                 RetrospectiveApproval = true,
                 SubmissionRequired = true,
@@ -40,12 +39,12 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
                 ReceivedRequestDate = fixture.Create<DateTimeOffset>(),
                 DecisionTypes = decisionTypes,
                 TotalAmountRequested = 13.5m,
-                SupportingNotes = fixture.Create<string>()
+                SupportingNotes = fixture.Create<string>(),
+                CurrentDateTime = DateTimeOffset.UtcNow
             };
 
             var sut = new Decision(
                 expectation.ConcernsCaseId,
-                expectation.DecisionId,
                 expectation.CrmCaseNumber,
                 expectation.RetrospectiveApproval,
                 expectation.SubmissionRequired,
@@ -53,10 +52,14 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
                 expectation.ReceivedRequestDate,
                 expectation.DecisionTypes,
                 expectation.TotalAmountRequested,
-                expectation.SupportingNotes
+                expectation.SupportingNotes,
+                expectation.CurrentDateTime
             );
 
-            sut.Should().BeEquivalentTo(expectation);
+            sut.Should().BeEquivalentTo(expectation, cfg => cfg.Excluding(e => e.CurrentDateTime));
+            sut.CreatedAtDateTimeOffset.Should().Be(expectation.CurrentDateTime);
+            sut.UpdatedAtDateTimeOffset.Should().Be(expectation.CurrentDateTime);
+            sut.DecisionId.Should().Be(0, "DecisionId should be assigned by the database");
         }
     }
 }

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -57,8 +57,8 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             );
 
             sut.Should().BeEquivalentTo(expectation, cfg => cfg.Excluding(e => e.CurrentDateTime));
-            sut.CreatedAtDateTimeOffset.Should().Be(expectation.CurrentDateTime);
-            sut.UpdatedAtDateTimeOffset.Should().Be(expectation.CurrentDateTime);
+            sut.CreatedAt.Should().Be(expectation.CurrentDateTime);
+            sut.UpdatedAt.Should().Be(expectation.CurrentDateTime);
             sut.DecisionId.Should().Be(0, "DecisionId should be assigned by the database");
         }
     }

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -1,0 +1,58 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using System;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.DatabaseModels.Concerns
+{
+    public class CaseDecisionTests
+    {
+        [Fact]
+        public void CanConstruct_Decision()
+        {
+            var fixture = new Fixture();
+            var sut = fixture.Create<Decision>();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Decision_Properties_SetByConstructor()
+        {
+
+            var fixture = new Fixture();
+
+
+            var decisionTypes = new[]
+            {
+                new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove, "Notice to Improve"),
+                new DecisionType(Enums.Concerns.DecisionType.OtherFinancialSupport, "Other financial support")
+            };
+
+            var expectation = new
+            {
+                CrmCaseNumber = fixture.Create<string>(),
+                RetrospectiveApproval = true,
+                SubmissionRequired = true,
+                SubmissionDocumentLink = fixture.Create<string>(),
+                ReceivedRequestDate = fixture.Create<DateTimeOffset>(),
+                DecisionTypes = decisionTypes,
+                TotalAmountRequested = 13.5m,
+                SupportingNotes = fixture.Create<string>()
+            };
+
+            var sut = new Decision(
+                expectation.CrmCaseNumber,
+                expectation.RetrospectiveApproval,
+                expectation.SubmissionRequired,
+                expectation.SubmissionDocumentLink,
+                expectation.ReceivedRequestDate,
+                expectation.DecisionTypes,
+                expectation.TotalAmountRequested,
+                expectation.SupportingNotes
+            );
+
+            sut.Should().BeEquivalentTo(expectation);
+        }
+    }
+}

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -25,8 +25,8 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
 
             var decisionTypes = new[]
             {
-                new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove, decisionId),
-                new DecisionType(Enums.Concerns.DecisionType.OtherFinancialSupport, decisionId)
+                new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove) { DecisionId =decisionId },
+                new DecisionType(Enums.Concerns.DecisionType.OtherFinancialSupport){ DecisionId =decisionId }
             };
 
             var expectation = new

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace TramsDataApi.Test.DatabaseModels.Concerns
 {
-    public class CaseDecisionTests
+    public class DecisionTests
     {
         [Fact]
         public void CanConstruct_Decision()
@@ -21,16 +21,18 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
         {
 
             var fixture = new Fixture();
-
-
+            var decisionId = fixture.Create<int>();
+            
             var decisionTypes = new[]
             {
-                new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove, "Notice to Improve"),
-                new DecisionType(Enums.Concerns.DecisionType.OtherFinancialSupport, "Other financial support")
+                new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove, decisionId),
+                new DecisionType(Enums.Concerns.DecisionType.OtherFinancialSupport, decisionId)
             };
 
             var expectation = new
             {
+                ConcernsCaseId = fixture.Create<int>(),
+                DecisionId = decisionId,
                 CrmCaseNumber = fixture.Create<string>(),
                 RetrospectiveApproval = true,
                 SubmissionRequired = true,
@@ -42,6 +44,8 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             };
 
             var sut = new Decision(
+                expectation.ConcernsCaseId,
+                expectation.DecisionId,
                 expectation.CrmCaseNumber,
                 expectation.RetrospectiveApproval,
                 expectation.SubmissionRequired,

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeIdTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeIdTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace TramsDataApi.Test.DatabaseModels.Concerns
 {
-    public class DecisionTypeTests
+    public class DecisionTypeIdTests
     {
         [Fact]
         public void CanConstruct_DecisionType()
         {
             var fixture = new Fixture();
-            var sut = fixture.Create<DecisionType>();
+            var sut = fixture.Create<DecisionTypeId>();
             sut.Should().NotBeNull();
         }
 
@@ -19,13 +19,12 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
         public void DecisionType_Properties_SetByConstructor()
         {
             var fixture = new Fixture();
+            const string noticeToImproveNti = "Notice to Improve (NTI)";
             var expectedId = Enums.Concerns.DecisionType.EsfaApproval;
-            var expectedDecisionId = fixture.Create<int>();
-            var sut = new DecisionType(expectedId, expectedDecisionId);
+            var sut = new DecisionTypeId(expectedId, noticeToImproveNti);
 
-            sut.DecisionTypeId.Should().Be(expectedId);
-            sut.DecisionId.Should().Be(expectedDecisionId);
-
+            sut.Id.Should().Be(expectedId);
+            sut.Name.Should().Be(noticeToImproveNti);
         }
     }
 }

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
@@ -1,0 +1,36 @@
+﻿using AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.DatabaseModels.Concerns
+{
+    public class DecisionTypeTests
+    {
+        [Fact]
+        public void CanConstruct_DecisionType()
+        {
+            var fixture = new Fixture();
+            var sut = fixture.Create<DecisionType>();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DecisionType_Properties_SetByConstructor()
+        {
+            var fixture = new Fixture();
+            const string noticeToImproveNti = "Notice to Improve (NTI)";
+            var expectedId = Enums.Concerns.DecisionType.EsfaApproval;
+            var sut = new DecisionType(expectedId, noticeToImproveNti);
+
+            sut.Id.Should().Be(expectedId);
+            sut.Name.Should().Be(noticeToImproveNti);
+
+        }
+    }
+}

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
+using System;
 using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using Xunit;
 
@@ -26,6 +27,16 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             sut.DecisionTypeId.Should().Be(expectedId);
             sut.DecisionId.Should().Be(expectedDecisionId);
 
+        }
+
+        [Fact]
+        public void Given_Invalid_DecisionTypes_Constructor_Throws_Exception()
+        {
+            var fixture = new Fixture();
+
+            Action action = () => new DecisionType(0) { DecisionId = 1 };
+
+            action.Should().ThrowExactly<ArgumentOutOfRangeException>().And.ParamName.Should().Be("decisionType");
         }
     }
 }

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
@@ -32,8 +32,6 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
         [Fact]
         public void Given_Invalid_DecisionTypes_Constructor_Throws_Exception()
         {
-            var fixture = new Fixture();
-
             Action action = () => new DecisionType(0) { DecisionId = 1 };
 
             action.Should().ThrowExactly<ArgumentOutOfRangeException>().And.ParamName.Should().Be("decisionType");

--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTypeTests.cs
@@ -21,7 +21,7 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             var fixture = new Fixture();
             var expectedId = Enums.Concerns.DecisionType.EsfaApproval;
             var expectedDecisionId = fixture.Create<int>();
-            var sut = new DecisionType(expectedId, expectedDecisionId);
+            var sut = new DecisionType(expectedId) { DecisionId = expectedDecisionId };
 
             sut.DecisionTypeId.Should().Be(expectedId);
             sut.DecisionId.Should().Be(expectedDecisionId);

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/CreateDecisionResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/CreateDecisionResponseFactoryTests.cs
@@ -34,16 +34,4 @@ namespace TramsDataApi.Test.Factories.Concerns.Decisions
             return fixture;
         }
     }
-
-    static class PrivateSetterExtension
-    {
-        public static void SetProperty<TSource, TProperty>(
-            this TSource source,
-            Expression<Func<TSource, TProperty>> prop,
-            TProperty value)
-        {
-            var propertyInfo = (PropertyInfo)((MemberExpression)prop.Body).Member;
-            propertyInfo.SetValue(source, value);
-        }
-    }
 }

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/CreateDecisionResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/CreateDecisionResponseFactoryTests.cs
@@ -1,0 +1,49 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories.Concerns.Decisions
+{
+    public class CreateDecisionResponseFactoryTests
+    {
+        [Fact]
+        public void Can_Create_Response()
+        {
+            var fixture = CreateFixture();
+
+            var expectedConcernsCaseUrn = fixture.Create<int>();
+            var expectedDecisionId = fixture.Create<int>();
+
+            var sut = new CreateDecisionResponseFactory();
+            var result = sut.Create(expectedConcernsCaseUrn, expectedDecisionId);
+
+            result.ConcernsCaseUrn.Should().Be(expectedConcernsCaseUrn);
+            result.DecisionId.Should().Be(expectedDecisionId);
+        }
+
+        private static Fixture CreateFixture()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            return fixture;
+        }
+    }
+
+    static class PrivateSetterExtension
+    {
+        public static void SetProperty<TSource, TProperty>(
+            this TSource source,
+            Expression<Func<TSource, TProperty>> prop,
+            TProperty value)
+        {
+            var propertyInfo = (PropertyInfo)((MemberExpression)prop.Body).Member;
+            propertyInfo.SetValue(source, value);
+        }
+    }
+}

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/DecisionFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/DecisionFactoryTests.cs
@@ -12,14 +12,16 @@ namespace TramsDataApi.Test.Factories.Concerns.Decisions
         public void DecisionFactory_Create_CreatesDecision()
         {
             var fixture = new Fixture();
+
+            var concernsCaseId = fixture.Create<int>();
             var input = fixture.Create<CreateDecisionRequest>();
 
             var sut = new DecisionFactory();
-            var decision = sut.CreateDecision(input);
+            var decision = sut.CreateDecision(concernsCaseId, input);
 
-            decision.Should().BeEquivalentTo(input,
-                cfg => cfg.Excluding(x => x.ConcernsCaseUrn).Excluding(x => x.DecisionTypes));
-
+            decision.Should().BeEquivalentTo(input, cfg => cfg.Excluding(x => x.DecisionTypes)
+                .Excluding(x => x.ConcernsCaseUrn)
+                .Excluding(x => x.DecisionId));
 
             for (int i = 0; i < input.DecisionTypes.Length; i++)
             {

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/DecisionFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/DecisionFactoryTests.cs
@@ -1,0 +1,30 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using TramsDataApi.Factories.Concerns.Decisions;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories.Concerns.Decisions
+{
+    public class DecisionFactoryTests
+    {
+        [Fact]
+        public void DecisionFactory_Create_CreatesDecision()
+        {
+            var fixture = new Fixture();
+            var input = fixture.Create<CreateDecisionRequest>();
+
+            var sut = new DecisionFactory();
+            var decision = sut.CreateDecision(input);
+
+            decision.Should().BeEquivalentTo(input,
+                cfg => cfg.Excluding(x => x.ConcernsCaseUrn).Excluding(x => x.DecisionTypes));
+
+
+            for (int i = 0; i < input.DecisionTypes.Length; i++)
+            {
+                decision.DecisionTypes[i].DecisionTypeId.Should().Be(input.DecisionTypes[i]);
+            }
+        }
+    }
+}

--- a/TramsDataApi.Test/RequestModels/Concerns/Decisions/CreateDecisionRequestTests.cs
+++ b/TramsDataApi.Test/RequestModels/Concerns/Decisions/CreateDecisionRequestTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using TramsDataApi.Enums.Concerns;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.RequestModels.Concerns.Decisions
+{
+    public class CreateDecisionRequestTests
+    {
+        [Fact]
+        public void IsValid_When_Invalid_DecisionType_Returns_False()
+        {
+            var fixture = new Fixture();
+            var sut = fixture.Build<CreateDecisionRequest>()
+                    .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType [] {0})
+                    .Create();
+
+            sut.IsValid().Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsValid_When_Valid_DecisionType_Returns_True()
+        {
+            var fixture = new Fixture();
+            var sut = fixture.Build<CreateDecisionRequest>()
+                .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType [] { DecisionType.EsfaApproval })
+                .Create();
+
+            sut.IsValid().Should().BeTrue();
+        }
+    }
+}

--- a/TramsDataApi.Test/RequestModels/Concerns/Decisions/CreateDecisionRequestTests.cs
+++ b/TramsDataApi.Test/RequestModels/Concerns/Decisions/CreateDecisionRequestTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AutoFixture;
+﻿using AutoFixture;
 using FluentAssertions;
 using TramsDataApi.Enums.Concerns;
 using TramsDataApi.RequestModels.Concerns.Decisions;
@@ -18,7 +13,7 @@ namespace TramsDataApi.Test.RequestModels.Concerns.Decisions
         {
             var fixture = new Fixture();
             var sut = fixture.Build<CreateDecisionRequest>()
-                    .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType [] {0})
+                    .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType[] { 0 })
                     .Create();
 
             sut.IsValid().Should().BeFalse();
@@ -29,7 +24,7 @@ namespace TramsDataApi.Test.RequestModels.Concerns.Decisions
         {
             var fixture = new Fixture();
             var sut = fixture.Build<CreateDecisionRequest>()
-                .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType [] { DecisionType.EsfaApproval })
+                .With(x => x.DecisionTypes, new Enums.Concerns.DecisionType[] { DecisionType.EsfaApproval })
                 .Create();
 
             sut.IsValid().Should().BeTrue();

--- a/TramsDataApi.Test/TramsDataApi.Test.csproj
+++ b/TramsDataApi.Test/TramsDataApi.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/TramsDataApi.Test/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
+++ b/TramsDataApi.Test/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
@@ -1,0 +1,97 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Linq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.Factories.Concerns.Decisions;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+using TramsDataApi.UseCases;
+using TramsDataApi.UseCases.CaseActions.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases.CaseActions.Decisions
+{
+    public class CreateDecisionTests
+    {
+        [Fact]
+        public void CreateDecision_Implements_IUseCase()
+        {
+            typeof(CreateDecision).Should().BeAssignableTo<IUseCase<CreateDecisionRequest, CreateDecisionResponse>>();
+        }
+
+        [Fact]
+        public void Execute_Throws_Exception_If_Request_IsNull()
+        {
+            var sut = new CreateDecision(Mock.Of<IConcernsCaseGateway>(), Mock.Of<IDecisionFactory>(), Mock.Of<ICreateDecisionResponseFactory>());
+
+            Action action = () => sut.Execute(null);
+            action.Should().Throw<ArgumentNullException>();
+
+        }
+
+        [Fact]
+        public void Execute_When_Concerns_Case_NotFound_Throws_Exception()
+        {
+            var fixture = CreateFixture();
+
+            var mockGateway = new Mock<IConcernsCaseGateway>();
+            mockGateway.Setup(x => x.GetConcernsCaseByUrn(It.IsAny<int>()))
+                .Returns(default(ConcernsCase));
+
+            var request = fixture.Create<CreateDecisionRequest>();
+
+            var sut = new CreateDecision(mockGateway.Object, Mock.Of<IDecisionFactory>(), Mock.Of<ICreateDecisionResponseFactory>());
+            Action action = () => sut.Execute(request);
+
+            action.Should().Throw<InvalidOperationException>().And.Message.Should()
+                .Contain($"The concerns case for urn {request.ConcernsCaseUrn}, was not found");
+        }
+        
+        [Fact]
+        public void Execute_Adds_Decision()
+        {
+            var fixture = CreateFixture();
+
+            var fakeConcernsCase = fixture.Create<ConcernsCase>();
+
+            var request = fixture.Create<CreateDecisionRequest>();
+            var fakeNewDecision = fixture.Create<Decision>();
+
+
+            var mockGateway = new Mock<IConcernsCaseGateway>();
+            mockGateway.Setup(x => x.GetConcernsCaseByUrn(request.ConcernsCaseUrn))
+                .Returns(fakeConcernsCase);
+
+
+            var mockDecisionFactory = new Mock<IDecisionFactory>();
+            mockDecisionFactory.Setup(x => x.CreateDecision(request))
+                .Returns(fakeNewDecision);
+
+            var fakeResponse = new CreateDecisionResponse(fakeConcernsCase.Urn, fixture.Create<int>());
+            var mockResponseFactory = new Mock<ICreateDecisionResponseFactory>();
+            mockResponseFactory.Setup(x => x.Create(fakeConcernsCase.Urn, fakeNewDecision.DecisionId))
+                .Returns(fakeResponse);
+
+            mockGateway.Setup(x => x.SaveConcernsCase(It.Is<ConcernsCase>(cc => cc.Decisions.First() == fakeNewDecision))).Returns(fakeConcernsCase);
+
+            var sut = new CreateDecision(mockGateway.Object, mockDecisionFactory.Object, mockResponseFactory.Object);
+
+            var result = sut.Execute(request);
+
+            mockGateway.Verify(x => x.SaveConcernsCase(fakeConcernsCase), Times.Once);
+            result.Should().Be(fakeResponse);
+        }
+
+        private static Fixture CreateFixture()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            return fixture;
+        }
+    }
+}

--- a/TramsDataApi.Test/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
+++ b/TramsDataApi.Test/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
@@ -61,14 +61,13 @@ namespace TramsDataApi.Test.UseCases.CaseActions.Decisions
             var request = fixture.Create<CreateDecisionRequest>();
             var fakeNewDecision = fixture.Create<Decision>();
 
-
             var mockGateway = new Mock<IConcernsCaseGateway>();
             mockGateway.Setup(x => x.GetConcernsCaseByUrn(request.ConcernsCaseUrn))
                 .Returns(fakeConcernsCase);
 
 
             var mockDecisionFactory = new Mock<IDecisionFactory>();
-            mockDecisionFactory.Setup(x => x.CreateDecision(request))
+            mockDecisionFactory.Setup(x => x.CreateDecision(fakeConcernsCase.Id, request))
                 .Returns(fakeNewDecision);
 
             var fakeResponse = new CreateDecisionResponse(fakeConcernsCase.Urn, fixture.Create<int>());

--- a/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
@@ -1,31 +1,28 @@
-using System;
-using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using TramsDataApi.RequestModels;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using TramsDataApi.RequestModels.Concerns.Decisions;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.ResponseModels.Concerns.Decisions;
 using TramsDataApi.UseCases;
-using TramsDataApi.UseCases.CaseActions.Decisions;
-using TramsDataApi.Validators;
 
 namespace TramsDataApi.Controllers.V2
 {
     [ApiVersion("2.0")]
     [ApiController]
     [Route("v{version:apiVersion}/concerns-cases/{urn:int}/decisions/")]
-    [Obsolete(
-        "This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class ConcernsCaseDecisionController : ControllerBase
     {
         private readonly ILogger<ConcernsCaseDecisionController> _logger;
-        private readonly IUseCase<CreateDecisionRequest, CreateDecisionResponse> _createDecisionUseCase;
+        private readonly IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse> _createDecisionUseCase;
 
         public ConcernsCaseDecisionController(
             ILogger<ConcernsCaseDecisionController> logger,
-            IUseCase<CreateDecisionRequest, CreateDecisionResponse> createDecisionUseCase
+            IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse> createDecisionUseCase
         )
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -35,63 +32,21 @@ namespace TramsDataApi.Controllers.V2
 
         [HttpPost]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(int urn, CreateDecisionRequest request)
+        public async Task<ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>>> Create(int urn, CreateDecisionRequest request, CancellationToken cancellationToken)
         {
             _ = request ?? throw new ArgumentNullException(nameof(request));
 
-            if (! request.IsValid())
+            if (!request.IsValid())
             {
-                _logger.LogInformation($"Failed to create Concerns Case due to bad request");
+                _logger.LogInformation($"Failed to create Concerns Case Decision due to bad request");
                 return BadRequest();
             }
 
             request.ConcernsCaseUrn = urn;
-            var createdDecision = _createDecisionUseCase.Execute(request);
+            var createdDecision = await _createDecisionUseCase.Execute(request, cancellationToken);
             var response = new ApiSingleResponseV2<CreateDecisionResponse>(createdDecision);
 
             return new ObjectResult(response) { StatusCode = StatusCodes.Status201Created };
-            
         }
-
-        //[HttpPut("{decisionId:int}")]
-        //[MapToApiVersion("2.0")]
-        //public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(int urn, int decisionId, CreateDecisionRequest request)
-        //{
-        //    _ = request ?? throw new ArgumentNullException(nameof(request));
-
-        //    // var validator = new ConcernsCaseRequestValidator();
-        //    //if (validator.Validate(request).IsValid)
-        //    //{
-
-        //    request.ConcernsCaseUrn = urn;
-        //    var createdDecision = _createDecisionUseCase.Execute(request);
-        //    var response = new ApiSingleResponseV2<CreateDecisionResponse>(createdDecision);
-
-        //    return new ObjectResult(response) { StatusCode = StatusCodes.Status201Created };
-        //    //}
-        //    //_logger.LogInformation($"Failed to create Concerns Case due to bad request");
-        //    //return BadRequest();
-        //}
-
-        //[HttpGet]
-        //[Route("{int:int}")]
-        //[MapToApiVersion("2.0")]
-        //public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> GetByUrn(int id)
-        //{
-        //    _logger.LogInformation($"Attempting to get Concerns Case by Urn {urn}");
-        //    var concernsCase = _getConcernsCaseByUrn.Execute(urn);
-
-        //    if (concernsCase == null)
-        //    {
-        //        _logger.LogInformation($"No Concerns case found for URN {urn}");
-        //        return NotFound();
-        //    }
-
-        //    _logger.LogInformation($"Returning Concerns case with Urn {urn}");
-        //    _logger.LogDebug(JsonSerializer.Serialize(concernsCase));
-        //    var response = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCase);
-
-        //    return Ok(response);
-        //}
     }
 }

--- a/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TramsDataApi.RequestModels;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+using TramsDataApi.UseCases;
+using TramsDataApi.UseCases.CaseActions.Decisions;
+using TramsDataApi.Validators;
+
+namespace TramsDataApi.Controllers.V2
+{
+    [ApiVersion("2.0")]
+    [ApiController]
+    [Route("v{version:apiVersion}/concerns-cases/{urn:int}/decisions/")]
+    [Obsolete(
+        "This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
+    public class ConcernsCaseDecisionController : ControllerBase
+    {
+        private readonly ILogger<ConcernsCaseDecisionController> _logger;
+        private readonly IUseCase<CreateDecisionRequest, CreateDecisionResponse> _createDecisionUseCase;
+
+        public ConcernsCaseDecisionController(
+            ILogger<ConcernsCaseDecisionController> logger,
+            IUseCase<CreateDecisionRequest, CreateDecisionResponse> createDecisionUseCase
+        )
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _createDecisionUseCase =
+                createDecisionUseCase ?? throw new ArgumentNullException(nameof(createDecisionUseCase));
+        }
+
+        [HttpPost]
+        [MapToApiVersion("2.0")]
+        public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(int urn, CreateDecisionRequest request)
+        {
+            _ = request ?? throw new ArgumentNullException(nameof(request));
+
+            if (! request.IsValid())
+            {
+                _logger.LogInformation($"Failed to create Concerns Case due to bad request");
+                return BadRequest();
+            }
+
+            request.ConcernsCaseUrn = urn;
+            var createdDecision = _createDecisionUseCase.Execute(request);
+            var response = new ApiSingleResponseV2<CreateDecisionResponse>(createdDecision);
+
+            return new ObjectResult(response) { StatusCode = StatusCodes.Status201Created };
+            
+        }
+
+        //[HttpPut("{decisionId:int}")]
+        //[MapToApiVersion("2.0")]
+        //public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(int urn, int decisionId, CreateDecisionRequest request)
+        //{
+        //    _ = request ?? throw new ArgumentNullException(nameof(request));
+
+        //    // var validator = new ConcernsCaseRequestValidator();
+        //    //if (validator.Validate(request).IsValid)
+        //    //{
+
+        //    request.ConcernsCaseUrn = urn;
+        //    var createdDecision = _createDecisionUseCase.Execute(request);
+        //    var response = new ApiSingleResponseV2<CreateDecisionResponse>(createdDecision);
+
+        //    return new ObjectResult(response) { StatusCode = StatusCodes.Status201Created };
+        //    //}
+        //    //_logger.LogInformation($"Failed to create Concerns Case due to bad request");
+        //    //return BadRequest();
+        //}
+
+        //[HttpGet]
+        //[Route("{int:int}")]
+        //[MapToApiVersion("2.0")]
+        //public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> GetByUrn(int id)
+        //{
+        //    _logger.LogInformation($"Attempting to get Concerns Case by Urn {urn}");
+        //    var concernsCase = _getConcernsCaseByUrn.Execute(urn);
+
+        //    if (concernsCase == null)
+        //    {
+        //        _logger.LogInformation($"No Concerns case found for URN {urn}");
+        //        return NotFound();
+        //    }
+
+        //    _logger.LogInformation($"Returning Concerns case with Urn {urn}");
+        //    _logger.LogDebug(JsonSerializer.Serialize(concernsCase));
+        //    var response = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCase);
+
+        //    return Ok(response);
+        //}
+    }
+}

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -36,19 +36,19 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             UpdatedAtDateTimeOffset = createdAtDateTimeOffset;
         }
 
-        public int ConcernsCaseId { get;  set; }
+        public int ConcernsCaseId { get;  private set; }
         
-        public int DecisionId { get;  set; } 
-        public IList<DecisionType> DecisionTypes { get;  set; }
-        public decimal TotalAmountRequested { get;  set; }
-        public string SupportingNotes { get;  set; }
-        public DateTimeOffset ReceivedRequestDate { get;  set; }
-        public string SubmissionDocumentLink { get;  set; }
-        public bool SubmissionRequired { get;  set; }
-        public bool RetrospectiveApproval { get;  set; }
-        public string CrmCaseNumber { get;  set; }
-        public DateTimeOffset CreatedAtDateTimeOffset { get;  set; }
-        public DateTimeOffset UpdatedAtDateTimeOffset { get;  set; }
+        public int DecisionId { get;  private set; } 
+        public IList<DecisionType> DecisionTypes { get;  private set; }
+        public decimal TotalAmountRequested { get;  private set; }
+        public string SupportingNotes { get;  private set; }
+        public DateTimeOffset ReceivedRequestDate { get;  private set; }
+        public string SubmissionDocumentLink { get;  private set; }
+        public bool SubmissionRequired { get;  private set; }
+        public bool RetrospectiveApproval { get;  private set; }
+        public string CrmCaseNumber { get;  private set; }
+        public DateTimeOffset CreatedAtDateTimeOffset { get;  private set; }
+        public DateTimeOffset UpdatedAtDateTimeOffset { get;  private set; }
 
     }
 }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -6,20 +6,24 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
     {
         private Decision()
         {
-            
+
         }
 
         public Decision(
+            int concernsCaseId,
+            int decisionId,
             string crmCaseNumber,
-            bool retrospectiveApproval, 
+            bool retrospectiveApproval,
             bool submissionRequired,
-            string submissionDocumentLink, 
-            DateTimeOffset receivedRequestDate, 
-            DecisionType[] decisionTypes, 
-            decimal totalAmountRequested, 
+            string submissionDocumentLink,
+            DateTimeOffset receivedRequestDate,
+            DecisionType[] decisionTypes,
+            decimal totalAmountRequested,
             string supportingNotes
         )
         {
+            ConcernsCaseId = concernsCaseId;
+            DecisionId = decisionId;
             DecisionTypes = decisionTypes;
             TotalAmountRequested = totalAmountRequested;
             SupportingNotes = supportingNotes;
@@ -30,6 +34,8 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             CrmCaseNumber = crmCaseNumber;
         }
 
+        public int ConcernsCaseId { get; set; }
+        public int DecisionId { get; private set; }
         public DecisionType[] DecisionTypes { get; private set; }
         public decimal TotalAmountRequested { get; private set; }
         public string SupportingNotes { get; private set; }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -22,7 +22,7 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             DecisionType[] decisionTypes,
             decimal totalAmountRequested,
             string supportingNotes,
-            DateTimeOffset createdAtDateTimeOffset
+            DateTimeOffset createdAt
         )
         {
             ConcernsCaseId = concernsCaseId;
@@ -34,8 +34,8 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             SubmissionRequired = submissionRequired;
             RetrospectiveApproval = retrospectiveApproval;
             CrmCaseNumber = crmCaseNumber;
-            CreatedAtDateTimeOffset = createdAtDateTimeOffset;
-            UpdatedAtDateTimeOffset = createdAtDateTimeOffset;
+            CreatedAt = createdAt;
+            UpdatedAt = createdAt;
         }
 
         public int ConcernsCaseId { get;  private set; }
@@ -49,8 +49,8 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
         public bool SubmissionRequired { get;  private set; }
         public bool RetrospectiveApproval { get;  private set; }
         public string CrmCaseNumber { get;  private set; }
-        public DateTimeOffset CreatedAtDateTimeOffset { get;  private set; }
-        public DateTimeOffset UpdatedAtDateTimeOffset { get;  private set; }
+        public DateTimeOffset CreatedAt { get;  private set; }
+        public DateTimeOffset UpdatedAt { get;  private set; }
 
     }
 }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -11,7 +11,6 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 
         public Decision(
             int concernsCaseId,
-            int decisionId,
             string crmCaseNumber,
             bool retrospectiveApproval,
             bool submissionRequired,
@@ -19,11 +18,11 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             DateTimeOffset receivedRequestDate,
             DecisionType[] decisionTypes,
             decimal totalAmountRequested,
-            string supportingNotes
+            string supportingNotes,
+            DateTimeOffset createdAtDateTimeOffset
         )
         {
             ConcernsCaseId = concernsCaseId;
-            DecisionId = decisionId;
             DecisionTypes = decisionTypes;
             TotalAmountRequested = totalAmountRequested;
             SupportingNotes = supportingNotes;
@@ -32,17 +31,23 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
             SubmissionRequired = submissionRequired;
             RetrospectiveApproval = retrospectiveApproval;
             CrmCaseNumber = crmCaseNumber;
+            CreatedAtDateTimeOffset = createdAtDateTimeOffset;
+            UpdatedAtDateTimeOffset = createdAtDateTimeOffset;
         }
 
-        public int ConcernsCaseId { get; set; }
-        public int DecisionId { get; private set; }
-        public DecisionType[] DecisionTypes { get; private set; }
-        public decimal TotalAmountRequested { get; private set; }
-        public string SupportingNotes { get; private set; }
-        public DateTimeOffset ReceivedRequestDate { get; private set; }
-        public string SubmissionDocumentLink { get; private set; }
-        public bool SubmissionRequired { get; private set; }
-        public bool RetrospectiveApproval { get; private set; }
-        public string CrmCaseNumber { get; private set; }
+        public int ConcernsCaseId { get;  set; }
+        
+        public int DecisionId { get;  set; } 
+        public DecisionType[] DecisionTypes { get;  set; }
+        public decimal TotalAmountRequested { get;  set; }
+        public string SupportingNotes { get;  set; }
+        public DateTimeOffset ReceivedRequestDate { get;  set; }
+        public string SubmissionDocumentLink { get;  set; }
+        public bool SubmissionRequired { get;  set; }
+        public bool RetrospectiveApproval { get;  set; }
+        public string CrmCaseNumber { get;  set; }
+        public DateTimeOffset CreatedAtDateTimeOffset { get;  set; }
+        public DateTimeOffset UpdatedAtDateTimeOffset { get;  set; }
+
     }
 }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
+{
+    public class Decision
+    {
+        private Decision()
+        {
+            
+        }
+
+        public Decision(
+            string crmCaseNumber,
+            bool retrospectiveApproval, 
+            bool submissionRequired,
+            string submissionDocumentLink, 
+            DateTimeOffset receivedRequestDate, 
+            DecisionType[] decisionTypes, 
+            decimal totalAmountRequested, 
+            string supportingNotes
+        )
+        {
+            DecisionTypes = decisionTypes;
+            TotalAmountRequested = totalAmountRequested;
+            SupportingNotes = supportingNotes;
+            ReceivedRequestDate = receivedRequestDate;
+            SubmissionDocumentLink = submissionDocumentLink;
+            SubmissionRequired = submissionRequired;
+            RetrospectiveApproval = retrospectiveApproval;
+            CrmCaseNumber = crmCaseNumber;
+        }
+
+        public DecisionType[] DecisionTypes { get; private set; }
+        public decimal TotalAmountRequested { get; private set; }
+        public string SupportingNotes { get; private set; }
+        public DateTimeOffset ReceivedRequestDate { get; private set; }
+        public string SubmissionDocumentLink { get; private set; }
+        public bool SubmissionRequired { get; private set; }
+        public bool RetrospectiveApproval { get; private set; }
+        public string CrmCaseNumber { get; private set; }
+    }
+}

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 {
@@ -6,7 +7,7 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
     {
         private Decision()
         {
-
+            DecisionTypes = new List<DecisionType>();
         }
 
         public Decision(
@@ -38,7 +39,7 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
         public int ConcernsCaseId { get;  set; }
         
         public int DecisionId { get;  set; } 
-        public DecisionType[] DecisionTypes { get;  set; }
+        public IList<DecisionType> DecisionTypes { get;  set; }
         public decimal TotalAmountRequested { get;  set; }
         public string SupportingNotes { get;  set; }
         public DateTimeOffset ReceivedRequestDate { get;  set; }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 {
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class Decision
     {
         private Decision()

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
@@ -1,4 +1,6 @@
-﻿namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
+﻿using System;
+
+namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 {
     public class DecisionType
     {
@@ -11,6 +13,11 @@
 
         public DecisionType(Enums.Concerns.DecisionType decisionType)
         {
+            if (!Enum.IsDefined(typeof(Enums.Concerns.DecisionType), decisionType))
+            {
+                throw new ArgumentOutOfRangeException(nameof(decisionType),
+                    "The given value is not one of the supported decision types");
+            }
             DecisionTypeId = decisionType;
         }
 

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
@@ -2,20 +2,19 @@
 {
     public class DecisionType
     {
-        public Enums.Concerns.DecisionType Id { get; private set; }
-        public string Name { get; private set; }
+        public Enums.Concerns.DecisionType DecisionTypeId { get; private set; }
 
         private DecisionType()
         {
                 
         }
 
-        public DecisionType(Enums.Concerns.DecisionType decisionType, string name)
+        public DecisionType(Enums.Concerns.DecisionType decisionType, int decisionId)
         {
-            Id = decisionType;
-            Name = name;
-        }   
+            DecisionTypeId = decisionType;
+            DecisionId = decisionId;
+        }
 
-
+        public int DecisionId { get; private set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
@@ -1,0 +1,21 @@
+﻿namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
+{
+    public class DecisionType
+    {
+        public Enums.Concerns.DecisionType Id { get; private set; }
+        public string Name { get; private set; }
+
+        private DecisionType()
+        {
+                
+        }
+
+        public DecisionType(Enums.Concerns.DecisionType decisionType, string name)
+        {
+            Id = decisionType;
+            Name = name;
+        }   
+
+
+    }
+}

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionType.cs
@@ -2,19 +2,18 @@
 {
     public class DecisionType
     {
-        public Enums.Concerns.DecisionType DecisionTypeId { get; private set; }
+        public Enums.Concerns.DecisionType DecisionTypeId { get; set; }
 
         private DecisionType()
         {
                 
         }
 
-        public DecisionType(Enums.Concerns.DecisionType decisionType, int decisionId)
+        public DecisionType(Enums.Concerns.DecisionType decisionType)
         {
             DecisionTypeId = decisionType;
-            DecisionId = decisionId;
         }
 
-        public int DecisionId { get; private set; }
+        public int DecisionId { get; set; }
     }
 }

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionTypeId.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/DecisionTypeId.cs
@@ -1,0 +1,20 @@
+﻿namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
+{
+    // reference table, not required by app in normal use, but used to give context to the data
+    public class DecisionTypeId
+    {
+        public Enums.Concerns.DecisionType Id { get; private set; }
+        public string Name { get; private set; }
+
+        private DecisionTypeId()
+        {
+                
+        }
+
+        public DecisionTypeId(Enums.Concerns.DecisionType decisionType, string name)
+        {
+            Id = decisionType;
+            Name = name;
+        }
+    }
+}

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -30,7 +30,12 @@ namespace TramsDataApi.DatabaseModels
         public int RatingUrn { get; set; }
         public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
 
-        public Decision Decision { get; private set; }
+        public virtual ICollection<Decision> Decisions { get; private set; } = new List<Decision>();
 
+        public void AddDecision(Decision decision)
+        {
+            _ = decision ?? throw new ArgumentNullException(nameof(decision));
+            Decisions.Add(decision);
+        }
     }
 }

--- a/TramsDataApi/DatabaseModels/ConcernsCase.cs
+++ b/TramsDataApi/DatabaseModels/ConcernsCase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 
 namespace TramsDataApi.DatabaseModels
 {
@@ -28,5 +29,8 @@ namespace TramsDataApi.DatabaseModels
         public int StatusUrn { get; set; }
         public int RatingUrn { get; set; }
         public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
+
+        public Decision Decision { get; private set; }
+
     }
 }

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -752,6 +752,8 @@ namespace TramsDataApi.DatabaseModels
                 .WithOne()
                 .OnDelete(DeleteBehavior.Cascade);
             });
+
+
             OnModelCreatingPartial(modelBuilder);
         }
 

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -778,7 +778,6 @@ namespace TramsDataApi.DatabaseModels
                 e.HasKey(x => x.Id);
                 e.HasData(
                     Enum.GetValues(typeof(Enums.Concerns.DecisionType)).Cast<Enums.Concerns.DecisionType>()
-                        .Where(enm => enm != Enums.Concerns.DecisionType.Unknown)
                         .Select(enm => new DecisionTypeId(enm, enm.ToString())));
             });
 

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.VisualBasic;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.DatabaseModels.Concerns.TeamCasework;
 
 namespace TramsDataApi.DatabaseModels
@@ -156,6 +158,8 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
 
+                entity.HasOne(x => x.Decision)
+                    .WithOne();
             });
 
             modelBuilder.Entity<ConcernsStatus>(entity =>
@@ -753,6 +757,30 @@ namespace TramsDataApi.DatabaseModels
                 .OnDelete(DeleteBehavior.Cascade);
             });
 
+
+            modelBuilder.Entity<Decision>(e =>
+            {
+                e.ToTable("ConcernsDecision", "sdd");
+                e.HasKey(x => x.DecisionId);
+                e.Property(x => x.TotalAmountRequested).HasColumnType("money");
+                e.HasMany(x => x.DecisionTypes).WithOne();
+            });
+
+            modelBuilder.Entity<DecisionType>(e =>
+            {
+                e.ToTable("ConcernsDecisionType", "sdd");
+                e.HasKey(x => new { x.DecisionId, x.DecisionTypeId });
+            });
+
+            modelBuilder.Entity<DecisionTypeId>(e =>
+            {
+                e.ToTable("ConcernsDecisionTypeId", "sdd");
+                e.HasKey(x => x.Id);
+                e.HasData(
+                    Enum.GetValues(typeof(Enums.Concerns.DecisionType)).Cast<Enums.Concerns.DecisionType>()
+                        .Where(enm => enm != Enums.Concerns.DecisionType.Unknown)
+                        .Select(enm => new DecisionTypeId(enm, enm.ToString())));
+            });
 
             OnModelCreatingPartial(modelBuilder);
         }

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -1,8 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using Microsoft.VisualBasic;
 using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.DatabaseModels.Concerns.TeamCasework;
 

--- a/TramsDataApi/DatabaseModels/TramsDbContext.cs
+++ b/TramsDataApi/DatabaseModels/TramsDbContext.cs
@@ -158,7 +158,7 @@ namespace TramsDataApi.DatabaseModels
                 entity.Property(e => e.Urn)
                     .HasDefaultValueSql("NEXT VALUE FOR ConcernsGlobalSequence");
 
-                entity.HasOne(x => x.Decision)
+                entity.HasMany(x => x.Decisions)
                     .WithOne();
             });
 

--- a/TramsDataApi/Enums/Concerns/DecisionType.cs
+++ b/TramsDataApi/Enums/Concerns/DecisionType.cs
@@ -2,7 +2,6 @@
 {
     public enum DecisionType
     {
-        Unknown = 0,
         NoticeToImprove = 1,
         Section128 = 2,
         QualifiedFloatingCharge = 3,

--- a/TramsDataApi/Enums/Concerns/DecisionType.cs
+++ b/TramsDataApi/Enums/Concerns/DecisionType.cs
@@ -2,16 +2,17 @@
 {
     public enum DecisionType
     {
-        NoticeToImprove = 0,
-        Section128 = 1,
-        QualifiedFloatingCharge = 2,
-        NonRepayableFinancialSupport = 3,
-        RepayableFinancialSupport = 4,
-        ShortTermCashAdvance = 5,
-        WriteOffRecoverableFunding = 6,
-        OtherFinancialSupport = 7,
-        EstimatesFundingOrPupilNumberAdjustment = 8,
-        EsfaApproval = 9,
-        FreedomOfInformationExemptions = 10
+        Unknown = 0,
+        NoticeToImprove = 1,
+        Section128 = 2,
+        QualifiedFloatingCharge = 3,
+        NonRepayableFinancialSupport = 4,
+        RepayableFinancialSupport = 5,
+        ShortTermCashAdvance = 6,
+        WriteOffRecoverableFunding = 7,
+        OtherFinancialSupport = 8,
+        EstimatesFundingOrPupilNumberAdjustment = 9,
+        EsfaApproval = 10,
+        FreedomOfInformationExemptions = 11
     }
 }

--- a/TramsDataApi/Enums/Concerns/DecisionType.cs
+++ b/TramsDataApi/Enums/Concerns/DecisionType.cs
@@ -1,0 +1,17 @@
+﻿namespace TramsDataApi.Enums.Concerns
+{
+    public enum DecisionType
+    {
+        NoticeToImprove = 0,
+        Section128 = 1,
+        QualifiedFloatingCharge = 2,
+        NonRepayableFinancialSupport = 3,
+        RepayableFinancialSupport = 4,
+        ShortTermCashAdvance = 5,
+        WriteOffRecoverableFunding = 6,
+        OtherFinancialSupport = 7,
+        EstimatesFundingOrPupilNumberAdjustment = 8,
+        EsfaApproval = 9,
+        FreedomOfInformationExemptions = 10
+    }
+}

--- a/TramsDataApi/Enums/Concerns/DecisionType.cs
+++ b/TramsDataApi/Enums/Concerns/DecisionType.cs
@@ -1,5 +1,8 @@
-﻿namespace TramsDataApi.Enums.Concerns
+﻿using System;
+
+namespace TramsDataApi.Enums.Concerns
 {
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public enum DecisionType
     {
         NoticeToImprove = 1,

--- a/TramsDataApi/Factories/Concerns/Decisions/CreateDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/CreateDecisionResponseFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
+    public class CreateDecisionResponseFactory : ICreateDecisionResponseFactory
+    {
+        public CreateDecisionResponse Create(int concernsCaseUrn, int decisionId)
+        {
+            _ = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
+            _ = decisionId <= 0 ? throw new ArgumentOutOfRangeException(nameof(decisionId)) : decisionId;
+
+
+            return new CreateDecisionResponse(concernsCaseUrn, decisionId);
+        }
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/CreateDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/CreateDecisionResponseFactory.cs
@@ -6,13 +6,6 @@ namespace TramsDataApi.Factories.Concerns.Decisions
     [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateDecisionResponseFactory : ICreateDecisionResponseFactory
     {
-        public CreateDecisionResponse Create(int concernsCaseUrn, int decisionId)
-        {
-            _ = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
-            _ = decisionId <= 0 ? throw new ArgumentOutOfRangeException(nameof(decisionId)) : decisionId;
-
-
-            return new CreateDecisionResponse(concernsCaseUrn, decisionId);
-        }
+        public CreateDecisionResponse Create(int concernsCaseUrn, int decisionId) => new CreateDecisionResponse(concernsCaseUrn, decisionId);
     }
 }

--- a/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
@@ -1,15 +1,20 @@
 ﻿using System;
+using System.Linq;
 using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.RequestModels.Concerns.Decisions;
 
 namespace TramsDataApi.Factories.Concerns.Decisions
 {
     [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
-    public class DecisionFactory : IDecisionFactory
+    public class DecisionFactory : IDecisionFactory 
     {
         public Decision CreateDecision(CreateDecisionRequest request)
         {
-            throw new System.NotImplementedException();
+            var decisionTypes = request.DecisionTypes.Select(x => new DecisionType(x)).ToArray();
+
+            return new Decision(request.ConcernsCaseId, request.CrmCaseNumber, request.RetrospectiveApproval,
+                request.SubmissionRequired, request.SubmissionDocumentLink, request.ReceivedRequestDate,
+                decisionTypes, request.TotalAmountRequested, request.SupportingNotes, DateTimeOffset.Now);
         }
     }
 }

--- a/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
+    public class DecisionFactory : IDecisionFactory
+    {
+        public Decision CreateDecision(CreateDecisionRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/DecisionFactory.cs
@@ -8,11 +8,11 @@ namespace TramsDataApi.Factories.Concerns.Decisions
     [Obsolete("This is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class DecisionFactory : IDecisionFactory 
     {
-        public Decision CreateDecision(CreateDecisionRequest request)
+        public Decision CreateDecision(int concernsCaseId, CreateDecisionRequest request)
         {
             var decisionTypes = request.DecisionTypes.Select(x => new DecisionType(x)).ToArray();
 
-            return new Decision(request.ConcernsCaseId, request.CrmCaseNumber, request.RetrospectiveApproval,
+            return new Decision(concernsCaseId, request.CrmCaseNumber, request.RetrospectiveApproval,
                 request.SubmissionRequired, request.SubmissionDocumentLink, request.ReceivedRequestDate,
                 decisionTypes, request.TotalAmountRequested, request.SupportingNotes, DateTimeOffset.Now);
         }

--- a/TramsDataApi/Factories/Concerns/Decisions/ICreateDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/ICreateDecisionResponseFactory.cs
@@ -1,0 +1,10 @@
+﻿using TramsDataApi.DatabaseModels;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    public interface ICreateDecisionResponseFactory
+    {
+        public CreateDecisionResponse Create(int concernsCaseUrn, int decisionId);
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
@@ -5,6 +5,6 @@ namespace TramsDataApi.Factories.Concerns.Decisions
 {
     public interface IDecisionFactory
     {
-        public Decision CreateDecision(CreateDecisionRequest request);
+        public Decision CreateDecision(int concernsCaseId, CreateDecisionRequest request);
     }
 }

--- a/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
@@ -1,0 +1,10 @@
+﻿using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    public interface IDecisionFactory
+    {
+        public Decision CreateDecision(CreateDecisionRequest request);
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/IDecisionFactory.cs
@@ -1,8 +1,10 @@
-﻿using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+﻿using System;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.RequestModels.Concerns.Decisions;
 
 namespace TramsDataApi.Factories.Concerns.Decisions
 {
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public interface IDecisionFactory
     {
         public Decision CreateDecision(int concernsCaseId, CreateDecisionRequest request);

--- a/TramsDataApi/Gateways/ConcernsCaseGateway.cs
+++ b/TramsDataApi/Gateways/ConcernsCaseGateway.cs
@@ -30,6 +30,7 @@ namespace TramsDataApi.Gateways
                 .Where(c => c.TrustUkprn == trustUkPrn)
                 .Skip((page - 1) * count)
                 .Take(count)
+                .Include(x => x.Decisions)
                 .AsNoTracking()
                 .ToList();
         }
@@ -37,6 +38,7 @@ namespace TramsDataApi.Gateways
         public ConcernsCase GetConcernsCaseByUrn(int urn)
         {
             var concernsCase = _tramsDbContext.ConcernsCase
+                .Include(x => x.Decisions)
                 .AsNoTracking()
                 .FirstOrDefault(c => c.Urn == urn);
             
@@ -52,6 +54,7 @@ namespace TramsDataApi.Gateways
                 .ThenInclude(record => record.ConcernsType)
                 .Include(c => c.ConcernsRecords)
                 .ThenInclude(record => record.ConcernsMeansOfReferral)
+                .Include(x => x.Decisions)
                 .AsNoTracking()
                 .FirstOrDefault(c => c.Urn == urn);
             
@@ -62,6 +65,7 @@ namespace TramsDataApi.Gateways
         {
 
             var query = _tramsDbContext.ConcernsCase
+                .Include(x => x.Decisions)
                 .Where(c => c.CreatedBy == ownerId);
 
             if (statusUrn != null)

--- a/TramsDataApi/Migrations/TramsDb/20221003163210_addConcernsDecisions.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221003163210_addConcernsDecisions.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221003163210_addConcernsDecisions")]
+    partial class addConcernsDecisions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20221003163210_addConcernsDecisions.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221003163210_addConcernsDecisions.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class addConcernsDecisions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ConcernsDecision",
+                schema: "sdd",
+                columns: table => new
+                {
+                    DecisionId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ConcernsCaseId = table.Column<int>(nullable: false),
+                    TotalAmountRequested = table.Column<decimal>(type: "money", nullable: false),
+                    SupportingNotes = table.Column<string>(nullable: true),
+                    ReceivedRequestDate = table.Column<DateTimeOffset>(nullable: false),
+                    SubmissionDocumentLink = table.Column<string>(nullable: true),
+                    SubmissionRequired = table.Column<bool>(nullable: false),
+                    RetrospectiveApproval = table.Column<bool>(nullable: false),
+                    CrmCaseNumber = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConcernsDecision", x => x.DecisionId);
+                    table.ForeignKey(
+                        name: "FK_ConcernsDecision_ConcernsCase_ConcernsCaseId",
+                        column: x => x.ConcernsCaseId,
+                        principalSchema: "sdd",
+                        principalTable: "ConcernsCase",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConcernsDecisionTypeId",
+                schema: "sdd",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false),
+                    Name = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConcernsDecisionTypeId", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConcernsDecisionType",
+                schema: "sdd",
+                columns: table => new
+                {
+                    DecisionTypeId = table.Column<int>(nullable: false),
+                    DecisionId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConcernsDecisionType", x => new { x.DecisionId, x.DecisionTypeId });
+                    table.ForeignKey(
+                        name: "FK_ConcernsDecisionType_ConcernsDecision_DecisionId",
+                        column: x => x.DecisionId,
+                        principalSchema: "sdd",
+                        principalTable: "ConcernsDecision",
+                        principalColumn: "DecisionId",
+                        onDelete: ReferentialAction.NoAction);
+                    table.ForeignKey(
+                        name: "FK_ConcernsDecisionType_ConcernsDecisionTypeId_Id",
+                        column: x => x.DecisionTypeId,
+                        principalSchema: "sdd",
+                        principalTable: "ConcernsDecisionTypeId",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.NoAction
+                    );
+                });
+
+            migrationBuilder.InsertData(
+                schema: "sdd",
+                table: "ConcernsDecisionTypeId",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "NoticeToImprove" },
+                    { 2, "Section128" },
+                    { 3, "QualifiedFloatingCharge" },
+                    { 4, "NonRepayableFinancialSupport" },
+                    { 5, "RepayableFinancialSupport" },
+                    { 6, "ShortTermCashAdvance" },
+                    { 7, "WriteOffRecoverableFunding" },
+                    { 8, "OtherFinancialSupport" },
+                    { 9, "EstimatesFundingOrPupilNumberAdjustment" },
+                    { 10, "EsfaApproval" },
+                    { 11, "FreedomOfInformationExemptions" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConcernsDecision_ConcernsCaseId",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                column: "ConcernsCaseId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ConcernsDecisionType",
+                schema: "sdd");
+
+            migrationBuilder.DropTable(
+                name: "ConcernsDecisionTypeId",
+                schema: "sdd");
+
+            migrationBuilder.DropTable(
+                name: "ConcernsDecision",
+                schema: "sdd");
+        }
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/20221005114856_addConcernsDecisions.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221005114856_addConcernsDecisions.Designer.cs
@@ -10,7 +10,7 @@ using TramsDataApi.DatabaseModels;
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    [Migration("20221003163210_addConcernsDecisions")]
+    [Migration("20221005114856_addConcernsDecisions")]
     partial class addConcernsDecisions
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -973,6 +973,9 @@ namespace TramsDataApi.Migrations.TramsDb
                     b.Property<int>("ConcernsCaseId")
                         .HasColumnType("int");
 
+                    b.Property<DateTimeOffset>("CreatedAtDateTimeOffset")
+                        .HasColumnType("datetimeoffset");
+
                     b.Property<string>("CrmCaseNumber")
                         .HasColumnType("nvarchar(max)");
 
@@ -994,10 +997,12 @@ namespace TramsDataApi.Migrations.TramsDb
                     b.Property<decimal>("TotalAmountRequested")
                         .HasColumnType("money");
 
+                    b.Property<DateTimeOffset>("UpdatedAtDateTimeOffset")
+                        .HasColumnType("datetimeoffset");
+
                     b.HasKey("DecisionId");
 
-                    b.HasIndex("ConcernsCaseId")
-                        .IsUnique();
+                    b.HasIndex("ConcernsCaseId");
 
                     b.ToTable("ConcernsDecision","sdd");
                 });
@@ -3271,8 +3276,8 @@ namespace TramsDataApi.Migrations.TramsDb
             modelBuilder.Entity("TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions.Decision", b =>
                 {
                     b.HasOne("TramsDataApi.DatabaseModels.ConcernsCase", null)
-                        .WithOne("Decision")
-                        .HasForeignKey("TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions.Decision", "ConcernsCaseId")
+                        .WithMany("Decisions")
+                        .HasForeignKey("ConcernsCaseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/TramsDataApi/Migrations/TramsDb/20221005114856_addConcernsDecisions.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221005114856_addConcernsDecisions.cs
@@ -21,7 +21,9 @@ namespace TramsDataApi.Migrations.TramsDb
                     SubmissionDocumentLink = table.Column<string>(nullable: true),
                     SubmissionRequired = table.Column<bool>(nullable: false),
                     RetrospectiveApproval = table.Column<bool>(nullable: false),
-                    CrmCaseNumber = table.Column<string>(nullable: true)
+                    CrmCaseNumber = table.Column<string>(nullable: true),
+                    CreatedAtDateTimeOffset = table.Column<DateTimeOffset>(nullable: false),
+                    UpdatedAtDateTimeOffset = table.Column<DateTimeOffset>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -65,15 +67,7 @@ namespace TramsDataApi.Migrations.TramsDb
                         principalSchema: "sdd",
                         principalTable: "ConcernsDecision",
                         principalColumn: "DecisionId",
-                        onDelete: ReferentialAction.NoAction);
-                    table.ForeignKey(
-                        name: "FK_ConcernsDecisionType_ConcernsDecisionTypeId_Id",
-                        column: x => x.DecisionTypeId,
-                        principalSchema: "sdd",
-                        principalTable: "ConcernsDecisionTypeId",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.NoAction
-                    );
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.InsertData(
@@ -99,8 +93,7 @@ namespace TramsDataApi.Migrations.TramsDb
                 name: "IX_ConcernsDecision_ConcernsCaseId",
                 schema: "sdd",
                 table: "ConcernsDecision",
-                column: "ConcernsCaseId",
-                unique: true);
+                column: "ConcernsCaseId");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/TramsDataApi/Migrations/TramsDb/20221007124839_concernsDecisionsRenameCreatedAt.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221007124839_concernsDecisionsRenameCreatedAt.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221007124839_concernsDecisionsRenameCreatedAt")]
+    partial class concernsDecisionsRenameCreatedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20221007124839_concernsDecisionsRenameCreatedAt.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221007124839_concernsDecisionsRenameCreatedAt.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class concernsDecisionsRenameCreatedAt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAtDateTimeOffset",
+                schema: "sdd",
+                table: "ConcernsDecision");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAtDateTimeOffset",
+                schema: "sdd",
+                table: "ConcernsDecision");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "sdd",
+                table: "ConcernsDecision");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                schema: "sdd",
+                table: "ConcernsDecision");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAtDateTimeOffset",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAtDateTimeOffset",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/TramsDbContextModelSnapshot.cs
+++ b/TramsDataApi/Migrations/TramsDb/TramsDbContextModelSnapshot.cs
@@ -971,6 +971,9 @@ namespace TramsDataApi.Migrations.TramsDb
                     b.Property<int>("ConcernsCaseId")
                         .HasColumnType("int");
 
+                    b.Property<DateTimeOffset>("CreatedAtDateTimeOffset")
+                        .HasColumnType("datetimeoffset");
+
                     b.Property<string>("CrmCaseNumber")
                         .HasColumnType("nvarchar(max)");
 
@@ -992,10 +995,12 @@ namespace TramsDataApi.Migrations.TramsDb
                     b.Property<decimal>("TotalAmountRequested")
                         .HasColumnType("money");
 
+                    b.Property<DateTimeOffset>("UpdatedAtDateTimeOffset")
+                        .HasColumnType("datetimeoffset");
+
                     b.HasKey("DecisionId");
 
-                    b.HasIndex("ConcernsCaseId")
-                        .IsUnique();
+                    b.HasIndex("ConcernsCaseId");
 
                     b.ToTable("ConcernsDecision","sdd");
                 });
@@ -3269,8 +3274,8 @@ namespace TramsDataApi.Migrations.TramsDb
             modelBuilder.Entity("TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions.Decision", b =>
                 {
                     b.HasOne("TramsDataApi.DatabaseModels.ConcernsCase", null)
-                        .WithOne("Decision")
-                        .HasForeignKey("TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions.Decision", "ConcernsCaseId")
+                        .WithMany("Decisions")
+                        .HasForeignKey("ConcernsCaseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
+++ b/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace TramsDataApi.RequestModels.Concerns.Decisions
+{
+    public class CreateDecisionRequest
+    {
+        public int ConcernsCaseUrn { get; set; }
+        
+        public int ConcernsCaseId { get; set; }
+        public int DecisionId { get; set; }
+        public Enums.Concerns.DecisionType[] DecisionTypes { get; set; }
+        public decimal TotalAmountRequested { get; set; }
+        public string SupportingNotes { get; set; }
+        public DateTimeOffset ReceivedRequestDate { get; set; }
+        public string SubmissionDocumentLink { get; set; }
+        public bool SubmissionRequired { get; set; }
+        public bool RetrospectiveApproval { get; set; }
+        public string CrmCaseNumber { get; set; }
+        public DateTimeOffset CreatedAtDateTimeOffset { get; set; }
+        public DateTimeOffset UpdatedAtDateTimeOffset { get; set; }
+    }
+}

--- a/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
+++ b/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
@@ -5,9 +5,7 @@ namespace TramsDataApi.RequestModels.Concerns.Decisions
     public class CreateDecisionRequest
     {
         public int ConcernsCaseUrn { get; set; }
-        
         public int ConcernsCaseId { get; set; }
-        public int DecisionId { get; set; }
         public Enums.Concerns.DecisionType[] DecisionTypes { get; set; }
         public decimal TotalAmountRequested { get; set; }
         public string SupportingNotes { get; set; }
@@ -16,7 +14,5 @@ namespace TramsDataApi.RequestModels.Concerns.Decisions
         public bool SubmissionRequired { get; set; }
         public bool RetrospectiveApproval { get; set; }
         public string CrmCaseNumber { get; set; }
-        public DateTimeOffset CreatedAtDateTimeOffset { get; set; }
-        public DateTimeOffset UpdatedAtDateTimeOffset { get; set; }
     }
 }

--- a/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
+++ b/TramsDataApi/RequestModels/Concerns/Decisions/CreateDecisionRequest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace TramsDataApi.RequestModels.Concerns.Decisions
 {
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateDecisionRequest
     {
         public int ConcernsCaseUrn { get; set; }

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/CreateDecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/CreateDecisionResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace TramsDataApi.ResponseModels.Concerns.Decisions
+{
+    public class CreateDecisionResponse
+    {
+        public CreateDecisionResponse(int concernsCaseUrn, int decisionId)
+        {
+            ConcernsCaseUrn = concernsCaseUrn >= 0 ? concernsCaseUrn : throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn), "value must be greater than zero");
+            DecisionId = decisionId >= 0 ? decisionId : throw new ArgumentOutOfRangeException(nameof(decisionId), "value must be greater than zero");;
+        }
+        public int ConcernsCaseUrn { get; private set; }
+        public int DecisionId { get; private set; }
+    }
+}

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/CreateDecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/CreateDecisionResponse.cs
@@ -2,6 +2,7 @@
 
 namespace TramsDataApi.ResponseModels.Concerns.Decisions
 {
+    [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public class CreateDecisionResponse
     {
         public CreateDecisionResponse(int concernsCaseUrn, int decisionId)

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionResponse.cs
@@ -1,13 +1,14 @@
 ﻿using System;
-using System.Linq;
+using TramsDataApi.Enums.Concerns;
 
-namespace TramsDataApi.RequestModels.Concerns.Decisions
+namespace TramsDataApi.ResponseModels.Concerns.Decisions
 {
-    public class CreateDecisionRequest
+    public class DecisionResponse
     {
-        public int ConcernsCaseUrn { get; set; }
+        public int ConcernsCaseId { get; set; }
+
         public int DecisionId { get; set; }
-        public Enums.Concerns.DecisionType[] DecisionTypes { get; set; }
+        public DecisionType[] DecisionTypes { get; set; }
         public decimal TotalAmountRequested { get; set; }
         public string SupportingNotes { get; set; }
         public DateTimeOffset ReceivedRequestDate { get; set; }
@@ -15,10 +16,7 @@ namespace TramsDataApi.RequestModels.Concerns.Decisions
         public bool SubmissionRequired { get; set; }
         public bool RetrospectiveApproval { get; set; }
         public string CrmCaseNumber { get; set; }
-
-        public bool IsValid()
-        {
-            return DecisionTypes.All(x => Enum.IsDefined(typeof(Enums.Concerns.DecisionType), x));
-        }
+        public DateTimeOffset CreatedAtDateTimeOffset { get; set; }
+        public DateTimeOffset UpdatedAtDateTimeOffset { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionResponse.cs
@@ -16,7 +16,7 @@ namespace TramsDataApi.ResponseModels.Concerns.Decisions
         public bool SubmissionRequired { get; set; }
         public bool RetrospectiveApproval { get; set; }
         public string CrmCaseNumber { get; set; }
-        public DateTimeOffset CreatedAtDateTimeOffset { get; set; }
-        public DateTimeOffset UpdatedAtDateTimeOffset { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset UpdatedAt { get; set; }
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -104,7 +104,7 @@ namespace TramsDataApi
             services.AddScoped<IConcernsTeamCaseworkGateway, ConcernsTeamCaseworkGateway>();
 
             // concerns factories
-            services.AddScoped<IUseCase<CreateDecisionRequest, CreateDecisionResponse>, CreateDecision>();
+            services.AddScoped<IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse>, CreateDecision>();
             services.AddScoped<ICreateDecisionResponseFactory, CreateDecisionResponseFactory>();
             services.AddScoped<IDecisionFactory, DecisionFactory>();
 

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -11,8 +11,11 @@ using TramsDataApi.DatabaseModels;
 using TramsDataApi.Factories.Concerns.Decisions;
 using TramsDataApi.Gateways;
 using TramsDataApi.Middleware;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
 using TramsDataApi.Swagger;
 using TramsDataApi.UseCases;
+using TramsDataApi.UseCases.CaseActions.Decisions;
 
 namespace TramsDataApi
 {
@@ -101,6 +104,7 @@ namespace TramsDataApi
             services.AddScoped<IConcernsTeamCaseworkGateway, ConcernsTeamCaseworkGateway>();
 
             // concerns factories
+            services.AddScoped<IUseCase<CreateDecisionRequest, CreateDecisionResponse>, CreateDecision>();
             services.AddScoped<ICreateDecisionResponseFactory, CreateDecisionResponseFactory>();
             services.AddScoped<IDecisionFactory, DecisionFactory>();
 

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories.Concerns.Decisions;
 using TramsDataApi.Gateways;
 using TramsDataApi.Middleware;
 using TramsDataApi.Swagger;
@@ -98,6 +99,10 @@ namespace TramsDataApi
             services.AddScoped<IGetConcernsCaseworkTeamOwners, GetConcernsCaseworkTeamOwners>();
             services.AddScoped<IUpdateConcernsCaseworkTeam, UpdateConcernsCaseworkTeam>();
             services.AddScoped<IConcernsTeamCaseworkGateway, ConcernsTeamCaseworkGateway>();
+
+            // concerns factories
+            services.AddScoped<ICreateDecisionResponseFactory, CreateDecisionResponseFactory>();
+            services.AddScoped<IDecisionFactory, DecisionFactory>();
 
             services.AddApiVersioning(config => 
             {

--- a/TramsDataApi/UseCases/CaseActions/Decisions/CreateDecision.cs
+++ b/TramsDataApi/UseCases/CaseActions/Decisions/CreateDecision.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using TramsDataApi.Factories.Concerns.Decisions;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.UseCases.CaseActions.Decisions
+{
+    public class CreateDecision : IUseCase<CreateDecisionRequest, CreateDecisionResponse>
+    {
+        private readonly IConcernsCaseGateway _concernsCaseGateway;
+        private readonly IDecisionFactory _factory;
+        private readonly ICreateDecisionResponseFactory _createDecisionResponseFactory;
+
+        public CreateDecision(IConcernsCaseGateway concernsCaseGateway, IDecisionFactory factory, ICreateDecisionResponseFactory createDecisionResponseFactory)
+        {
+            _concernsCaseGateway = concernsCaseGateway ?? throw new ArgumentNullException(nameof(concernsCaseGateway));
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            _createDecisionResponseFactory = createDecisionResponseFactory ?? throw new ArgumentNullException(nameof(createDecisionResponseFactory));
+        }
+
+        public CreateDecisionResponse Execute(CreateDecisionRequest request)
+        {
+            _ = request ?? throw new ArgumentNullException(nameof(request));
+            var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn)
+                          ?? throw new InvalidOperationException($"The concerns case for urn {request.ConcernsCaseUrn}, was not found");
+
+            var decision = _factory.CreateDecision(request);
+            concernsCase.AddDecision(decision);
+
+            _concernsCaseGateway.SaveConcernsCase(concernsCase);
+
+            return _createDecisionResponseFactory.Create(concernsCase.Urn, decision.DecisionId);
+        }
+    }
+}

--- a/TramsDataApi/UseCases/CaseActions/Decisions/CreateDecision.cs
+++ b/TramsDataApi/UseCases/CaseActions/Decisions/CreateDecision.cs
@@ -22,10 +22,16 @@ namespace TramsDataApi.UseCases.CaseActions.Decisions
         public CreateDecisionResponse Execute(CreateDecisionRequest request)
         {
             _ = request ?? throw new ArgumentNullException(nameof(request));
+
+            if (!request.IsValid())
+            {
+                throw new ArgumentException("Request is not valid", nameof(request));
+            }
+
             var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn)
                           ?? throw new InvalidOperationException($"The concerns case for urn {request.ConcernsCaseUrn}, was not found");
 
-            var decision = _factory.CreateDecision(request);
+            var decision = _factory.CreateDecision(concernsCase.Id, request);
             concernsCase.AddDecision(decision);
 
             _concernsCaseGateway.SaveConcernsCase(concernsCase);

--- a/TramsDataApi/UseCases/IUseCaseAsync.cs
+++ b/TramsDataApi/UseCases/IUseCaseAsync.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace TramsDataApi.UseCases
+{
+    /// <summary>
+    /// Represents a use case executor which accepts a request and returns a response. Enhances the standard IUseCase by supporting asynchronous execution.
+    /// </summary>
+    /// <typeparam name="TRequest"></typeparam>
+    /// <typeparam name="TResponse"></typeparam>
+    public interface IUseCaseAsync<in TRequest, TResponse>
+    {
+        Task<TResponse> Execute(TRequest request, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
What is the change?
Add new controller, request+response & use-case to allow for decisions to be created against a concerns case.

Why do we need the change?
There is ongoing work to add decision functionality to the concerns casework website. The back-end data is entirely held in the trams-data-api

What is the impact?
Should be no impact on existing endpoints or data. All tables are new.

Azure DevOps Ticket
102796