### PR TITLE
Feature/102797 cd get endpoint for multiple decisions

### DIFF
--- a/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -41,7 +41,13 @@ namespace TramsDataApi.Test.Factories.Concerns.Decisions
             var result = sut.Create(concernsCaseUrn, decision);
 
             result.ConcernsCaseUrn.Should().Be(concernsCaseUrn);
-            result.Should().BeEquivalentTo(decision, opt => opt.ExcludingMissingMembers());
+            result.Should().BeEquivalentTo(decision,
+                opt => opt.IncludingAllDeclaredProperties()
+                    .Excluding(x => x.DecisionTypes)
+                    .Excluding(x => x.Status));
+            result.DecisionTypes.Should().BeEquivalentTo(decision.DecisionTypes.Select(x => x.DecisionTypeId),
+                opt => opt.WithStrictOrdering());
+            result.DecisionStatus.Should().Be(decision.Status);
         }
 
         [Fact]

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -32,12 +32,15 @@ namespace TramsDataApi.Test.Factories.Concerns.Decisions
         public void Create_Returns_DecisionResponse()
         {
             var fixture = CreateFixture();
+
+            var concernsCaseUrn = fixture.Create<int>();
             var decision = fixture.Create<Decision>();
 
             var sut = new GetDecisionResponseFactory();
 
-            var result = sut.Create(decision);
+            var result = sut.Create(concernsCaseUrn, decision);
 
+            result.ConcernsCaseUrn.Should().Be(concernsCaseUrn);
             result.Should().BeEquivalentTo(decision, opt => opt.ExcludingMissingMembers());
         }
 

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionsSummariesFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionsSummariesFactoryTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.Factories.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.Factories.Concerns.Decisions
+{
+    public class GetDecisionsSummariesFactoryTests
+    {
+        [Fact]
+        public void GetDecisionsSummariesFactory_Implements_IGetDecisionsSummariesFactory()
+        {
+            var sut = new GetDecisionsSummariesFactory();
+            sut.Should().BeAssignableTo<IGetDecisionsSummariesFactory>();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Create_When_Invalid_Urn_Throws_Exception(int invalidUrn)
+        {
+            var fixture = CreateFixture();
+            CustomiseFixtureToCreateDecisions(fixture);
+            var expectedDecisions = fixture.CreateMany<Decision>().ToArray();
+
+            var sut = new GetDecisionsSummariesFactory();
+            Action act = () => sut.Create(invalidUrn, expectedDecisions);
+            act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("concernsCaseUrn");
+        }
+
+        [Fact]
+        public void Create_When_Null_Decisions_Throws_Exception()
+        {
+            var fixture = CreateFixture();
+            CustomiseFixtureToCreateDecisions(fixture);
+
+            var sut = new GetDecisionsSummariesFactory();
+            Action act = () => sut.Create(fixture.Create<int>(), null);
+            act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("decisions");
+        }
+
+        [Fact]
+        public void Create_Maps_Decisions_To_DecisionSummaries()
+        {
+            var fixture = CreateFixture();
+            CustomiseFixtureToCreateDecisions(fixture);
+
+            var expectedDecisions = fixture.CreateMany<Decision>().ToArray();
+
+            var sut = new GetDecisionsSummariesFactory();
+            var result = sut.Create(123, expectedDecisions);
+
+            result.Should().BeEquivalentTo(expectedDecisions, opt => opt.ExcludingMissingMembers());
+        }
+
+        [Fact]
+        public void Create_When_Decision_Has_No_DecisionTypes_Maps_Decisions_To_DecisionSummaries()
+        {
+            var fixture = CreateFixture();
+            CustomiseFixtureToCreateDecisionsWithNoDecisionTypes(fixture);
+
+            var expectedDecisions = fixture.CreateMany<Decision>().ToArray();
+
+            var sut = new GetDecisionsSummariesFactory();
+            var result = sut.Create(123, expectedDecisions);
+
+            result.Should().BeEquivalentTo(expectedDecisions, opt => opt.ExcludingMissingMembers());
+            result[0].Title.Should().Be("Not Available");
+        }
+
+        private Fixture CreateFixture()
+        {
+            var fixture = new Fixture();
+
+            fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            return fixture;
+        }
+
+        private Fixture CustomiseFixtureToCreateDecisions(Fixture fixture)
+        {
+            fixture.Customize<Decision>(sb => sb.FromFactory(() =>
+            {
+                var decision = Decision.CreateNew(
+                    concernsCaseId: fixture.Create<int>(),
+                    crmCaseNumber: new string(fixture.CreateMany<char>(Decision.MaxCaseNumberLength).ToArray()),
+                    retrospectiveApproval: fixture.Create<bool>(),
+                    submissionRequired: fixture.Create<bool>(),
+                    submissionDocumentLink: new string(fixture.CreateMany<char>(Decision.MaxUrlLength).ToArray()),
+                    receivedRequestDate: DateTimeOffset.Now,
+                    decisionTypes: new DecisionType[] { new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove) },
+                    totalAmountRequested: fixture.Create<decimal>(),
+                    supportingNotes: new string(fixture.CreateMany<char>(Decision.MaxSupportingNotesLength).ToArray()),
+                    createdAt: DateTimeOffset.Now
+                );
+                decision.DecisionId = fixture.Create<int>();
+                return decision;
+            }));
+            return fixture;
+        }
+
+        private Fixture CustomiseFixtureToCreateDecisionsWithNoDecisionTypes(Fixture fixture)
+        {
+            fixture.Customize<Decision>(sb => sb.FromFactory(() =>
+            {
+                var decision = Decision.CreateNew(
+                    concernsCaseId: fixture.Create<int>(),
+                    crmCaseNumber: new string(fixture.CreateMany<char>(Decision.MaxCaseNumberLength).ToArray()),
+                    retrospectiveApproval: fixture.Create<bool>(),
+                    submissionRequired: fixture.Create<bool>(),
+                    submissionDocumentLink: new string(fixture.CreateMany<char>(Decision.MaxUrlLength).ToArray()),
+                    receivedRequestDate: DateTimeOffset.Now,
+                    decisionTypes: null,
+                    totalAmountRequested: fixture.Create<decimal>(),
+                    supportingNotes: new string(fixture.CreateMany<char>(Decision.MaxSupportingNotesLength).ToArray()),
+                    createdAt: DateTimeOffset.Now
+                );
+                decision.DecisionId = fixture.Create<int>();
+                return decision;
+            }));
+            return fixture;
+        }
+    }
+}

