### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - .env.development
 
   db:
-    image: ghcr.io/dfe-digital/trams-development-database:sql-2022
+    image: ghcr.io/dfe-digital/trams-development-database:latest
     env_file: .env.database
     ports:
       - 1433:1433


### PR DESCRIPTION
Switch to latest version of the DB Docker image - now synonymous with the SQL 2022 variant.