### PR TITLE
Use dotnet test for coverage collection, reportgenerator to output to sonarcloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,8 @@ jobs:
       run: dotnet tool install --global dotnet-sonarscanner
     - name: Install EF for tests
       run: dotnet tool install --global dotnet-ef --version 6.0.5
-    - name: Install dotnet-coverage
-      run: dotnet tool install --global dotnet-coverage
+    - name: Install dotnet reportgenerator
+      run: dotnet tool install --global dotnet-reportgenerator-globaltool
     - name: Restore tools for tests
       run: dotnet tool restore
     - name: Restore dependencies
@@ -50,7 +50,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_trams-data-api" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+        dotnet-sonarscanner begin /k:"DFE-Digital_trams-data-api" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
         dotnet build --no-restore
-        dotnet test --no-build --verbosity normal
+        dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./CoverageReport -reporttypes:SonarQube
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"      


### PR DESCRIPTION
~Uses dotCover to collect test coverage results to pipe to SonarCloud.
If unit tests are failing, the build will now fail with this command - see example [here](https://github.com/DFE-Digital/academies-academisation-api/actions/runs/3384728750)~
Uses default dotnet test functionality to collect test results and outputs it to generic test coverage data for SonarCloud using [ReportGenerator](https://reportgenerator.io/)