--- a/TramsDataApi.Test/RequestModels/Concerns/Decisions/GetDecisionsRequestTests.cs
+++ b/TramsDataApi.Test/RequestModels/Concerns/Decisions/GetDecisionsRequestTests.cs
@@ -1,0 +1,43 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.RequestModels.Concerns.Decisions
+{
+    public class GetDecisionsRequestTests
+    {
+        [Fact]
+        public void Constructor_Guards_Against_Nulls()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<GuardClauseAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(GetDecisionsRequest).GetConstructors());
+        }
+
+        [Fact]
+        public void Properties_Are_Initialized_By_Constructor()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<ConstructorInitializedMemberAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(GetDecisionsRequest));
+        }
+
+        [Fact]
+        public void Property_Setters_Work_As_Expected()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<WritablePropertyAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(GetDecisionsRequest));
+        }
+    }
+}

--- a/TramsDataApi.Test/ResponseModels/Concerns/Decisions/DecisionSummaryResponseTests.cs
+++ b/TramsDataApi.Test/ResponseModels/Concerns/Decisions/DecisionSummaryResponseTests.cs
@@ -1,0 +1,43 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.ResponseModels.Concerns.Decisions
+{
+    public class DecisionSummaryResponseTests
+    {
+        [Fact]
+        public void Constructor_Guards_Against_Nulls()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<GuardClauseAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(DecisionSummaryResponse).GetConstructors());
+        }
+
+        [Fact]
+        public void Properties_Are_Initialized_By_Constructor()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<ConstructorInitializedMemberAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(DecisionSummaryResponse));
+        }
+
+        [Fact]
+        public void Property_Setters_Work_As_Expected()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var assertion = fixture.Create<WritablePropertyAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(DecisionSummaryResponse));
+        }
+    }
+}

