### PR TITLE
Fix flaky Establishments integration tests

### DIFF
--- a/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/EstablishmentsIntegrationTests.cs
@@ -287,6 +287,7 @@ namespace TramsDataApi.Test.Integration
             _legacyDbContext.MisEstablishments.RemoveRange(_legacyDbContext.MisEstablishments);
             _legacyDbContext.SmartData.RemoveRange(_legacyDbContext.SmartData);
             _legacyDbContext.ViewAcademyConversions.RemoveRange(_legacyDbContext.ViewAcademyConversions);
+            _legacyDbContext.FurtherEducationEstablishments.RemoveRange(_legacyDbContext.FurtherEducationEstablishments);
             _legacyDbContext.SaveChanges();
         }
     }


### PR DESCRIPTION
We clean up the test database for the Establishments integration tests in the `Dispose` method.

Currently, we aren't removing the test data from the `FurtherEducationEstablishments` table. This means that when running the tests multiple times, we see a primary key constraint error because we are trying to insert the same test data.

This adds clean up of the `FurtherEducationEstablishments` table to the `Dispose` method so that any test data is removed after every test.