### PR TITLE
Get bulk establishments

### DIFF
--- a/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
@@ -63,6 +63,23 @@ namespace TramsDataApi.Test.Integration
         }
 
         [Fact]
+        public async Task CanGetEstablishmentsByBulkUrns()
+        {
+            const int urn1 = 12345;
+            const int urn2 = 23456;
+            var response1 = AddTestData(urn1);
+            var response2 = AddTestData(urn2);
+            var establishmentResponses = new List<EstablishmentResponse> { response1, response2 };
+
+            var response = await _client.GetAsync($"/establishments/bulk?Urn={urn1}&Urn={urn2}");
+            var jsonString = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<IList<EstablishmentResponse>>(jsonString);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+
+        [Fact]
         public async Task CanGetEstablishmentURNsByRegion()
         {
             var urn = _randomGenerator.Next(100000, 199999);

--- a/TramsDataApi.Test/UseCases/GetEstablishmentsByUrnsTests.cs
+++ b/TramsDataApi.Test/UseCases/GetEstablishmentsByUrnsTests.cs
@@ -1,0 +1,167 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.DatabaseModels;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.UseCases;
+using Xunit;
+
+namespace TramsDataApi.Test.UseCases
+{
+    public class GetEstablishmentsByUrnsTests
+    {
+        private readonly Mock<IEstablishmentGateway> _mockEstablishmentGateway;
+
+        public GetEstablishmentsByUrnsTests()
+        {
+            _mockEstablishmentGateway = new Mock<IEstablishmentGateway>();
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenNoEstablishmentsFound_ReturnsNull()
+        {
+            var requestUrns = new int[] { 12345 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+            _mockEstablishmentGateway .Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => new List<Establishment>());
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenEstablishmentsAreFound_ReturnsListOfEstablishmentResponses()
+        {
+            var requestUrns = new int[] { 12345, 23456 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+
+            var establishments = Builder<Establishment>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var establishmentResponses = establishments.Select((e) => EstablishmentResponseFactory
+                .Create(e, null, null, null, null, null)).ToList();
+
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => establishments);
+
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenMisEstablishmentsAreFound_ReturnsListOfEstablishmentResponses()
+        {
+            var requestUrns = new int[] { 12345, 23456 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+
+            var establishments = Builder<Establishment>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var misEstablishments = Builder<MisEstablishments>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var establishmentResponses = establishments.Select((e, i) => EstablishmentResponseFactory
+                .Create(e, misEstablishments[i], null, null, null, null)).ToList();
+
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => establishments);
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetMisEstablishmentsByUrns(requestUrns)).Returns(() => misEstablishments);
+
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenSmartDataIsFound_ReturnsListOfEstablishmentResponses()
+        {
+            var requestUrns = new int[] { 12345, 23456 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+
+            var establishments = Builder<Establishment>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var smartData = Builder<SmartData>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i].ToString())
+                .Build();
+            var establishmentResponses = establishments.Select((e, i) => EstablishmentResponseFactory
+                .Create(e, null, smartData[i], null, null, null)).ToList();
+
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => establishments);
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetSmartDataByUrns(requestUrns)).Returns(() => smartData);
+
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenFurtherEducationEstablishmentsAreFound_ReturnsListOfEstablishmentResponses()
+        {
+            var requestUrns = new int[] { 12345, 23456 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+
+            var establishments = Builder<Establishment>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var furtherEducationEstablishments = Builder<FurtherEducationEstablishments>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.ProviderUrn = requestUrns[i])
+                .Build();
+            var establishmentResponses = establishments.Select((e, i) => EstablishmentResponseFactory
+                .Create(e, null, null, furtherEducationEstablishments[i], null, null)).ToList();
+
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => establishments);
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetFurtherEducationEstablishmentsByUrns(requestUrns)).Returns(() => furtherEducationEstablishments);
+
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+
+        [Fact]
+        public void GetEstablishmentsByUrns_WhenViewAcademyConversionsAreFound_ReturnsListOfEstablishmentResponses()
+        {
+            var requestUrns = new int[] { 12345, 23456 };
+            var request = new GetEstablishmentsByUrnsRequest { Urns = requestUrns };
+
+            var establishments = Builder<Establishment>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.Urn = requestUrns[i])
+                .Build();
+            var viewAcademyConversions = Builder<ViewAcademyConversions>.CreateListOfSize(requestUrns.Length)
+                .All()
+                .With((e, i) => e.GeneralDetailsAcademyUrn = requestUrns[i].ToString())
+                .Build();
+            var establishmentResponses = establishments.Select((e, i) => EstablishmentResponseFactory
+                .Create(e, null, null, null, viewAcademyConversions[i], null)).ToList();
+
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetByUrns(requestUrns)).Returns(() => establishments);
+            _mockEstablishmentGateway.Setup(gateway => gateway.GetViewAcademyConversionInfoByUrns(requestUrns)).Returns(() => viewAcademyConversions);
+
+            var useCase = new GetEstablishmentsByUrns(_mockEstablishmentGateway.Object);
+
+            var result = useCase.Execute(request);
+
+            result.Should().BeEquivalentTo(establishmentResponses);
+        }
+    }
+}

