### PR TITLE
111799/project filters performance

### DIFF
--- a/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
+++ b/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
@@ -1,10 +1,6 @@
 ﻿using FizzWare.NBuilder;
 using Moq;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Gateways;
@@ -40,6 +36,7 @@ namespace TramsDataApi.Test.UseCases
             var expectedIncomingTrust = Builder<Trust>.CreateNew().Build();
 
             var academyTransferProjectsGateway = new Mock<IAcademyTransferProjectGateway>();
+            var trustGateway = new Mock<ITrustGateway>();
 
             academyTransferProjectsGateway.Setup(atGateway => atGateway.GetAcademyTransferProjects())
                 .Returns(() => expectedAcademyTransferProjects);
@@ -76,7 +73,8 @@ namespace TramsDataApi.Test.UseCases
                 .Returns(() => expectedIndexResponse[j]);
             }
 
-            SearchAcademyTransferProjects useCase = new SearchAcademyTransferProjects(academyTransferProjectsGateway.Object, indexAcademyTransferProjects.Object);
+            SearchAcademyTransferProjects useCase =
+               new SearchAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
             var searchResult = useCase.Execute(1, 50, default, searchCriteria).Result; 
             
             searchResult.Results.Should().NotBeEmpty();

--- a/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
+++ b/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
@@ -14,23 +14,25 @@ namespace TramsDataApi.Test.UseCases
 {
    public class SearchAcademyTransferProjectsTests
    {
+      private const int Outgoing = 0, Incoming = 1;
+
       [Fact]
       public void
          Search_ReturnsAListOfAcademyTransferProjectSummaryResponses_WhenThereAreAcademyTransferProjects_ByTitle()
       {
          IList<Trust> trusts = Builder<Trust>.CreateListOfSize(2).Build();
          IList<Group> groups = Builder<Group>.CreateListOfSize(2).Build();
-         trusts[0].TrustRef = groups[0].GroupId;
-         trusts[1].TrustRef = groups[1].GroupId;
+         trusts[Outgoing].TrustRef = groups[Outgoing].GroupId;
+         trusts[Incoming].TrustRef = groups[Incoming].GroupId;
 
          var academyTransferProjectsGateway = new Mock<IAcademyTransferProjectGateway>();
          var trustGateway = new Mock<ITrustGateway>();
 
          IList<AcademyTransferProjects> expectedAcademyTransferProjects = Builder<AcademyTransferProjects>
-            .CreateListOfSize(3).All()
-            .With(p => p.OutgoingTrustUkprn = groups[0].Ukprn)
+            .CreateListOfSize(5).All()
+            .With(p => p.OutgoingTrustUkprn = groups[Outgoing].Ukprn)
             .With(p => p.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(3).All()
-               .With(a => a.IncomingTrustUkprn = groups[0].Ukprn)
+               .With(a => a.IncomingTrustUkprn = groups[Outgoing].Ukprn)
                .With(a => a.PupilNumbersAdditionalInformation = "pupil numbers")
                .With(a => a.LatestOfstedReportAdditionalInformation = "ofsted")
                .With(a => a.KeyStage2PerformanceAdditionalInformation = "ks2")
@@ -40,7 +42,7 @@ namespace TramsDataApi.Test.UseCases
             .Build();
 
          expectedAcademyTransferProjects[1].TransferringAcademies.Skip(1).Take(1).First().IncomingTrustUkprn =
-            groups[1].Ukprn;
+            groups[Incoming].Ukprn;
 
          academyTransferProjectsGateway.Setup(atGateway => atGateway.GetAcademyTransferProjects())
             .Returns(() => expectedAcademyTransferProjects);
@@ -57,8 +59,8 @@ namespace TramsDataApi.Test.UseCases
                ProjectUrn = expectedAcademyTransferProjects[1].Urn.ToString(),
                ProjectReference = expectedAcademyTransferProjects[1].ProjectReference,
                OutgoingTrustUkprn = expectedAcademyTransferProjects[1].OutgoingTrustUkprn,
-               OutgoingTrustName = groups[0].GroupName,
-               OutgoingTrustLeadRscRegion = trusts[0].LeadRscRegion,
+               OutgoingTrustName = groups[Outgoing].GroupName,
+               OutgoingTrustLeadRscRegion = trusts[Outgoing].LeadRscRegion,
                TransferringAcademies = expectedAcademyTransferProjects[1].TransferringAcademies.Select(ta =>
                {
                   Group group = groups.First(g => g.Ukprn == ta.IncomingTrustUkprn);
@@ -78,7 +80,7 @@ namespace TramsDataApi.Test.UseCases
             }
          };
 
-         var searchCriteria = groups[1].GroupName;
+         var searchCriteria = groups[Incoming].GroupName;
 
          var useCase = new SearchAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
 

--- a/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
+++ b/TramsDataApi.Test/UseCases/SearchAcademyTransferProjectsTests.cs
@@ -1,86 +1,94 @@
-﻿using FizzWare.NBuilder;
-using Moq;
+﻿using System.Collections.Generic;
 using System.Linq;
+using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Gateways;
-using TramsDataApi.ResponseModels.AcademyTransferProject;
 using TramsDataApi.ResponseModels;
+using TramsDataApi.ResponseModels.AcademyTransferProject;
 using TramsDataApi.UseCases;
 using Xunit;
 
 namespace TramsDataApi.Test.UseCases
 {
-    public class SearchAcademyTransferProjectsTests
-    {
-        [Fact]
-        public void Search_ReturnsAListOfAcademyTransferProjectSummaryResponses_WhenThereAreAcademyTransferProjects_ByTitle()
-        {
-            string outgoingTrust = nameof(outgoingTrust);
-            string incomingTrust = nameof(incomingTrust);
-            var expectedAcademyTransferProjects = Builder<AcademyTransferProjects>.CreateListOfSize(5).All()
-                .With(p => p.OutgoingTrustUkprn = outgoingTrust)
-                .With(p => p.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(5).All()
-                    .With(a => a.IncomingTrustUkprn = incomingTrust)
-                    .With(a => a.PupilNumbersAdditionalInformation = "pupil numbers")
-                    .With(a => a.LatestOfstedReportAdditionalInformation = "ofsted")
-                    .With(a => a.KeyStage2PerformanceAdditionalInformation = "ks2")
-                    .With(a => a.KeyStage4PerformanceAdditionalInformation = "ks4")
-                    .With(a => a.KeyStage5PerformanceAdditionalInformation = "ks5")
-                    .Build())
-                .Build();
+   public class SearchAcademyTransferProjectsTests
+   {
+      [Fact]
+      public void
+         Search_ReturnsAListOfAcademyTransferProjectSummaryResponses_WhenThereAreAcademyTransferProjects_ByTitle()
+      {
+         IList<Trust> trusts = Builder<Trust>.CreateListOfSize(2).Build();
+         IList<Group> groups = Builder<Group>.CreateListOfSize(2).Build();
+         trusts[0].TrustRef = groups[0].GroupId;
+         trusts[1].TrustRef = groups[1].GroupId;
 
-            var expectedOutgoingGroup = Builder<Group>.CreateNew().Build();
-            var expectedOutgoingTrust = Builder<Trust>.CreateNew().Build();
-            var expectedIncomingGroup = Builder<Group>.CreateNew().Build();
-            var expectedIncomingTrust = Builder<Trust>.CreateNew().Build();
+         var academyTransferProjectsGateway = new Mock<IAcademyTransferProjectGateway>();
+         var trustGateway = new Mock<ITrustGateway>();
 
-            var academyTransferProjectsGateway = new Mock<IAcademyTransferProjectGateway>();
-            var trustGateway = new Mock<ITrustGateway>();
+         IList<AcademyTransferProjects> expectedAcademyTransferProjects = Builder<AcademyTransferProjects>
+            .CreateListOfSize(3).All()
+            .With(p => p.OutgoingTrustUkprn = groups[0].Ukprn)
+            .With(p => p.TransferringAcademies = Builder<TransferringAcademies>.CreateListOfSize(3).All()
+               .With(a => a.IncomingTrustUkprn = groups[0].Ukprn)
+               .With(a => a.PupilNumbersAdditionalInformation = "pupil numbers")
+               .With(a => a.LatestOfstedReportAdditionalInformation = "ofsted")
+               .With(a => a.KeyStage2PerformanceAdditionalInformation = "ks2")
+               .With(a => a.KeyStage4PerformanceAdditionalInformation = "ks4")
+               .With(a => a.KeyStage5PerformanceAdditionalInformation = "ks5")
+               .Build())
+            .Build();
 
-            academyTransferProjectsGateway.Setup(atGateway => atGateway.GetAcademyTransferProjects())
-                .Returns(() => expectedAcademyTransferProjects);
+         expectedAcademyTransferProjects[1].TransferringAcademies.Skip(1).Take(1).First().IncomingTrustUkprn =
+            groups[1].Ukprn;
 
-            var expectedIndexResponse = expectedAcademyTransferProjects
-                .Select(atp => new AcademyTransferProjectSummaryResponse
-                {
-                    ProjectUrn = atp.Urn.ToString(),
-                    ProjectReference = atp.ProjectReference,
-                    OutgoingTrustUkprn = atp.OutgoingTrustUkprn,
-                    OutgoingTrustName = expectedOutgoingGroup.GroupName,
-                    OutgoingTrustLeadRscRegion = expectedOutgoingTrust.LeadRscRegion,
-                    TransferringAcademies = atp.TransferringAcademies.Select(ta => new TransferringAcademiesResponse
-                    {
-                        OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
-                        IncomingTrustUkprn = ta.IncomingTrustUkprn,
-                        IncomingTrustName = expectedIncomingGroup.GroupName,
-                        IncomingTrustLeadRscRegion = expectedIncomingTrust.LeadRscRegion,
-                        PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
-                        LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
-                        KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
-                        KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
-                        KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
-                    }).ToList()
-                }).ToList();
+         academyTransferProjectsGateway.Setup(atGateway => atGateway.GetAcademyTransferProjects())
+            .Returns(() => expectedAcademyTransferProjects);
 
-            var indexAcademyTransferProjects = new Mock<IIndexAcademyTransferProjects>();
-            string searchCriteria = "Find me!";
-            expectedIndexResponse[0].TransferringAcademies[0].IncomingTrustName = searchCriteria;
-            for (int i = 0; i < expectedAcademyTransferProjects.Count; i++)
+         trustGateway.Setup(x => x.GetMultipleTrustsByGroupId(It.IsAny<IEnumerable<string>>()))
+            .Returns(trusts);
+         trustGateway.Setup(x => x.GetMultipleGroupsByUkprn(It.IsAny<IEnumerable<string>>()))
+            .Returns(groups);
+
+         var expectedIndexResponse = new List<AcademyTransferProjectSummaryResponse>
+         {
+            new AcademyTransferProjectSummaryResponse
             {
-                int j = i;
-                indexAcademyTransferProjects.Setup(index => index.AcademyTransferProjectSummaryResponse(expectedAcademyTransferProjects[j]))
-                .Returns(() => expectedIndexResponse[j]);
+               ProjectUrn = expectedAcademyTransferProjects[1].Urn.ToString(),
+               ProjectReference = expectedAcademyTransferProjects[1].ProjectReference,
+               OutgoingTrustUkprn = expectedAcademyTransferProjects[1].OutgoingTrustUkprn,
+               OutgoingTrustName = groups[0].GroupName,
+               OutgoingTrustLeadRscRegion = trusts[0].LeadRscRegion,
+               TransferringAcademies = expectedAcademyTransferProjects[1].TransferringAcademies.Select(ta =>
+               {
+                  Group group = groups.First(g => g.Ukprn == ta.IncomingTrustUkprn);
+                  return new TransferringAcademiesResponse
+                  {
+                     OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
+                     IncomingTrustUkprn = ta.IncomingTrustUkprn,
+                     IncomingTrustName = group.GroupName,
+                     IncomingTrustLeadRscRegion = trusts.First(x => x.TrustRef == group.GroupId).LeadRscRegion,
+                     PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                     LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                     KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                     KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                     KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
+                  };
+               }).ToList()
             }
+         };
 
-            SearchAcademyTransferProjects useCase =
-               new SearchAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
-            var searchResult = useCase.Execute(1, 50, default, searchCriteria).Result; 
-            
-            searchResult.Results.Should().NotBeEmpty();
-            searchResult.Results.Count().Should().Be(1);
-            searchResult.TotalCount.Should().Be(5);
-            searchResult.Results.First().Should().BeEquivalentTo(expectedIndexResponse[0]);
-        }
-    }
+         var searchCriteria = groups[1].GroupName;
+
+         var useCase = new SearchAcademyTransferProjects(academyTransferProjectsGateway.Object, trustGateway.Object);
+
+         PagedResult<AcademyTransferProjectSummaryResponse> searchResult =
+            useCase.Execute(1, 50, default, searchCriteria).Result;
+
+         searchResult.Results.Should().NotBeEmpty();
+         searchResult.Results.Count().Should().Be(1);
+         searchResult.TotalCount.Should().Be(1);
+         searchResult.Results.Should().BeEquivalentTo(expectedIndexResponse);
+      }
+   }
 }

--- a/TramsDataApi/Gateways/AcademyTransferProjectGateway.cs
+++ b/TramsDataApi/Gateways/AcademyTransferProjectGateway.cs
@@ -66,10 +66,9 @@ namespace TramsDataApi.Gateways
 
         public IEnumerable<AcademyTransferProjects> GetAcademyTransferProjects()
         {
-            return _tramsDbContext.AcademyTransferProjects
-                .Include(atp => atp.AcademyTransferProjectIntendedTransferBenefits)
-                .Include(atp => atp.TransferringAcademies)
-                .AsEnumerable(); //.ToList();
+           return _tramsDbContext.AcademyTransferProjects
+              .Include(atp => atp.AcademyTransferProjectIntendedTransferBenefits)
+              .Include(atp => atp.TransferringAcademies);
         }
     }
 }

--- a/TramsDataApi/Gateways/ITrustGateway.cs
+++ b/TramsDataApi/Gateways/ITrustGateway.cs
@@ -11,5 +11,7 @@ namespace TramsDataApi.Gateways
         Trust GetIfdTrustByRID(string RID);
         IQueryable<Trust> GetIfdTrustsByTrustRef(string[] trustRefs);
         (IList<Group>, int) SearchGroups(int page, int count, string groupName, string ukPrn, string companiesHouseNumber);
+        IEnumerable<Group> GetMultipleGroupsByUkprn(IEnumerable<string> ukprns);
+        IEnumerable<Trust> GetMultipleTrustsByGroupId(IEnumerable<string> groupIds);
     }
 }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -1,69 +1,81 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Extensions;
 
 namespace TramsDataApi.Gateways
 {
-    public class TrustGateway : ITrustGateway
-    {
-        private readonly LegacyTramsDbContext _dbContext;
+   public class TrustGateway : ITrustGateway
+   {
+      private readonly LegacyTramsDbContext _dbContext;
 
-        public TrustGateway(LegacyTramsDbContext dbContext)
-        {
-            _dbContext = dbContext;
-        }
+      public TrustGateway(LegacyTramsDbContext dbContext)
+      {
+         _dbContext = dbContext;
+      }
 
-        public Group GetGroupByUkPrn(string ukPrn)
-        {
-            return _dbContext.Group.FirstOrDefault(g => g.Ukprn == ukPrn);
-        }
+      public Group GetGroupByUkPrn(string ukPrn)
+      {
+         return _dbContext.Group.FirstOrDefault(g => g.Ukprn == ukPrn);
+      }
 
-        public Trust GetIfdTrustByGroupId(string groupId)
-        {
-            return _dbContext.Trust.FirstOrDefault(t => t.TrustRef == groupId);
-        }
+      public Trust GetIfdTrustByGroupId(string groupId)
+      {
+         return _dbContext.Trust.FirstOrDefault(t => t.TrustRef == groupId);
+      }
 
-        public Trust GetIfdTrustByRID(string RID)
-        {
-            return _dbContext.Trust.FirstOrDefault(x => x.Rid.Equals(RID));
-        }
+      public Trust GetIfdTrustByRID(string RID)
+      {
+         return _dbContext.Trust.FirstOrDefault(x => x.Rid.Equals(RID));
+      }
 
-        public IQueryable<Trust> GetIfdTrustsByTrustRef(string[] trustRefs)
-        {
-            var predicate = PredicateBuilder.False<Trust>();
-            foreach (var trustRef in trustRefs)
-            {
-                predicate = predicate.Or(t => t.TrustRef == trustRef);
-            }
+      public IQueryable<Trust> GetIfdTrustsByTrustRef(string[] trustRefs)
+      {
+         Expression<Func<Trust, bool>> predicate = PredicateBuilder.False<Trust>();
+         foreach (var trustRef in trustRefs) predicate = predicate.Or(t => t.TrustRef == trustRef);
 
-            return _dbContext.Trust.Where(predicate);
-        }
+         return _dbContext.Trust.Where(predicate);
+      }
 
-        public (IList<Group>, int) SearchGroups(int page, int count, string groupName, string ukPrn, string companiesHouseNumber)
-        {
-            if (groupName == null && ukPrn == null && companiesHouseNumber == null)
-            {
-                var allGroups = _dbContext.Group.OrderBy(group => group.GroupUid).Skip((page - 1) * count).Take(count).ToList();
-                return (allGroups, allGroups.Count);
-            }
+      public (IList<Group>, int) SearchGroups(int page, int count, string groupName, string ukPrn,
+         string companiesHouseNumber)
+      {
+         if (groupName == null && ukPrn == null && companiesHouseNumber == null)
+         {
+            List<Group> allGroups = _dbContext.Group.OrderBy(group => group.GroupUid).Skip((page - 1) * count)
+               .Take(count).ToList();
+            return (allGroups, allGroups.Count);
+         }
 
-            var filteredGroups = _dbContext.Group
-                .Where(g => (
-                    (g.GroupName.Contains(groupName) ||
-                     g.Ukprn.Contains(ukPrn) ||
-                     g.CompaniesHouseNumber.Contains(companiesHouseNumber))
-                    && (
-                        g.GroupType == "Single-academy trust" ||
-                        g.GroupType == "Multi-academy trust"
-                    )
-                ))
-                .OrderBy(group => group.GroupUid);
+         IOrderedQueryable<Group> filteredGroups = _dbContext.Group
+            .Where(g => (g.GroupName.Contains(groupName) ||
+                         g.Ukprn.Contains(ukPrn) ||
+                         g.CompaniesHouseNumber.Contains(companiesHouseNumber))
+                        && (
+                           g.GroupType == "Single-academy trust" ||
+                           g.GroupType == "Multi-academy trust"
+                        ))
+            .OrderBy(group => group.GroupUid);
 
-            return (
-                filteredGroups.Skip((page - 1) * count).Take(count).ToList(), 
-                filteredGroups.Count()
-                );
-        }
-    }
+         return (
+            filteredGroups.Skip((page - 1) * count).Take(count).ToList(),
+            filteredGroups.Count()
+         );
+      }
+
+      public IEnumerable<Group> GetMultipleGroupsByUkprn(IEnumerable<string> ukprns)
+      {
+         IEnumerable<string> distinctUkprns = ukprns.Distinct();
+         return _dbContext.Group.AsNoTracking().Where(x => distinctUkprns.Contains(x.Ukprn));
+      }
+
+      public IEnumerable<Trust> GetMultipleTrustsByGroupId(IEnumerable<string> groupIds)
+      {
+         IEnumerable<string> distinctGroupIds = groupIds.Distinct();
+         return _dbContext.Trust.AsNoTracking().Where(x => distinctGroupIds.Contains(x.TrustRef));
+      }
+   }
 }

