### PR TITLE
Added a GetTitle method to decisions, to return some meaningful text …

### DIFF
--- a/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
+++ b/TramsDataApi.Test/DatabaseModels/Concerns/DecisionTests.cs
@@ -1,8 +1,11 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using AutoFixture.Xunit2;
 using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
+using TramsDataApi.Extensions;
 using Xunit;
 
 namespace TramsDataApi.Test.DatabaseModels.Concerns
@@ -41,7 +44,7 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
         public void CreateNew_With_Invalid_Arguments_Throws_Exception(int caseId, decimal amountRequested, string crmCaseNumber, string supportingNotes, string submissionDocumentLink, string expectedParamName)
         {
             var fixture = new Fixture();
-            crmCaseNumber = crmCaseNumber == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxCaseNumberLength + 1): crmCaseNumber;
+            crmCaseNumber = crmCaseNumber == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxCaseNumberLength + 1) : crmCaseNumber;
             supportingNotes = supportingNotes == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxSupportingNotesLength + 1) : supportingNotes;
             submissionDocumentLink = submissionDocumentLink == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxUrlLength + 1) : submissionDocumentLink;
 
@@ -110,6 +113,81 @@ namespace TramsDataApi.Test.DatabaseModels.Concerns
             var fixture = new Fixture();
             var sut = CreateRandomDecision(fixture);
             sut.Status.Should().Be(Enums.Concerns.DecisionStatus.InProgress);
+        }
+
+        [Fact]
+        public void GetTitle_Maps_Multiple_Decision_Types_To_Text()
+        {
+            var fixture = new Fixture();
+            var sut = Decision.CreateNew(
+                123,
+                "12345",
+                true,
+                true,
+                "https://somewhere/somelink.doc",
+                DateTimeOffset.UtcNow,
+                fixture.CreateMany<DecisionType>(5).ToArray(),
+                13.5m,
+                "some notes",
+                DateTimeOffset.UtcNow
+            );
+
+            sut.GetTitle().Should().Be("Multiple Decision Types");
+        }
+
+        [Fact]
+        public void GetTitle_Maps_Zero_Decision_Types_To_Text()
+        {
+            var sut = Decision.CreateNew(
+                123,
+                "12345",
+                true,
+                true,
+                "https://somewhere/somelink.doc",
+                DateTimeOffset.UtcNow,
+                null,
+                13.5m,
+                "some notes",
+                DateTimeOffset.UtcNow
+            );
+
+            sut.GetTitle().Should().Be("No Decision Types");
+        }
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void GetTitle_When_One_DecisionType_Maps_To_DecisionType_Description(Enums.Concerns.DecisionType decisionType)
+        {
+            var decisionTypes = new[]
+            {
+                new DecisionType(decisionType) { DecisionId = (int)decisionType },
+            };
+
+            var sut = Decision.CreateNew(
+                123,
+                "12345",
+                true,
+                true,
+                "https://somewhere/somelink.doc",
+                DateTimeOffset.UtcNow,
+                decisionTypes,
+                13.5m,
+                "some notes",
+                DateTimeOffset.UtcNow
+            );
+
+            sut.GetTitle().Should().Be(decisionType.GetDescription());
+        }
+
+        public static IEnumerable<object[]> Data
+        {
+            get
+            {
+                foreach (var enumValue in Enum.GetValues(typeof(Enums.Concerns.DecisionType)))
+                {
+                    yield return new object[] { (Enums.Concerns.DecisionType)enumValue };
+                }
+            }
         }
     }
 }

--- a/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/TramsDataApi.Test/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -48,6 +48,7 @@ namespace TramsDataApi.Test.Factories.Concerns.Decisions
             result.DecisionTypes.Should().BeEquivalentTo(decision.DecisionTypes.Select(x => x.DecisionTypeId),
                 opt => opt.WithStrictOrdering());
             result.DecisionStatus.Should().Be(decision.Status);
+            result.Title.Should().Be(decision.GetTitle());
         }
 
         [Fact]

--- a/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/TramsDataApi/DatabaseModels/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using TramsDataApi.Extensions;
 
 namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 {
@@ -73,17 +74,17 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
 
         // nullable
         public decimal TotalAmountRequested { get; set;}
-        
+
         [StringLength(MaxSupportingNotesLength)]
         public string SupportingNotes { get; set;}
-        
+
         public DateTimeOffset ReceivedRequestDate { get; set;}
-        
+
         [StringLength(MaxUrlLength)]
         public string SubmissionDocumentLink { get; set;}
-        
+
         public bool? SubmissionRequired { get; set;}
-        
+
         public bool? RetrospectiveApproval { get; set;}
 
         [StringLength(MaxCaseNumberLength)]
@@ -94,5 +95,17 @@ namespace TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions
         public Enums.Concerns.DecisionStatus Status { get; set;}
         public DateTimeOffset? ClosedAt { get; set; }
 
+        public string GetTitle()
+        {
+            switch (this.DecisionTypes?.Count ?? 0)
+            {
+                case 0 :
+                    return "No Decision Types";
+                case int i when i > 1:
+                    return "Multiple Decision Types";
+                default:
+                    return this.DecisionTypes[0].DecisionTypeId.GetDescription();
+            }
+        }
     }
 }