--- a/TramsDataApi/Gateways/EstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/EstablishmentGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
@@ -32,6 +33,11 @@ namespace TramsDataApi.Gateways
             return _dbContext.Establishment.SingleOrDefault(e => e.Urn == urn);
         }
 
+        public IList<Establishment> GetByUrns(int[] urns)
+        {
+            return _dbContext.Establishment.AsNoTracking().Where(e => urns.Contains(e.Urn)).ToList();
+        }
+
         public IList<Establishment> GetByTrustUid(string trustUid)
         {
             return _dbContext.Establishment.Where(e => e.TrustsCode == trustUid)
@@ -43,9 +49,19 @@ namespace TramsDataApi.Gateways
             return _dbContext.MisEstablishments.FirstOrDefault(m => m.Urn == establishmentUrn);
         }
 
+        public IList<MisEstablishments> GetMisEstablishmentsByUrns(int[] establishmentUrns)
+        {
+            return _dbContext.MisEstablishments.AsNoTracking().Where(e => establishmentUrns.Contains((int)e.Urn)).ToList();
+        }
+
         public FurtherEducationEstablishments GetFurtherEducationEstablishmentByUrn(int establishmentUrn)
         {
             return _dbContext.FurtherEducationEstablishments.FirstOrDefault(m => m.ProviderUrn == establishmentUrn);
+        }
+
+        public IList<FurtherEducationEstablishments> GetFurtherEducationEstablishmentsByUrns(int[] establishmentUrns)
+        {
+            return _dbContext.FurtherEducationEstablishments.AsNoTracking().Where(e => establishmentUrns.Contains(e.ProviderUrn)).ToList();
         }
 
         public SmartData GetSmartDataByUrn(int establishmentUrn)
@@ -53,11 +69,23 @@ namespace TramsDataApi.Gateways
             return _dbContext.SmartData.FirstOrDefault(s => s.Urn == establishmentUrn.ToString());
         }
 
-
-         public ViewAcademyConversions GetViewAcademyConversionInfoByUrn(int establishmentUrn) 
+        public IList<SmartData> GetSmartDataByUrns(int[] establishmentUrns)
         {
-            var viewAcademyConversionInfo = _dbContext.ViewAcademyConversions.FirstOrDefault(x => x.GeneralDetailsAcademyUrn == establishmentUrn.ToString());
-            return viewAcademyConversionInfo;
+            var stringUrns = Array.ConvertAll(establishmentUrns, urn => urn.ToString());
+
+            return _dbContext.SmartData.AsNoTracking().Where(e => stringUrns.Contains(e.Urn)).ToList();
+        }
+
+        public ViewAcademyConversions GetViewAcademyConversionInfoByUrn(int establishmentUrn) 
+        {
+            return _dbContext.ViewAcademyConversions.FirstOrDefault(x => x.GeneralDetailsAcademyUrn == establishmentUrn.ToString());
+        }
+
+        public IList<ViewAcademyConversions> GetViewAcademyConversionInfoByUrns(int[] establishmentUrns)
+        {
+            var stringUrns = Array.ConvertAll(establishmentUrns, urn => urn.ToString());
+
+            return _dbContext.ViewAcademyConversions.AsNoTracking().Where(e => stringUrns.Contains(e.GeneralDetailsAcademyUrn)).ToList();
         }
 
         public IList<Establishment> SearchEstablishments(int? urn, string ukprn, string name)