--- a/TramsDataApi.Test/UseCases/CaseActions/Decisions/GetDecisionTests.cs
+++ b/TramsDataApi.Test/UseCases/CaseActions/Decisions/GetDecisionTests.cs
@@ -95,7 +95,7 @@ namespace TramsDataApi.Test.UseCases.CaseActions.Decisions
 
             var mockGetDecisionResponseFactory = new Mock<IGetDecisionResponseFactory>();
             mockGetDecisionResponseFactory
-                .Setup(x => x.Create(fakeDecision))
+                .Setup(x => x.Create(fakeConcernsCase.Urn, fakeDecision))
                 .Returns(fakeResponse);
 
             // act

--- a/TramsDataApi.Test/UseCases/CaseActions/Decisions/GetDecisionsTests.cs
+++ b/TramsDataApi.Test/UseCases/CaseActions/Decisions/GetDecisionsTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.Idioms;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.Factories.Concerns.Decisions;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+using TramsDataApi.UseCases;
+using TramsDataApi.UseCases.CaseActions.Decisions;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases.CaseActions.Decisions
+{
+    public class GetDecisionsTests
+    {
+        [Fact]
+        public void GetDecisions_Implements_IUseCaseAsync()
+        {
+            var fixture = CreateFixture();
+            var sut = fixture.Create<GetDecisions>();
+            sut.Should().BeAssignableTo<IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]>>();
+        }
+
+        [Fact]
+        public void Constructor_Guards_Against_Null_Arguments()
+        {
+            // Arrange
+            var fixture = CreateFixture();
+
+            var assertion = fixture.Create<GuardClauseAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(GetDecisions).GetConstructors());
+        }
+
+        [Fact]
+        public void Methods_Guards_Against_Null_Arguments()
+        {
+            // Arrange
+            var fixture = CreateFixture();
+
+            var assertion = fixture.Create<GuardClauseAssertion>();
+
+            // Act & Assert
+            assertion.Verify(typeof(GetDecisions).GetMethods());
+        }
+
+        [Fact]
+        public async Task Execute_Returns_Null_When_No_ConcernsCase_Found()
+        {
+            var mockGateWay = new Mock<IConcernsCaseGateway>();
+            var mockLogger = new Mock<ILogger<GetDecisions>>();
+            var fixture = CreateFixture(mockLogger.Object, mockGateWay.Object);
+            var expectedRequest = fixture.Create<GetDecisionsRequest>();
+
+            mockGateWay.Setup(x => x.GetConcernsCaseByUrn(It.IsAny<int>())).Returns(default(ConcernsCase));
+
+            var sut = fixture.Create<GetDecisions>();
+            var result = await sut.Execute(expectedRequest, CancellationToken.None);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Execute_Returns_Empty_Array_When_ConcernsCase_Has_No_Decisions()
+        {
+            var mockGateWay = new Mock<IConcernsCaseGateway>();
+            var mockLogger = new Mock<ILogger<GetDecisions>>();
+            var mockFactory = new Mock<IGetDecisionsSummariesFactory>();
+
+            var fixture = CreateFixture(mockLogger.Object, mockGateWay.Object, mockFactory.Object);
+
+            var expectedRequest = fixture.Create<GetDecisionsRequest>();
+            var expectedConcernsCase = fixture.Create<ConcernsCase>();
+
+            mockGateWay.Setup(x => x.GetConcernsCaseByUrn(It.IsAny<int>())).Returns(expectedConcernsCase);
+
+            var sut = fixture.Create<GetDecisions>();
+            var result = await sut.Execute(expectedRequest, CancellationToken.None);
+
+            result.Should().BeEquivalentTo(Array.Empty<DecisionSummaryResponse>());
+            mockFactory.Verify(x => x.Create(expectedRequest.ConcernsCaseUrn, It.IsAny<IEnumerable<Decision>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Execute_Returns_Summary_Array_When_ConcernsCase_Has_Decisions()
+        {
+            var mockGateWay = new Mock<IConcernsCaseGateway>();
+            var mockLogger = new Mock<ILogger<GetDecisions>>();
+            var mockFactory = new Mock<IGetDecisionsSummariesFactory>();
+
+            var fixture = CreateFixture(mockLogger.Object, mockGateWay.Object, mockFactory.Object);
+
+            var expectedConcernsCase = fixture.Create<ConcernsCase>();
+            var expectedRequest = new GetDecisionsRequest(expectedConcernsCase.Urn);
+
+            expectedConcernsCase.AddDecision(fixture.Create<Decision>());
+
+            var expectedResult = new[]
+            {
+                new DecisionSummaryResponse() { ConcernsCaseUrn = expectedConcernsCase.Urn }
+            };
+
+            mockGateWay.Setup(x => x.GetConcernsCaseByUrn(It.IsAny<int>()))
+                .Returns(expectedConcernsCase);
+
+            mockFactory.Setup(x => x.Create(expectedConcernsCase.Urn, It.IsAny<IEnumerable<Decision>>()))
+                .Returns(() => expectedResult);
+
+            var sut = fixture.Create<GetDecisions>();
+            var result = await sut.Execute(expectedRequest, CancellationToken.None);
+
+            mockFactory.Verify(x => x.Create(expectedConcernsCase.Urn, It.IsAny<IEnumerable<Decision>>()), Times.Once);
+            result.Should().BeSameAs(expectedResult);
+        }
+
+        private static Fixture CreateFixture(
+            ILogger<GetDecisions> logger = null,
+            IConcernsCaseGateway gateway = null,
+            IGetDecisionsSummariesFactory decisionsSummariesFactory = null)
+        {
+            var fixture = new Fixture();
+            fixture.Register(() => logger ?? Mock.Of<ILogger<GetDecisions>>());
+            fixture.Register(() => gateway ?? Mock.Of<IConcernsCaseGateway>());
+            fixture.Register(() => decisionsSummariesFactory ?? Mock.Of<IGetDecisionsSummariesFactory>());
+
+            fixture.Customize<Decision>(sb => sb.FromFactory(() =>
+            {
+                var decision = Decision.CreateNew(
+                    concernsCaseId: fixture.Create<int>(),
+                    crmCaseNumber: new string(fixture.CreateMany<char>(Decision.MaxCaseNumberLength).ToArray()),
+                    retrospectiveApproval: fixture.Create<bool>(),
+                    submissionRequired: fixture.Create<bool>(),
+                    submissionDocumentLink: new string(fixture.CreateMany<char>(Decision.MaxUrlLength).ToArray()),
+                    receivedRequestDate: DateTimeOffset.Now,
+                    decisionTypes: new DecisionType[] { new DecisionType(Enums.Concerns.DecisionType.NoticeToImprove) },
+                    totalAmountRequested: fixture.Create<decimal>(),
+                    supportingNotes: new string(fixture.CreateMany<char>(Decision.MaxSupportingNotesLength).ToArray()),
+                    createdAt: DateTimeOffset.Now
+                );
+                decision.DecisionId = fixture.Create<int>();
+                return decision;
+            }));
+
+            fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+            return fixture;
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
+++ b/TramsDataApi/Controllers/V2/ConcernsCaseDecisionController.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Runtime.CompilerServices;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.RequestModels.Concerns.Decisions;
 using TramsDataApi.ResponseModels;
 using TramsDataApi.ResponseModels.Concerns.Decisions;
@@ -21,16 +23,19 @@ namespace TramsDataApi.Controllers.V2
         private readonly ILogger<ConcernsCaseDecisionController> _logger;
         private readonly IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse> _createDecisionUseCase;
         private readonly IUseCaseAsync<GetDecisionRequest, GetDecisionResponse> _getDecisionUserCase;
+        private readonly IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]> _getDecisionsUserCase;
 
         public ConcernsCaseDecisionController(
             ILogger<ConcernsCaseDecisionController> logger,
             IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse> createDecisionUseCase,
-            IUseCaseAsync<GetDecisionRequest, GetDecisionResponse> getDecisionUserCase
+            IUseCaseAsync<GetDecisionRequest, GetDecisionResponse> getDecisionUseCase,
+            IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]> getDecisionsUseCase
         )
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _createDecisionUseCase = createDecisionUseCase ?? throw new ArgumentNullException(nameof(createDecisionUseCase));
-            _getDecisionUserCase = getDecisionUserCase ?? throw new ArgumentNullException(nameof(getDecisionUserCase));
+            _getDecisionUserCase = getDecisionUseCase ?? throw new ArgumentNullException(nameof(getDecisionUseCase));
+            _getDecisionsUserCase = getDecisionsUseCase ?? throw new ArgumentNullException(nameof(getDecisionsUseCase));
         }
 
         [HttpPost]
@@ -39,9 +44,8 @@ namespace TramsDataApi.Controllers.V2
         {
             LogInfo($"Executing Create. Urn {urn}");
 
-            if (urn <= 0)
+            if (!ValidateUrn(urn, nameof(Create)))
             {
-                LogInfo($"Failed to create Concerns Case Decision - invalid urn value");
                 return BadRequest();
             }
 
@@ -50,7 +54,7 @@ namespace TramsDataApi.Controllers.V2
                 request.ConcernsCaseUrn = urn;
             }
 
-            if(request == null || !request.IsValid())
+            if (request == null || !request.IsValid())
             {
                 LogInfo($"Failed to create Concerns Case Decision due to bad request");
                 return BadRequest();
@@ -58,7 +62,7 @@ namespace TramsDataApi.Controllers.V2
 
             var createdDecision = await _createDecisionUseCase.Execute(request, cancellationToken);
             var response = new ApiSingleResponseV2<CreateDecisionResponse>(createdDecision);
-            
+
             LogInfo($"Returning created response. Concerns Case Urn {response.Data.ConcernsCaseUrn}, DecisionId {response.Data.DecisionId}");
             return new ObjectResult(response) { StatusCode = StatusCodes.Status201Created };
         }
@@ -69,11 +73,11 @@ namespace TramsDataApi.Controllers.V2
         {
             LogInfo($"Attempting to get Concerns Decision by Urn {urn}, DecisionId {decisionId}");
 
-            if (urn <= 0)
+            if (!ValidateUrn(urn, nameof(GetById)))
             {
-                LogInfo($"Failed to GET Concerns Case Decision - invalid urn value");
                 return BadRequest();
             }
+
             if (decisionId <= 0)
             {
                 LogInfo($"Failed to GET Concerns Case Decision - invalid urn value");
@@ -92,6 +96,37 @@ namespace TramsDataApi.Controllers.V2
                 var actionResponse = new ApiSingleResponseV2<GetDecisionResponse>(decisionResponse);
                 return Ok(actionResponse);
             }
+        }
+
+        private bool ValidateUrn(int urn, string methodName)
+        {
+            if (urn <= 0)
+            {
+                LogInfo($"{methodName} found invalid urn value");
+                return false;
+            }
+
+            return true;
+        }
+
+        [HttpGet()]
+        [MapToApiVersion("2.0")]
+        public async Task<ActionResult<ApiSingleResponseV2<DecisionSummaryResponse[]>>> GetDecisions(int urn, CancellationToken cancellationToken)
+        {
+            LogInfo($"Entered {nameof(GetDecisions)}, Urn {urn}");
+
+            if (!ValidateUrn(urn, nameof(GetDecisions)))
+            {
+                return BadRequest();
+            }
+
+            var results = await _getDecisionsUserCase.Execute(new GetDecisionsRequest(urn), cancellationToken);
+            if (results is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new ApiSingleResponseV2<DecisionSummaryResponse[]>(results));
         }
 
         private void LogInfo(string msg, [CallerMemberName] string caller = "")

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -73,22 +73,17 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 
         // nullable
         public decimal TotalAmountRequested { get; set;}
-
-        // 2,000 chars   
+        
         [StringLength(MaxSupportingNotesLength)]
         public string SupportingNotes { get; set;}
-
-        // nullable
+        
         public DateTimeOffset ReceivedRequestDate { get; set;}
-
-        // 2,048 chars
+        
         [StringLength(MaxUrlLength)]
         public string SubmissionDocumentLink { get; set;}
-
-        // nullable
+        
         public bool? SubmissionRequired { get; set;}
-
-        // nullable
+        
         public bool? RetrospectiveApproval { get; set;}
 
         [StringLength(MaxCaseNumberLength)]
@@ -97,6 +92,7 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
         public DateTimeOffset UpdatedAt { get; set;}
 
         public Enums.Concerns.DecisionStatus Status { get; set;}
+        public DateTimeOffset? ClosedAt { get; set; }
 
     }
 }

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
@@ -7,12 +7,14 @@ namespace TramsDataApi.Factories.Concerns.Decisions
 {
     public class GetDecisionResponseFactory : IGetDecisionResponseFactory
     {
-        public GetDecisionResponse Create(Decision decision)
+        public GetDecisionResponse Create(int concernsCaseUrn, Decision decision)
         {
+            _ = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
             _ = decision ?? throw new ArgumentNullException(nameof(decision));
             
             return new GetDecisionResponse()
             {
+                ConcernsCaseUrn = concernsCaseUrn,
                 ConcernsCaseId = decision.ConcernsCaseId,
                 DecisionId = decision.DecisionId,
                 DecisionTypes = decision.DecisionTypes.Select(x => x.DecisionTypeId).ToArray(),

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
@@ -26,7 +26,9 @@ namespace TramsDataApi.Factories.Concerns.Decisions
                 RetrospectiveApproval = decision.RetrospectiveApproval,
                 CrmCaseNumber = decision.CrmCaseNumber,
                 CreatedAt = decision.CreatedAt,
-                UpdatedAt = decision.UpdatedAt
+                UpdatedAt = decision.UpdatedAt,
+                ClosedAt = decision.ClosedAt, // TODO,
+                DecisionStatus = decision.Status
             };
         }
     }

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    public class GetDecisionsSummariesFactory : IGetDecisionsSummariesFactory
+    {
+        public DecisionSummaryResponse[] Create(int concernsCaseUrn, IEnumerable<Decision> decisions)
+        {
+            _ = concernsCaseUrn > 0 ? concernsCaseUrn : throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn));
+            _ = decisions ?? throw new ArgumentNullException(nameof(decisions));
+
+            return decisions.Select(x => new DecisionSummaryResponse()
+            {
+                ConcernsCaseUrn = concernsCaseUrn,
+                DecisionId = x.DecisionId, 
+                DecisionStatus = x.Status,
+                CreatedAt = x.CreatedAt,
+                UpdatedAt = x.UpdatedAt,
+                ClosedAt = null,
+                Title = x.DecisionTypes.FirstOrDefault()?.DecisionTypeId.ToString() ?? "Not Available",
+            }).ToArray();
+        }
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
@@ -13,15 +13,15 @@ namespace TramsDataApi.Factories.Concerns.Decisions
             _ = concernsCaseUrn > 0 ? concernsCaseUrn : throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn));
             _ = decisions ?? throw new ArgumentNullException(nameof(decisions));
 