--- a/TramsDataApi/Enums/Concerns/DecisionType.cs
+++ b/TramsDataApi/Enums/Concerns/DecisionType.cs
@@ -1,20 +1,42 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace TramsDataApi.Enums.Concerns
 {
     [Obsolete("This endpoint is planned to be moved into the Concerns Casework API. If it is accessed by other APIs, please let the Concerns team know.")]
     public enum DecisionType
     {
+        [Description("Notice to Improve (NTI)")]
         NoticeToImprove = 1,
+
+        [Description("Section 128 (S128)")]
         Section128 = 2,
+
+        [Description("Qualified Floating Charge (QFC)")]
         QualifiedFloatingCharge = 3,
+
+        [Description("Non-repayable financial support")]
         NonRepayableFinancialSupport = 4,
+
+        [Description("Repayable financial support")]
         RepayableFinancialSupport = 5,
+
+        [Description("Short-term cash advance")]
         ShortTermCashAdvance = 6,
+
+        [Description("Write-off recoverable funding")]
         WriteOffRecoverableFunding = 7,
+
+        [Description("Other financial support")]
         OtherFinancialSupport = 8,
+
+        [Description("Other financial support")]
         EstimatesFundingOrPupilNumberAdjustment = 9,
+
+        [Description("ESFA approval to spend or write-off")]
         EsfaApproval = 10,
+
+        [Description("Freedom of Information exemptions (FOI) ")]
         FreedomOfInformationExemptions = 11
     }
 }

--- a/TramsDataApi/Extensions/EnumExtensions.cs
+++ b/TramsDataApi/Extensions/EnumExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+
+namespace TramsDataApi.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static string GetDescription<T>(this T e) where T : IConvertible
+        {
+            if (e is Enum)
+            {
+                Type type = e.GetType();
+
+                foreach (int val in System.Enum.GetValues(type))
+                {
+                    if (val == e.ToInt32(CultureInfo.InvariantCulture))
+                    {
+                        var memInfo = type.GetMember(type.GetEnumName(val));
+                        var descriptionAttribute = memInfo[0]
+                            .GetCustomAttributes(typeof(DescriptionAttribute), false)
+                            .FirstOrDefault() as DescriptionAttribute;
+
+                        if (descriptionAttribute != null)
+                        {
+                            return descriptionAttribute.Description;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
@@ -11,7 +11,7 @@ namespace TramsDataApi.Factories.Concerns.Decisions
         {
             _ = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
             _ = decision ?? throw new ArgumentNullException(nameof(decision));
-            
+
             return new GetDecisionResponse()
             {
                 ConcernsCaseUrn = concernsCaseUrn,
@@ -27,8 +27,9 @@ namespace TramsDataApi.Factories.Concerns.Decisions
                 CrmCaseNumber = decision.CrmCaseNumber,
                 CreatedAt = decision.CreatedAt,
                 UpdatedAt = decision.UpdatedAt,
-                ClosedAt = decision.ClosedAt, // TODO,
-                DecisionStatus = decision.Status
+                ClosedAt = decision.ClosedAt,
+                DecisionStatus = decision.Status,
+                Title = decision.GetTitle()
             };
         }
     }

--- a/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
+++ b/TramsDataApi/Factories/Concerns/Decisions/GetDecisionsSummariesFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TramsDataApi.DatabaseModels.Concerns.Case.Management.Actions.Decisions;
 using TramsDataApi.ResponseModels.Concerns.Decisions;
+using TramsDataApi.Extensions;
 
 namespace TramsDataApi.Factories.Concerns.Decisions
 {
@@ -16,12 +17,12 @@ namespace TramsDataApi.Factories.Concerns.Decisions
             return decisions.Select(decision => new DecisionSummaryResponse()
             {
                 ConcernsCaseUrn = concernsCaseUrn,
-                DecisionId = decision.DecisionId, 
+                DecisionId = decision.DecisionId,
                 Status = decision.Status,
                 CreatedAt = decision.CreatedAt,
                 UpdatedAt = decision.UpdatedAt,
                 ClosedAt = decision.ClosedAt,
-                Title = decision.DecisionTypes.FirstOrDefault()?.DecisionTypeId.ToString() ?? "Not Available",
+                Title = decision.GetTitle(),
             }).ToArray();
         }
     }

--- a/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
+++ b/TramsDataApi/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
@@ -22,5 +22,6 @@ namespace TramsDataApi.ResponseModels.Concerns.Decisions
         public DateTimeOffset UpdatedAt { get; set; }
         public Enums.Concerns.DecisionStatus DecisionStatus { get; set; }
         public DateTimeOffset? ClosedAt { get; set; }
+        public string Title { get; set; }
     }
 }


### PR DESCRIPTION
What is the change?
Introduced a 'Title' to decisions, which is a method that looks at the decision types selected and returns appropriate text.

Why do we need the change?
Frontend for concerns needs to show something meaningful to caseworkers, and because decisions can have a number of decisions types, the logic to decide what to show should sit with the decision.

What is the impact?
None

Azure DevOps Ticket
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2030?workitem=110998