--- a/TramsDataApi/Gateways/IEstablishmentGateway.cs
+++ b/TramsDataApi/Gateways/IEstablishmentGateway.cs
@@ -1,21 +1,23 @@
-using System.Collections;
 using System.Collections.Generic;
-using TramsDataApi.Controllers;
 using TramsDataApi.DatabaseModels;
 
 namespace TramsDataApi.Gateways
 {
     public interface IEstablishmentGateway
     {
-        public Establishment GetByUkprn(string ukprn);
+        Establishment GetByUkprn(string ukprn);
+        Establishment GetByUrn(int urn);
+        IList<Establishment> GetByTrustUid(string trustUid);
+        MisEstablishments GetMisEstablishmentByUrn(int establishmentUrn);
+        SmartData GetSmartDataByUrn(int establishmentUrn);
         public IEnumerable<int> GetURNsByRegion(IEnumerable<string> regions);
-        public Establishment GetByUrn(int urn);
-        public IList<Establishment> GetByTrustUid(string trustUid);
-        public MisEstablishments GetMisEstablishmentByUrn(int establishmentUrn);
-        public SmartData GetSmartDataByUrn(int establishmentUrn);
-
-        public IList<Establishment> SearchEstablishments(int? urn, string ukprn, string name);
-        public FurtherEducationEstablishments GetFurtherEducationEstablishmentByUrn(int establishmentUrn);
-        public ViewAcademyConversions GetViewAcademyConversionInfoByUrn(int urn);
+        IList<Establishment> SearchEstablishments(int? urn, string ukprn, string name);
+        FurtherEducationEstablishments GetFurtherEducationEstablishmentByUrn(int establishmentUrn);
+        ViewAcademyConversions GetViewAcademyConversionInfoByUrn(int urn);
+        IList<Establishment> GetByUrns(int[] urns);
+        IList<MisEstablishments> GetMisEstablishmentsByUrns(int[] establishmentUrns);
+        IList<FurtherEducationEstablishments> GetFurtherEducationEstablishmentsByUrns(int[] establishmentUrns);
+        IList<SmartData> GetSmartDataByUrns(int[] establishmentUrns);
+        IList<ViewAcademyConversions> GetViewAcademyConversionInfoByUrns(int[] establishmentUrns);
     }
 }

--- a/TramsDataApi/RequestModels/GetEstablishmentsByUrnsRequest.cs
+++ b/TramsDataApi/RequestModels/GetEstablishmentsByUrnsRequest.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 
 namespace TramsDataApi.RequestModels
 {
     public class GetEstablishmentsByUrnsRequest
     {
         [FromQuery(Name = "Urn")]
+        [Required]
         public int[] Urns { get; set; }
     }
 }

--- a/TramsDataApi/RequestModels/GetEstablishmentsByUrnsRequest.cs
+++ b/TramsDataApi/RequestModels/GetEstablishmentsByUrnsRequest.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace TramsDataApi.RequestModels
+{
+    public class GetEstablishmentsByUrnsRequest
+    {
+        [FromQuery(Name = "Urn")]
+        public int[] Urns { get; set; }
+    }
+}

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -46,6 +46,7 @@ namespace TramsDataApi
             services.AddScoped<IGetEstablishmentByUkprn, GetEstablishment>();
             services.AddScoped<IGetEstablishmentURNsByRegion, GetEstablishmentURNsByRegion>();
             services.AddScoped<IGetEstablishmentsByTrustUid, GetEstablishmentsByTrustUid>();