--- a/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
+++ b/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
@@ -47,7 +47,7 @@ namespace TramsDataApi.UseCases
                {
                   OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
                   IncomingTrustUkprn = ta.IncomingTrustUkprn,
-                  IncomingTrustName = group.GroupName.ToLower(),
+                  IncomingTrustName = group.GroupName,
                   IncomingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(group.GroupId).LeadRscRegion,
                   PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
                   LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,

--- a/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
+++ b/TramsDataApi/UseCases/IndexAcademyTransferProjects.cs
@@ -8,56 +8,55 @@ using TramsDataApi.ResponseModels.AcademyTransferProject;
 
 namespace TramsDataApi.UseCases
 {
-    public class IndexAcademyTransferProjects : IIndexAcademyTransferProjects
-    {
-        private readonly IAcademyTransferProjectGateway _academyTransferProjectGateway;
-        private readonly ITrustGateway _trustGateway;
+   public class IndexAcademyTransferProjects : IIndexAcademyTransferProjects
+   {
+      private readonly IAcademyTransferProjectGateway _academyTransferProjectGateway;
+      private readonly ITrustGateway _trustGateway;
 
-        public IndexAcademyTransferProjects(IAcademyTransferProjectGateway academyTransferProjectGateway,
-            ITrustGateway trustGateway)
-        {
-            _academyTransferProjectGateway = academyTransferProjectGateway;
-            _trustGateway = trustGateway;
-        }
+      public IndexAcademyTransferProjects(IAcademyTransferProjectGateway academyTransferProjectGateway,
+         ITrustGateway trustGateway)
+      {
+         _academyTransferProjectGateway = academyTransferProjectGateway;
+         _trustGateway = trustGateway;
+      }
 
-        public Tuple<IList<AcademyTransferProjectSummaryResponse>, int> Execute(int page)
-        {
-           Tuple<IList<AcademyTransferProjects>, int> listOfAcademyTransferProjects =
-              _academyTransferProjectGateway.IndexAcademyTransferProjects(page);
+      public Tuple<IList<AcademyTransferProjectSummaryResponse>, int> Execute(int page)
+      {
+         Tuple<IList<AcademyTransferProjects>, int> listOfAcademyTransferProjects =
+            _academyTransferProjectGateway.IndexAcademyTransferProjects(page);
 
-           return Tuple.Create<IList<AcademyTransferProjectSummaryResponse>, int>(
-              listOfAcademyTransferProjects.Item1.Select(AcademyTransferProjectSummaryResponse).ToList(),
-              listOfAcademyTransferProjects.Item2);
-        }
+         return Tuple.Create<IList<AcademyTransferProjectSummaryResponse>, int>(
+            listOfAcademyTransferProjects.Item1.Select(AcademyTransferProjectSummaryResponse).ToList(),
+            listOfAcademyTransferProjects.Item2);
+      }
 
-        public AcademyTransferProjectSummaryResponse AcademyTransferProjectSummaryResponse(AcademyTransferProjects atp)
-        {
-            var outgoingGroup = _trustGateway.GetGroupByUkPrn(atp.OutgoingTrustUkprn);
-            return new AcademyTransferProjectSummaryResponse()
+      public AcademyTransferProjectSummaryResponse AcademyTransferProjectSummaryResponse(AcademyTransferProjects atp)
+      {
+         Group outgoingGroup = _trustGateway.GetGroupByUkPrn(atp.OutgoingTrustUkprn);
+         return new AcademyTransferProjectSummaryResponse
+         {
+            ProjectUrn = atp.Urn.ToString(),
+            ProjectReference = atp.ProjectReference,
+            OutgoingTrustUkprn = atp.OutgoingTrustUkprn,
+            OutgoingTrustName = outgoingGroup.GroupName,
+            OutgoingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(outgoingGroup.GroupId).LeadRscRegion,
+            TransferringAcademies = atp.TransferringAcademies.Select(ta =>
             {
-                ProjectUrn = atp.Urn.ToString(),
-                ProjectReference = atp.ProjectReference,
-                OutgoingTrustUkprn = atp.OutgoingTrustUkprn,
-                OutgoingTrustName = outgoingGroup.GroupName,
-                OutgoingTrustLeadRscRegion =
-                    _trustGateway.GetIfdTrustByGroupId(outgoingGroup.GroupId).LeadRscRegion,
-                TransferringAcademies = atp.TransferringAcademies.Select(ta =>
-                {
-                    var group = _trustGateway.GetGroupByUkPrn(ta.IncomingTrustUkprn);
-                    return new TransferringAcademiesResponse
-                    {
-                        OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
-                        IncomingTrustUkprn = ta.IncomingTrustUkprn,
-                        IncomingTrustName = group.GroupName,
-                        IncomingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(group.GroupId).LeadRscRegion,
-                        PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
-                        LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
-                        KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
-                        KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
-                        KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
-                    };
-                }).ToList()
-            };
-        }
-    }
+               Group group = _trustGateway.GetGroupByUkPrn(ta.IncomingTrustUkprn);
+               return new TransferringAcademiesResponse
+               {
+                  OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
+                  IncomingTrustUkprn = ta.IncomingTrustUkprn,
+                  IncomingTrustName = group.GroupName.ToLower(),
+                  IncomingTrustLeadRscRegion = _trustGateway.GetIfdTrustByGroupId(group.GroupId).LeadRscRegion,
+                  PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                  LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                  KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                  KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                  KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
+               };
+            }).ToList()
+         };
+      }
+   }
 }

