### PR TITLE
Terraform Key Vault tfvars module

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -41,22 +41,22 @@ provider "registry.terraform.io/hashicorp/azuread" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.46.0"
+  version     = "3.47.0"
   constraints = ">= 3.41.0"
   hashes = [
-    "h1:YQh2ZPZULfNb+m9hAiEIsWdi8Wx04mcmaa2ftdWsUKo=",
-    "zh:02327ad31c998d9d55bafd280a4b1bd3702b496e49f53fad30823712cc85368a",
-    "zh:05882df6b5b59d23e2aa0c454caea84fcc35e435eb925e18293415260b4850c8",
-    "zh:0c0d6309abcfa24f0775df9bff81cb8f63029fead66956316d7cfa837c231873",
-    "zh:3607e8f5da720e053f7bada6b7c21b018ba25ccff8dade66bb64c2544214b400",
-    "zh:5662a2910bda19242b7be6bd7582a514082309691c97ee97aa9cf45bbbf45af4",
-    "zh:58d6de82cf26e2764f3d57d0e032b06cc97c90756044486b206d83cea53d3f7a",
-    "zh:5ee2f224ac1185e44fc4a2d60deb5c4a162d0fda07516e0939520cb8dcbedaca",
-    "zh:bbb6f9fd9cb6e8a79c9e1e3ce74647f743f60f3ea2c325b9aececf4a55ec0343",
-    "zh:c9d923b415f411eb68dfd43fab1753087b4701caeceb94550df562ca417c6007",
+    "h1:JW85JWb8IHUrf02p2ZA0bnfqbl/R6edKEke+1FnPbFA=",
+    "zh:099ffaec3ef0ef45a23aebd851fdf49a279f872632dd2e72fa3cb897621511ac",
+    "zh:0a2c33eff74c8934a371cff9647edc59a35cd2810d63613e5de4f6f2e43ae014",
+    "zh:0ac4934c8ebff2cdb5aba2728693ba8e2143f7a16f51dadaff5847a442d535b3",
+    "zh:125d2e039796ccf50f08e254be6f6258c28739fe28083c8e9fcb3952084bebb5",
+    "zh:39de12f00902dbe42a07b75687b9f4c2f141874bd8c0d544b02f23991e295f66",
+    "zh:584241a1dbee15d09007cfba5a341d0ae05722c194f51a67e01e4f6258dadc5e",
+    "zh:a0001c265faa25e3b3595fd530891cb08a01108cecea9b84289420a83e3d57dc",
+    "zh:c636316dc16226754b7c340fe0ad16fb1b2d9d4530303e9179be7205568cf40f",
+    "zh:ce6e92a57a5f277f9ccab2a119f939faa28ada04eb2cc9d3f2d2c70dc19a1a84",
+    "zh:cfde69b8c48edda6ac232d3afa676cfd9fa60515e43d764666a657b190b7ed71",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f6157b462ed33c27f101113b46463130d00de7f2731e05a371c922e5730a4b5e",
-    "zh:f96be10c899c0e30870056ec9c2c5002ec2e4f07fe2a64e1b3135ec232ef6f1e",
+    "zh:fc1269b2f4d27cd2d14cd970e5b5066adf68a3b267f21d57edc36b8ef6dba82f",
   ]
 }
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -130,25 +130,18 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.36.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.46.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.14.3 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.14.6 |
+| <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.1.1 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [azurerm_key_vault.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_secret.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+No resources.
 
 ## Inputs
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -163,6 +163,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
+| <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | n/a | yes |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_network_watcher_name"></a> [existing\_network\_watcher\_name](#input\_existing\_network\_watcher\_name) | Use an existing network watcher to add flow logs. | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.14.3"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.14.6"
 
   environment    = local.environment
   project_name   = local.project_name

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -18,6 +18,8 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_enable_rate_limiting      = local.cdn_frontdoor_enable_rate_limiting
   cdn_frontdoor_host_add_response_headers = local.cdn_frontdoor_host_add_response_headers
 
+  enable_event_hub = local.enable_event_hub
+
   enable_monitoring               = local.enable_monitoring
   monitor_email_receivers         = local.monitor_email_receivers
   container_health_probe_path     = local.container_health_probe_path

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,7 +1,0 @@
-data "azurerm_client_config" "current" {}
-
-data "azuread_user" "key_vault_access" {
-  for_each = local.key_vault_access_users
-
-  user_principal_name = each.value
-}

--- a/terraform/key-vault-tfvars-secrets.tf
+++ b/terraform/key-vault-tfvars-secrets.tf
@@ -1,54 +1,13 @@
-resource "azurerm_key_vault" "tfvars" {
-  name                       = "${local.environment}${local.project_name}-tfvars"
-  location                   = module.azure_container_apps_hosting.azurerm_resource_group_default.location
-  resource_group_name        = module.azure_container_apps_hosting.azurerm_resource_group_default.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
-  soft_delete_retention_days = 7
-  enable_rbac_authorization  = false
+module "azurerm_key_vault" {
+  source = "github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars?ref=v0.1.1"
 
-  dynamic "access_policy" {
-    for_each = data.azuread_user.key_vault_access
-
-    content {
-      tenant_id = data.azurerm_client_config.current.tenant_id
-      object_id = access_policy.value["object_id"]
-
-      key_permissions = [
-        "Create",
-        "Get",
-      ]
-
-      secret_permissions = [
-        "Set",
-        "Get",
-        "Delete",
-        "Purge",
-        "Recover",
-        "List",
-      ]
-    }
-  }
-
-  # It won't be possible to add/manage a network acl for this
-  # vault, as it will need to be accessable for multiple people.
-  # tfsec:ignore:azure-keyvault-specify-network-acl
-  network_acls {
-    bypass         = "None"
-    default_action = "Allow"
-  }
-
-  purge_protection_enabled = true
-
-  tags = local.tags
-}
-
-# Expiry doesn't need to be set, as this is just used as a way to
-# store and share the tfvars
-# tfsec:ignore:azure-keyvault-ensure-secret-expiry
-resource "azurerm_key_vault_secret" "tfvars" {
-  name         = "${local.environment}${local.project_name}-tfvars"
-  value        = base64encode(file(local.tfvars_filename))
-  key_vault_id = azurerm_key_vault.tfvars.id
-  content_type = "text/plain+base64"
+  environment                           = local.environment
+  project_name                          = local.project_name
+  resource_group_name                   = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+  azure_location                        = local.azure_location
+  key_vault_access_users                = local.key_vault_access_users
+  tfvars_filename                       = local.tfvars_filename
+  diagnostic_log_analytics_workspace_id = module.azure_container_apps_hosting.azurerm_log_analytics_workspace_container_app.id
+  diagnostic_eventhub_name              = local.enable_event_hub ? module.azure_container_apps_hosting.azurerm_eventhub_container_app.name : ""
+  tags                                  = local.tags
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,6 +9,7 @@ locals {
   container_command                            = var.container_command
   container_secret_environment_variables       = var.container_secret_environment_variables
   enable_cdn_frontdoor                         = var.enable_cdn_frontdoor
+  enable_event_hub                             = var.enable_event_hub
   key_vault_access_users                       = toset(var.key_vault_access_users)
   tfvars_filename                              = var.tfvars_filename
   enable_monitoring                            = var.enable_monitoring

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,3 +121,8 @@ variable "existing_network_watcher_resource_group_name" {
   description = "Existing network watcher resource group."
   type        = string
 }
+
+variable "enable_event_hub" {
+  description = "Send Azure Container App logs to an Event Hub sink"
+  type        = bool
+}


### PR DESCRIPTION
What is the change?
Instead of defining all of the terraform for deploying a Key Vault, I have switched to using a terraform module which shifts a lot of the configurable options upstream and reduces the complexity of the terraform code in this repo.

Why do we need the change?
Allows for centralised updates for the Key Vault resource and reduces complexity of the terraform in this repo.

What is the impact?
Applying this terraform change will destroy the existing tfvars Key Vault and recreate it. This has no impact on the running services within Azure and is considered safe/low impact.