### PR TITLE
This is a test PR to prove validation works and stops deployment

### DIFF
--- a/Dfe.Academies.Api.Infrastructure/Dfe.Academies.Infrastructure.csproj
+++ b/Dfe.Academies.Api.Infrastructure/Dfe.Academies.Infrastructure.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="GovUK.Dfe.CoreLibs.Caching" Version="1.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" /> 

--- a/Dfe.Academies.Application/Dfe.Academies.Application.csproj
+++ b/Dfe.Academies.Application/Dfe.Academies.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="GovUK.Dfe.CoreLibs.Contracts" Version="1.0.62" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/TramsDataApi/TramsDataApi.csproj
+++ b/TramsDataApi/TramsDataApi.csproj
@@ -17,7 +17,7 @@
       <None Remove="ServiceModels\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="14.0.0" />
+        <PackageReference Include="AutoMapper" Version="16.1.1" />
         <PackageReference Include="CsvHelper" Version="33.1.0" />
         <PackageReference Include="FluentValidation" Version="12.1.1" />
         <PackageReference Include="GovUK.Dfe.CoreLibs.Http" Version="1.0.11" />


### PR DESCRIPTION
Update AutoMapper to v16.1.1 in all projects

Upgraded AutoMapper from version 14.0.0 to 16.1.1 in Dfe.Academies.Infrastructure.csproj, Dfe.Academies.Application.csproj, and TramsDataApi.csproj to ensure compatibility and access to the latest features and fixes.