### PR TITLE
Adding sonarcloud scanning on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Build and run tests
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   build-and-test:
@@ -15,17 +16,38 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.301'
+    - name: Setup JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+    - name: Install SonarCloud scanners
+      run: |
+        dotnet tool install --global dotnet-sonarscanner
     - name: Install EF for tests
       run: dotnet tool install --global dotnet-ef --version 6.0.5
     - name: Restore tools for tests
       run: dotnet tool restore
     - name: Restore dependencies
       run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
+    - name: Build and Analyze
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        dotnet-sonarscanner begin /k:"DFE-Digital_trams-data-api" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        dotnet build --no-restore
+        dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"      
     - name: Test
       run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
Adding in SonarCloud scanning capability on pull requests to main branch being opened or updated.

Results should be posted to the pull request according to quality gates rules applied within SonarCloud and outputted to https://sonarcloud.io/project/configuration?id=DFE-Digital_trams-data-api