-            return decisions.Select(x => new DecisionSummaryResponse()
+            return decisions.Select(decision => new DecisionSummaryResponse()
             {
                 ConcernsCaseUrn = concernsCaseUrn,
-                DecisionId = x.DecisionId, 
-                DecisionStatus = x.Status,
-                CreatedAt = x.CreatedAt,
-                UpdatedAt = x.UpdatedAt,
-                ClosedAt = null,
-                Title = x.DecisionTypes.FirstOrDefault()?.DecisionTypeId.ToString() ?? "Not Available",
+                DecisionId = decision.DecisionId, 
+                Status = decision.Status,
+                CreatedAt = decision.CreatedAt,
+                UpdatedAt = decision.UpdatedAt,
+                ClosedAt = decision.ClosedAt,
+                Title = decision.DecisionTypes.FirstOrDefault()?.DecisionTypeId.ToString() ?? "Not Available",
             }).ToArray();
         }
     }

--- a/TramsDataApi/Factories/Concerns/Decisions/IGetDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/IGetDecisionResponseFactory.cs
@@ -5,6 +5,6 @@ namespace TramsDataApi.Factories.Concerns.Decisions
 {
     public interface IGetDecisionResponseFactory
     {
-        public GetDecisionResponse Create(Decision decision);
+        public GetDecisionResponse Create(int concernsCaseUrn, Decision decision);
     }
 }

