### PR TITLE
Add dotnet-coverage to testing to collect coverage for sonarcloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,11 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Install SonarCloud scanners
-      run: |
-        dotnet tool install --global dotnet-sonarscanner
+      run: dotnet tool install --global dotnet-sonarscanner
     - name: Install EF for tests
       run: dotnet tool install --global dotnet-ef --version 6.0.5
+    - name: Install dotnet-coverage
+      run: dotnet tool install --global dotnet-coverage
     - name: Restore tools for tests
       run: dotnet tool restore
     - name: Restore dependencies
@@ -49,7 +50,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_trams-data-api" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        dotnet-sonarscanner begin /k:"DFE-Digital_trams-data-api" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build --no-restore
-        dotnet test --no-build --verbosity normal
+        dotnet-coverage collect 'dotnet test --no-build --verbosity normal' -f xml -o 'coverage.xml'
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"      


### PR DESCRIPTION
Adding the dotnet-coverage tool to the build & test workflow. This allows us to collect code coverage results and report them back into SonarCloud.