### PR TITLE
Fixed logic for returning trusts and associated address information

### DIFF
--- a/TramsDataApi/UseCases/SearchTrusts.cs
+++ b/TramsDataApi/UseCases/SearchTrusts.cs
@@ -42,8 +42,8 @@ namespace TramsDataApi.UseCases
             return (
                 groups.Select(group =>
                 {
+                    var trust = trustsForGroup.FirstOrDefault(e => e.TrustRef == group.GroupId);
                     var establishments = establishmentsForGroup.Where(e => e.TrustsCode == group.GroupUid);
-                    var trust = trustsForGroup.FirstOrDefault(e => e.TrustRef == group.GroupUid);
                     return TrustSummaryResponseFactory.Create(group, establishments, trust);
                 }).ToArray(),
                 recordCount


### PR DESCRIPTION
**What is the change?**

- Fix issue when returning trust address information via the trusts endpoint . Incorrect field used when filtering trusts linked to a parent group. 
- Added associated test following similar format to existing tests.

**Why do we need the change?**

Ensure address information is returned by the trusts endpoint and can be consumed by other services

**What is the impact?**
Enable Record Concerns to display town within trust search page. The town is displayed to users enabling differentiation between trusts with the same name but in different parts of the country. 

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=125531