--- a/TramsDataApi/Factories/Concerns/Decisions/IGetDecisionsSummariesFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/IGetDecisionsSummariesFactory.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.Factories.Concerns.Decisions
+{
+    public interface IGetDecisionsSummariesFactory
+    {
+        public DecisionSummaryResponse[] Create(int concernsCaseUrn, IEnumerable<Decision> decisions);
+    }
+}

--- a/TramsDataApi/Migrations/TramsDb/20221026141434_concernsDecisionClosedAt.Designer.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221026141434_concernsDecisionClosedAt.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Migrations.TramsDb
 {
     [DbContext(typeof(TramsDbContext))]
-    partial class TramsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221026141434_concernsDecisionClosedAt")]
+    partial class concernsDecisionClosedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TramsDataApi/Migrations/TramsDb/20221026141434_concernsDecisionClosedAt.cs
+++ b/TramsDataApi/Migrations/TramsDb/20221026141434_concernsDecisionClosedAt.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TramsDataApi.Migrations.TramsDb
+{
+    public partial class concernsDecisionClosedAt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ClosedAt",
+                schema: "sdd",
+                table: "ConcernsDecision",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClosedAt",
+                schema: "sdd",
+                table: "ConcernsDecision");
+        }
+    }
+}

--- a/TramsDataApi/RequestModels/Concerns/Decisions/GetDecisionsRequest.cs
+++ b/TramsDataApi/RequestModels/Concerns/Decisions/GetDecisionsRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace TramsDataApi.RequestModels.Concerns.Decisions
+{
+    public class GetDecisionsRequest
+    {
+        public int ConcernsCaseUrn { get; set; }
+        public GetDecisionsRequest(int concernsCaseUrn)
+        {
+            ConcernsCaseUrn = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
+        }
+    }
+}

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionSummaryResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionSummaryResponse.cs
@@ -9,7 +9,7 @@ namespace TramsDataApi.ResponseModels.Concerns.Decisions
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
         public string Title { get; set; }
