### PR TITLE
Add probe path overrides

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -156,7 +156,9 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_enable_rate_limiting"></a> [cdn\_frontdoor\_enable\_rate\_limiting](#input\_cdn\_frontdoor\_enable\_rate\_limiting) | Enable CDN Front Door Rate Limiting. This will create a WAF policy, and CDN security policy. For pricing reasons, there will only be one WAF policy created. | `bool` | n/a | yes |
+| <a name="input_cdn_frontdoor_health_probe_path"></a> [cdn\_frontdoor\_health\_probe\_path](#input\_cdn\_frontdoor\_health\_probe\_path) | Specifies the path relative to the origin that is used to determine the health of the origin. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
+| <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | n/a | yes |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
@@ -165,6 +167,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
 | <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
+| <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -17,6 +17,9 @@ module "azure_container_apps_hosting" {
   enable_cdn_frontdoor               = local.enable_cdn_frontdoor
   cdn_frontdoor_enable_rate_limiting = local.cdn_frontdoor_enable_rate_limiting
 
-  enable_monitoring       = local.enable_monitoring
-  monitor_email_receivers = local.monitor_email_receivers
+  enable_monitoring               = local.enable_monitoring
+  monitor_email_receivers         = local.monitor_email_receivers
+  container_health_probe_path     = local.container_health_probe_path
+  cdn_frontdoor_health_probe_path = local.cdn_frontdoor_health_probe_path
+  monitor_endpoint_healthcheck    = local.monitor_endpoint_healthcheck
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -14,4 +14,7 @@ locals {
   enable_monitoring                      = var.enable_monitoring
   monitor_email_receivers                = var.monitor_email_receivers
   cdn_frontdoor_enable_rate_limiting     = var.cdn_frontdoor_enable_rate_limiting
+  container_health_probe_path            = var.container_health_probe_path
+  cdn_frontdoor_health_probe_path        = var.cdn_frontdoor_health_probe_path
+  monitor_endpoint_healthcheck           = var.monitor_endpoint_healthcheck
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,3 +73,18 @@ variable "monitor_email_receivers" {
   description = "A list of email addresses that should be notified by monitoring alerts"
   type        = list(string)
 }
+
+variable "container_health_probe_path" {
+  description = "Specifies the path that is used to determine the liveness of the Container"
+  type        = string
+}
+
+variable "cdn_frontdoor_health_probe_path" {
+  description = "Specifies the path relative to the origin that is used to determine the health of the origin."
+  type        = string
+}
+
+variable "monitor_endpoint_healthcheck" {
+  description = "Specify a route that should be monitored for a 200 OK status"
+  type        = string
+}


### PR DESCRIPTION
The default probe path of "/" returns a 401 status code due to a missing API Key. This change adds 3 vars to allow us to override the probe path to the Swagger API homepage which will return a 200 OK