+            services.AddScoped<IGetEstablishmentsByUrns, GetEstablishmentsByUrns>();
             services.AddScoped<ISearchTrusts, SearchTrusts>();
 
             services.AddScoped<ICreateAcademyTransferProject, CreateAcademyTransferProject>();

--- a/TramsDataApi/UseCases/GetEstablishmentsByUrns.cs
+++ b/TramsDataApi/UseCases/GetEstablishmentsByUrns.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TramsDataApi.Factories;
+using TramsDataApi.Gateways;
+using TramsDataApi.RequestModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public class GetEstablishmentsByUrns : IGetEstablishmentsByUrns
+    {
+        private readonly IEstablishmentGateway _establishmentGateway;
+
+        public GetEstablishmentsByUrns(IEstablishmentGateway establishmentGateway)
+        {
+            _establishmentGateway = establishmentGateway;
+        }
+
+        public IList<EstablishmentResponse> Execute(GetEstablishmentsByUrnsRequest request)
+        {
+            var establishments = _establishmentGateway.GetByUrns(request.Urns);
+            var misEstablishments = _establishmentGateway.GetMisEstablishmentsByUrns(request.Urns);
+            var smartData = _establishmentGateway.GetSmartDataByUrns(request.Urns);
+            var furtherEducationEstablishments = _establishmentGateway.GetFurtherEducationEstablishmentsByUrns(request.Urns);
+            var viewAcademyConversions = _establishmentGateway.GetViewAcademyConversionInfoByUrns(request.Urns);
+
+            if (!establishments.Any())
+            {
+                return null;
+            }
+
+            return establishments.Select(establishment =>
+                    EstablishmentResponseFactory.Create(
+                        establishment,
+                        misEstablishments?.FirstOrDefault(misEstablishment => misEstablishment.Urn == establishment.Urn),
+                        smartData?.FirstOrDefault(smartData => smartData.Urn == establishment.Urn.ToString()),
+                        furtherEducationEstablishments?.FirstOrDefault(furtherEducationEstablishment => furtherEducationEstablishment.ProviderUrn == establishment.Urn),
+                        viewAcademyConversions?.FirstOrDefault(viewAcademyConversion => viewAcademyConversion.GeneralDetailsAcademyUrn == establishment.Urn.ToString()),
+                        null)
+                    )
+                .ToList();
+        }
+    }
+}

--- a/TramsDataApi/UseCases/IGetEstablishmentsByUrns.cs
+++ b/TramsDataApi/UseCases/IGetEstablishmentsByUrns.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using TramsDataApi.RequestModels;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.UseCases
+{
+    public interface IGetEstablishmentsByUrns
+    {
+        IList<EstablishmentResponse> Execute(GetEstablishmentsByUrnsRequest request);
+    }
+}


### PR DESCRIPTION
### Add UseCase for getting establishments by URNs
Currently, in the Complete application, we fetch establishment data for each
project on our project index page as a separate API request. This is at times
very slow, and while we have explored various options to speed this up in the
client, we think adding a `bulk` endpoint to the API may be the better choice.

This adds a use case for getting establishments by a list of URNs. 

So that we aren't performing a database query for each related piece of data
per URN (`MisEstablishments`, `FurtherEducationEstablishments` etc.), this also
adds Gateway methods to fetch each by a list of URNs.

### Add controller action to get `bulk` Establishments by URNs
This adds a `bulk` endpoint in the format
`/establishments/bulk?Urn=12345&Urn=23456"` so that multiple establishments can
be retrieved in a single request.

There is no standard for the correct way to pass multiple values to an
endpoint, so I have opted for the easiest built-in method.

The endpoint will only return `not found` when no establishments are found for
all of the URNs passed, otherwise the establishments that were found will be
returned.