-        public Enums.Concerns.DecisionStatus DecisionStatus { get; set; }
+        public Enums.Concerns.DecisionStatus Status { get; set; }
         public DateTimeOffset? ClosedAt { get; set; }
     }
 }

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionSummaryResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/DecisionSummaryResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace TramsDataApi.ResponseModels.Concerns.Decisions
+{
+    public class DecisionSummaryResponse
+    {
+        public int ConcernsCaseUrn { get; set; }
+        public int DecisionId { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset UpdatedAt { get; set; }
+        public string Title { get; set; }
+        public Enums.Concerns.DecisionStatus DecisionStatus { get; set; }
+        public DateTimeOffset? ClosedAt { get; set; }
+    }
+}

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
@@ -5,7 +5,10 @@ namespace TramsDataApi.ResponseModels.Concerns.Decisions
 {
     public class GetDecisionResponse
     {
-        public int ConcernsCaseId { get; set; }
+        public int ConcernsCaseUrn { get; set; }
+
+        [Obsolete("This will be removed. Prefer the ConcernsCaseUrn instead")]
+        public int ConcernsCaseId { get; set; } // To be removed.
         public int DecisionId { get; set; }
         public DecisionType[] DecisionTypes { get; set; }
         public decimal TotalAmountRequested { get; set; }

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
@@ -20,5 +20,7 @@ namespace TramsDataApi.ResponseModels.Concerns.Decisions
         public string CrmCaseNumber { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
+        public Enums.Concerns.DecisionStatus DecisionStatus { get; set; }
+        public DateTimeOffset? ClosedAt { get; set; }
     }
 }

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -107,9 +107,11 @@ namespace TramsDataApi
             // concerns factories
             services.AddScoped<IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse>, CreateDecision>();
             services.AddScoped<IUseCaseAsync<GetDecisionRequest, GetDecisionResponse>, GetDecision>();
+            services.AddScoped<IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]>, GetDecisions>();
             services.AddScoped<ICreateDecisionResponseFactory, CreateDecisionResponseFactory>();
             services.AddScoped<IDecisionFactory, DecisionFactory>();
             services.AddScoped<IGetDecisionResponseFactory, GetDecisionResponseFactory>();
+            services.AddScoped<IGetDecisionsSummariesFactory, GetDecisionsSummariesFactory>();
 
             services.AddApiVersioning(config => 
             {

--- a/TramsDataApi/UseCases/CaseActions/Decisions/GetDecision.cs
+++ b/TramsDataApi/UseCases/CaseActions/Decisions/GetDecision.cs
@@ -27,7 +27,7 @@ namespace TramsDataApi.UseCases.CaseActions.Decisions
             var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn);
             var decision = concernsCase?.Decisions.FirstOrDefault(x => x.DecisionId == request.DecisionId);
             
-            return decision != null ? _responseFactory.Create(decision) : null;
+            return decision != null ? _responseFactory.Create(concernsCase.Urn, decision) : null;
         }
     }
 }

