### PR TITLE
Small perf tweaks to v2 Trust Search 

### DIFF
--- a/TramsDataApi/Controllers/V2/TrustsController.cs
+++ b/TramsDataApi/Controllers/V2/TrustsController.cs
@@ -26,7 +26,7 @@ namespace TramsDataApi.Controllers.V2
             _getTrustsByUkprns = getTrustsByUkprns;
             _logger = logger;
         }
-        
+
         [HttpGet("trusts")]
         [MapToApiVersion("2.0")]
         public ActionResult<ApiResponseV2<TrustSummaryResponse>> SearchTrusts(string groupName, string ukPrn, string companiesHouseNumber, int page = 1, int count = 50)
@@ -37,18 +37,21 @@ namespace TramsDataApi.Controllers.V2
 
             var (trusts, recordCount) = _searchTrusts
                 .Execute(page, count, groupName, ukPrn, companiesHouseNumber);
-            
+
             _logger.LogInformation(
                 "Found {count} trusts for groupName \"{name}\", UKPRN \"{prn}\", companiesHouseNumber \"{number}\", page {page}, count {count}",
                 trusts.Count(), groupName, ukPrn, companiesHouseNumber, page, count);
-            
-            _logger.LogDebug(JsonSerializer.Serialize(trusts));
-            
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(JsonSerializer.Serialize(trusts));
+            }
+
             var pagingResponse = PagingResponseFactory.Create(page, count, recordCount, Request);
             var response = new ApiResponseV2<TrustSummaryResponse>(trusts, pagingResponse);
             return new OkObjectResult(response);
         }
-        
+
         [HttpGet]
         [Route("trust/{ukprn}")]
         [MapToApiVersion("2.0")]

--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -16,7 +16,7 @@ namespace TramsDataApi.UseCases
             _trustGateway = trustGateway;
             _establishmentGateway = establishmentGateway;
         }
-        
+
         public (IEnumerable<TrustSummaryResponse>, int) Execute(int page, int count, string groupName, string ukPrn, string companiesHouseNumber)
         {
             var (groups, recordCount) = _trustGateway.SearchGroups(page, count, groupName, ukPrn, companiesHouseNumber);
@@ -27,7 +27,7 @@ namespace TramsDataApi.UseCases
                     var trust = _trustGateway.GetIfdTrustByGroupId(group.GroupId);
                     var establishments = _establishmentGateway.GetByTrustUid(group.GroupUid);
                     return TrustSummaryResponseFactory.Create(group, establishments, trust);
-                }), 
+                }).ToArray(),
                 recordCount
             );
         }


### PR DESCRIPTION
Changed Trust search execute to use ToArray so that it definitely won't cause any multiple enumerations.
Changed TrustsController to only serialise the results for logging if the debug logging is actually enabled.