--- a/TramsDataApi/UseCases/SearchAcademyTransferProjects.cs
+++ b/TramsDataApi/UseCases/SearchAcademyTransferProjects.cs
@@ -32,7 +32,7 @@ namespace TramsDataApi.UseCases
 
          var recordTotal = projects.Count();
          projects = projects.OrderByDescending(atp => atp.ProjectUrn)
-            .Skip((page - 1) * 10).Take(10).ToList();
+            .Skip((page - 1) * count).Take(count).ToList();
 
          return Task.FromResult(new PagedResult<AcademyTransferProjectSummaryResponse>(projects, recordTotal));
       }

--- a/TramsDataApi/UseCases/SearchAcademyTransferProjects.cs
+++ b/TramsDataApi/UseCases/SearchAcademyTransferProjects.cs
@@ -3,48 +3,103 @@ using System.Linq;
 using System.Threading.Tasks;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Gateways;
+using TramsDataApi.ResponseModels;
 using TramsDataApi.ResponseModels.AcademyTransferProject;
 
 namespace TramsDataApi.UseCases
 {
-    public class SearchAcademyTransferProjects : ISearchAcademyTransferProjects
-    {
-        private readonly IAcademyTransferProjectGateway _academyTransferProjectGateway;
-        private readonly IIndexAcademyTransferProjects _indexAcademyTransfer;
+   public class SearchAcademyTransferProjects : ISearchAcademyTransferProjects
+   {
+      private readonly IAcademyTransferProjectGateway _academyTransferProjectGateway;
+      private readonly ITrustGateway _trustGateway;
 
-        public SearchAcademyTransferProjects(
-            IAcademyTransferProjectGateway academyTransferProjectGateway, IIndexAcademyTransferProjects indexAcademyTransfer)
-        {
-            _academyTransferProjectGateway = academyTransferProjectGateway;
-            _indexAcademyTransfer = indexAcademyTransfer;
-        }
+      public SearchAcademyTransferProjects(
+         IAcademyTransferProjectGateway academyTransferProjectGateway,
+         ITrustGateway trustGateway)
+      {
+         _academyTransferProjectGateway = academyTransferProjectGateway;
+         _trustGateway = trustGateway;
+      }
 
-        public Task<PagedResult<AcademyTransferProjectSummaryResponse>> Execute(int page, int count, int? urn, string title)
-        {
-            IEnumerable<AcademyTransferProjects> academyTransferProjects = _academyTransferProjectGateway.GetAcademyTransferProjects();
-            
-            IEnumerable<AcademyTransferProjectSummaryResponse> projects = academyTransferProjects.Select(project => _indexAcademyTransfer.AcademyTransferProjectSummaryResponse(project)); //.ToList();
+      public Task<PagedResult<AcademyTransferProjectSummaryResponse>> Execute(int page, int count, int? urn,
+         string title)
+      {
+         IEnumerable<AcademyTransferProjects> academyTransferProjects = FilterByUrn(
+            _academyTransferProjectGateway.GetAcademyTransferProjects(), urn).ToList();
 
-            projects = FilterByUrn(urn, projects);
-            projects = FilterByIncomingTrust(title, projects);
-            int recordTotal = academyTransferProjects.Count();
-            projects = projects.OrderByDescending(atp => atp.ProjectUrn)
-                .Skip((page - 1) * 10).Take(10).ToList();
-            return Task.FromResult(new PagedResult<AcademyTransferProjectSummaryResponse>(projects, recordTotal));
-        }
-        private static IEnumerable<AcademyTransferProjectSummaryResponse> FilterByUrn(int? urn, IEnumerable<AcademyTransferProjectSummaryResponse> queryable)
-        {
-            if (urn.HasValue) queryable = queryable.Where(p => p.ProjectUrn == urn.ToString()); //.ToList();
+         IEnumerable<AcademyTransferProjectSummaryResponse> projects =
+            FilterByIncomingTrust(title, AcademyTransferProjectSummaryResponse(academyTransferProjects));
 
-            return queryable;
-        }
-        private static IEnumerable<AcademyTransferProjectSummaryResponse> FilterByIncomingTrust(string title, IEnumerable<AcademyTransferProjectSummaryResponse> queryable)
-        {
-            if (!string.IsNullOrWhiteSpace(title))
+         var recordTotal = projects.Count();
+         projects = projects.OrderByDescending(atp => atp.ProjectUrn)
+            .Skip((page - 1) * 10).Take(10).ToList();
+
+         return Task.FromResult(new PagedResult<AcademyTransferProjectSummaryResponse>(projects, recordTotal));
+      }
+
+      private static IEnumerable<AcademyTransferProjects> FilterByUrn(IEnumerable<AcademyTransferProjects> queryable,
+         int? urn)
+      {
+         if (urn.HasValue) queryable = queryable.Where(p => p.Urn == urn);
+
+         return queryable;
+      }
+
+      private static IEnumerable<AcademyTransferProjectSummaryResponse> FilterByIncomingTrust(string title,
+         IEnumerable<AcademyTransferProjectSummaryResponse> queryable)
+      {
+         if (!string.IsNullOrWhiteSpace(title))
+            queryable = queryable
+               .Where(p => p.TransferringAcademies.Any(r => r.IncomingTrustName!.ToLower().Contains(title!.ToLower())))
+               .ToList();
+         return queryable;
+      }
+
+      public IEnumerable<AcademyTransferProjectSummaryResponse> AcademyTransferProjectSummaryResponse(
+         IEnumerable<AcademyTransferProjects> atp)
+      {
+         IEnumerable<Group> outgoingGroups =
+            _trustGateway.GetMultipleGroupsByUkprn(atp.Select(x => x.OutgoingTrustUkprn)).ToList();
+
+         IEnumerable<Trust> outgoingTrusts =
+            _trustGateway.GetMultipleTrustsByGroupId(outgoingGroups.Select(x => x.GroupId)).ToList();
+
+         IEnumerable<Group> incomingGroups =
+            _trustGateway.GetMultipleGroupsByUkprn(atp.SelectMany(p =>
+               p.TransferringAcademies.Select(a => a.IncomingTrustUkprn))).ToList();
+
+         IEnumerable<Trust> incomingTrusts =
+            _trustGateway.GetMultipleTrustsByGroupId(incomingGroups.Select(g => g.GroupId)).ToList();
+
+         return atp.Select(x =>
+         {
+            Group outgoingGroup = outgoingGroups.First(g => g.Ukprn == x.OutgoingTrustUkprn);
+            return new AcademyTransferProjectSummaryResponse
             {
-                queryable = queryable.Where(p => p.TransferringAcademies.Any(r => r.IncomingTrustName!.ToLower().Contains(title!.ToLower()))); //.ToList();
-            }
-            return queryable;
-        }
-}
+               ProjectUrn = x.Urn.ToString(),
+               ProjectReference = x.ProjectReference,
+               OutgoingTrustUkprn = x.OutgoingTrustUkprn,
+               OutgoingTrustName = outgoingGroup.GroupName,
+               OutgoingTrustLeadRscRegion =
+                  outgoingTrusts.First(t => t.TrustRef == outgoingGroup.GroupId).LeadRscRegion,
+               TransferringAcademies = x.TransferringAcademies.Select(ta =>
+               {
+                  Group group = incomingGroups.First(g => g.Ukprn == ta.IncomingTrustUkprn);
+                  return new TransferringAcademiesResponse
+                  {
+                     OutgoingAcademyUkprn = ta.OutgoingAcademyUkprn,
+                     IncomingTrustUkprn = ta.IncomingTrustUkprn,
+                     IncomingTrustName = group.GroupName,
+                     IncomingTrustLeadRscRegion = incomingTrusts.First(t => t.TrustRef == group.GroupId).LeadRscRegion,
+                     PupilNumbersAdditionalInformation = ta.PupilNumbersAdditionalInformation,
+                     LatestOfstedReportAdditionalInformation = ta.LatestOfstedReportAdditionalInformation,
+                     KeyStage2PerformanceAdditionalInformation = ta.KeyStage2PerformanceAdditionalInformation,
+                     KeyStage4PerformanceAdditionalInformation = ta.KeyStage4PerformanceAdditionalInformation,
+                     KeyStage5PerformanceAdditionalInformation = ta.KeyStage5PerformanceAdditionalInformation
+                  };
+               }).ToList()
+            };
+         });
+      }
+   }
 }


### PR DESCRIPTION
This 'fixes' the performance problem by batching the requests for groups and trusts when loading projects. Though this will still experience performance degradation linearly in line with the number of projects in the database, it is at least down from several minutes to sub 1 second with the current test data set of approximately 1100 projects.