--- a/TramsDataApi/UseCases/CaseActions/Decisions/GetDecisions.cs
+++ b/TramsDataApi/UseCases/CaseActions/Decisions/GetDecisions.cs
@@ -23,24 +23,27 @@ namespace TramsDataApi.UseCases.CaseActions.Decisions
             _getDecisionsSummariesFactory = getDecisionsSummariesFactory ?? throw new ArgumentNullException(nameof(getDecisionsSummariesFactory));
         }
 
-        public async Task<DecisionSummaryResponse[]> Execute(GetDecisionsRequest request, CancellationToken cancellationToken)
+        public Task<DecisionSummaryResponse[]> Execute(GetDecisionsRequest request, CancellationToken cancellationToken)
         {
-            _ = request ?? throw new ArgumentNullException(nameof(request));
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
 
             async Task<DecisionSummaryResponse[]> DoWork()
             {
-                var concernsCase =  _gateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn);
+                cancellationToken.ThrowIfCancellationRequested();
+                var concernsCase = _gateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn);
 
                 if (concernsCase == null)
                 {
-                    return default(DecisionSummaryResponse[]);
+                    return default;
                 }
 
-                var result = _getDecisionsSummariesFactory.Create(request.ConcernsCaseUrn, concernsCase.Decisions.AsEnumerable());
-                return result;
+                return _getDecisionsSummariesFactory.Create(request.ConcernsCaseUrn, concernsCase.Decisions.AsEnumerable());
             }
 
-            return await DoWork();
+            return DoWork();
         }
     }
 }

--- a/TramsDataApi/UseCases/CaseActions/Decisions/GetDecisions.cs
+++ b/TramsDataApi/UseCases/CaseActions/Decisions/GetDecisions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TramsDataApi.Factories.Concerns.Decisions;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels.Concerns.Decisions;
+using TramsDataApi.ResponseModels.Concerns.Decisions;
+
+namespace TramsDataApi.UseCases.CaseActions.Decisions
+{
+    public class GetDecisions : IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]>
+    {
+        private readonly ILogger<GetDecisions> _logger;
+        private readonly IConcernsCaseGateway _gateway;
+        private readonly IGetDecisionsSummariesFactory _getDecisionsSummariesFactory;
+
+        public GetDecisions(ILogger<GetDecisions> logger, IConcernsCaseGateway gateway, IGetDecisionsSummariesFactory getDecisionsSummariesFactory)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _gateway = gateway ?? throw new ArgumentNullException(nameof(gateway));
+            _getDecisionsSummariesFactory = getDecisionsSummariesFactory ?? throw new ArgumentNullException(nameof(getDecisionsSummariesFactory));
+        }
+
+        public async Task<DecisionSummaryResponse[]> Execute(GetDecisionsRequest request, CancellationToken cancellationToken)
+        {
+            _ = request ?? throw new ArgumentNullException(nameof(request));
+
+            async Task<DecisionSummaryResponse[]> DoWork()
+            {
+                var concernsCase =  _gateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn);
+
+                if (concernsCase == null)
+                {
+                    return default(DecisionSummaryResponse[]);
+                }
+
+                var result = _getDecisionsSummariesFactory.Create(request.ConcernsCaseUrn, concernsCase.Decisions.AsEnumerable());
+                return result;
+            }
+
+            return await DoWork();
+        }
+    }
+}


### PR DESCRIPTION
What is the change?
Added a new endpoint to get a summary of decisions attached to a concerns case.

Why do we need the change?
Needed to show high level decision information on the concerns case overview page.

What is the impact?
No existing systems access the endpoint.
But a new field has been added to the concerns decisions table.

Azure DevOps Ticket
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2030?workitem=109749