### PR TITLE
Add POST search endpoint for establishments with filters

### DIFF
--- a/Dfe.Academies.Api.Infrastructure/MstrContext.cs
+++ b/Dfe.Academies.Api.Infrastructure/MstrContext.cs
@@ -23,6 +23,7 @@ public class MstrContext : DbContext
     public DbSet<TrustType> TrustTypes { get; set; } = null!;
     public DbSet<Establishment> Establishments { get; set; } = null!;
     public DbSet<EstablishmentType> EstablishmentTypes { get; set; } = null!;
+    public DbSet<EstablishmentGroupType> EstablishmentGroupTypes { get; set; } = null!;
     public DbSet<EducationEstablishmentTrust> EducationEstablishmentTrusts { get; set; } = null!;
     public DbSet<LocalAuthority> LocalAuthorities { get; set; } = null!;
     public DbSet<IfdPipeline> IfdPipelines { get; set; } = null!;
@@ -47,6 +48,7 @@ public class MstrContext : DbContext
 
         modelBuilder.Entity<Establishment>(ConfigureEstablishment);
         modelBuilder.Entity<EstablishmentType>(ConfigureEstablishmentType);
+        modelBuilder.Entity<EstablishmentGroupType>(ConfigureEstablishmentGroupType);
         modelBuilder.Entity<EducationEstablishmentTrust>(ConfigureEducationEstablishmentTrust);
         modelBuilder.Entity<LocalAuthority>(ConfigureLocalAuthority);
         modelBuilder.Entity<IfdPipeline>(ConfigureIfdPipeline);
@@ -76,6 +78,12 @@ public class MstrContext : DbContext
         }
 
         base.OnModelCreating(modelBuilder);
+    }
+
+    private void ConfigureEstablishmentGroupType(EntityTypeBuilder<EstablishmentGroupType> builder)
+    {
+        builder.HasKey(e => e.SK);
+        builder.ToTable("Ref_EducationEstablishmentGroupType", DEFAULT_SCHEMA);
     }
 
     private static void ConfigureEstablishment(EntityTypeBuilder<Establishment> establishmentConfiguration)
@@ -178,6 +186,12 @@ public class MstrContext : DbContext
             .HasOne(x => x.EstablishmentType)
             .WithMany()
             .HasForeignKey(x => x.EstablishmentTypeId)
+            .IsRequired(false);
+
+        establishmentConfiguration
+            .HasOne(x => x.EstablishmentGroupType)
+            .WithMany()
+            .HasForeignKey(x => x.EstablishmentGroupTypeId)
             .IsRequired(false);
 
         establishmentConfiguration

--- a/Dfe.Academies.Api.Infrastructure/MstrContext.cs
+++ b/Dfe.Academies.Api.Infrastructure/MstrContext.cs
@@ -80,7 +80,7 @@ public class MstrContext : DbContext
         base.OnModelCreating(modelBuilder);
     }
 
-    private void ConfigureEstablishmentGroupType(EntityTypeBuilder<EstablishmentGroupType> builder)
+    private static void ConfigureEstablishmentGroupType(EntityTypeBuilder<EstablishmentGroupType> builder)
     {
         builder.HasKey(e => e.SK);
         builder.ToTable("Ref_EducationEstablishmentGroupType", DEFAULT_SCHEMA);

--- a/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
@@ -74,7 +74,7 @@ namespace Dfe.Academies.Infrastructure.Repositories
 
             return queryResult.Select(ToEstablishment).ToList();
         }
-        
+
         public async Task<List<Establishment>> SearchByNameStartsWith(string name, bool? excludeClosed, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(name))
@@ -83,10 +83,10 @@ namespace Dfe.Academies.Infrastructure.Repositories
             }
 
             IQueryable<EstablishmentQueryResult> query = BaseQuery();
-            
-            
+
+
             query = query.Where(r => r.Establishment.EstablishmentName != null && r.Establishment.EstablishmentName.StartsWith(name));
-            
+
 
             if (excludeClosed == true)
             {
@@ -97,68 +97,84 @@ namespace Dfe.Academies.Infrastructure.Repositories
 
             return queryResult.Select(ToEstablishment).ToList();
         }
-        
 
-        public async Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken)
+
+        public async Task<List<Establishment>> SearchByFilters(
+            string name,
+            long[] groupTypeIds,
+            CancellationToken cancellationToken)
         {
-            return await context.Establishments
-                .AsNoTracking()
-                .Where(p => regions.Contains(p.GORregion) && p.URN.HasValue)
-                .Select(e => e.URN.Value)
-                .ToListAsync(cancellationToken);
-        }
+            var hasName = !string.IsNullOrWhiteSpace(name);
+            var hasGroupTypes = groupTypeIds != null && groupTypeIds.Length > 0;
 
-        public async Task<List<Establishment>> GetByUrns(int[] urns, CancellationToken cancellationToken)
-        {
-            var urnsList = urns.ToList();
-            var queryResult = await BaseQuery()
-                .Where(r => urnsList.Contains((int)r.Establishment.URN))
-                .ToListAsync(cancellationToken);
+            if (!hasName && !hasGroupTypes)
+            {
+                return [];
+            }
 
-            var result = queryResult.Select(ToEstablishment).ToList();
+            var groupTypeCodes = hasGroupTypes
+                ? groupTypeIds.Select(x => x.ToString()).ToArray()
+                : [];
 
-            return result;
-        }
+            var matchingGroupTypeSk = hasGroupTypes
+                ? await context.EstablishmentGroupTypes
+                    .AsNoTracking()
+                    .Where(g => g.Code != null && groupTypeCodes.Contains(g.Code))
+                    .Select(g => g.SK)
+                    .ToArrayAsync(cancellationToken)
+                    .ConfigureAwait(false)
+                : [];
 
-        public async Task<List<Establishment>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken)
-        {
-            var ukprnsList = ukprns.ToList();
-            var queryResult = await BaseQuery()
-                .Where(r => ukprnsList.Contains(r.Establishment.UKPRN))
-                .ToListAsync(cancellationToken);
+            if (hasGroupTypes && matchingGroupTypeSk.Length == 0 && !hasName)
+            {
+                return [];
+            }
 
-            var result = queryResult.Select(ToEstablishment).ToList();
+            IQueryable<Establishment> filteredEstablishments = context.Establishments.AsNoTracking();
 
-            return result;
-        }
+            if (hasName)
+            {
+                filteredEstablishments = filteredEstablishments.Where(e =>
+                    e.EstablishmentName != null &&
+                    e.EstablishmentName.StartsWith(name));
+            }
 
-        public async Task<List<Establishment>> GetByTrust(long? trustId, CancellationToken cancellationToken)
-        {
-            var establishmentIds =
-                await context.EducationEstablishmentTrusts
-                        .AsNoTracking()
-                        .Where(eet => eet.TrustId == Convert.ToInt32(trustId))
-                        .Select(eet => (long)eet.EducationEstablishmentId)
-                        .ToListAsync(cancellationToken);
+            if (hasGroupTypes)
+            {
+                filteredEstablishments = filteredEstablishments.Where(e =>
+                    e.EstablishmentGroupTypeId.HasValue &&
+                    matchingGroupTypeSk.Contains(e.EstablishmentGroupTypeId.Value));
+            }
 
-            var establishments =
-                    await BaseQuery()
-                        .Where(r => establishmentIds.Contains(r.Establishment.SK.Value))
-                        .ToListAsync(cancellationToken);
+            var queryResult = await BaseQuery(filteredEstablishments)
+                .Take(100)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            var result = establishments.Select(ToEstablishment).ToList();
-
-            return result;
+            return queryResult.Select(ToEstablishment).ToList();
         }
 
         private IQueryable<EstablishmentQueryResult> BaseQuery()
         {
+            return BaseQuery(context.Establishments);
+        }
+
+        private IQueryable<EstablishmentQueryResult> BaseQuery(IQueryable<Establishment> establishments)
+        {
             var result =
-                 from establishment in context.Establishments
-                 from ifdPipeline in context.IfdPipelines.Where(i => i.GeneralDetailsUrn == establishment.PK_GIAS_URN).DefaultIfEmpty()
-                 from establishmentType in context.EstablishmentTypes.Where(e => e.SK == establishment.EstablishmentTypeId).DefaultIfEmpty()
-                 from localAuthority in context.LocalAuthorities.Where(l => l.SK == establishment.LocalAuthorityId).DefaultIfEmpty()
-                 select new EstablishmentQueryResult { Establishment = establishment, IfdPipeline = ifdPipeline, LocalAuthority = localAuthority, EstablishmentType = establishmentType };
+                from establishment in establishments
+                from ifdPipeline in context.IfdPipelines.Where(i => i.GeneralDetailsUrn == establishment.PK_GIAS_URN).DefaultIfEmpty()
+                from establishmentType in context.EstablishmentTypes.Where(e => e.SK == establishment.EstablishmentTypeId).DefaultIfEmpty()
+                from localAuthority in context.LocalAuthorities.Where(l => l.SK == establishment.LocalAuthorityId).DefaultIfEmpty()
+                from groupType in context.EstablishmentGroupTypes.Where(g => g.SK == establishment.EstablishmentGroupTypeId).DefaultIfEmpty()
+                select new EstablishmentQueryResult
+                {
+                    Establishment = establishment,
+                    IfdPipeline = ifdPipeline,
+                    LocalAuthority = localAuthority,
+                    EstablishmentType = establishmentType,
+                    EstablishmentGroupType = groupType
+                };
 
             return result;
         }
@@ -169,6 +185,7 @@ namespace Dfe.Academies.Infrastructure.Repositories
             result.IfdPipeline = queryResult.IfdPipeline;
             result.LocalAuthority = queryResult.LocalAuthority;
             result.EstablishmentType = queryResult.EstablishmentType;
+            result.EstablishmentGroupType = queryResult.EstablishmentGroupType;
 
             return result;
         }
@@ -265,14 +282,68 @@ namespace Dfe.Academies.Infrastructure.Repositories
 
             return (dioceses, recordCount);
         }
-    }
 
-    internal record EstablishmentQueryResult
-    {
-        public Establishment Establishment { get; set; }
-        public IfdPipeline IfdPipeline { get; set; }
-        public LocalAuthority LocalAuthority { get; set; }
-        public EstablishmentType EstablishmentType { get; set; }
-    }
 
+        public async Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken)
+        {
+            return await context.Establishments
+                .AsNoTracking()
+                .Where(p => regions.Contains(p.GORregion) && p.URN.HasValue)
+                .Select(e => e.URN.Value)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<List<Establishment>> GetByUrns(int[] urns, CancellationToken cancellationToken)
+        {
+            var urnsList = urns.ToList();
+            var queryResult = await BaseQuery()
+                .Where(r => urnsList.Contains((int)r.Establishment.URN))
+                .ToListAsync(cancellationToken);
+
+            var result = queryResult.Select(ToEstablishment).ToList();
+
+            return result;
+        }
+
+        public async Task<List<Establishment>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken)
+        {
+            var ukprnsList = ukprns.ToList();
+            var queryResult = await BaseQuery()
+                .Where(r => ukprnsList.Contains(r.Establishment.UKPRN))
+                .ToListAsync(cancellationToken);
+
+            var result = queryResult.Select(ToEstablishment).ToList();
+
+            return result;
+        }
+
+        public async Task<List<Establishment>> GetByTrust(long? trustId, CancellationToken cancellationToken)
+        {
+            var establishmentIds =
+                await context.EducationEstablishmentTrusts
+                        .AsNoTracking()
+                        .Where(eet => eet.TrustId == Convert.ToInt32(trustId))
+                        .Select(eet => (long)eet.EducationEstablishmentId)
+                        .ToListAsync(cancellationToken);
+
+            var establishments =
+                    await BaseQuery()
+                        .Where(r => establishmentIds.Contains(r.Establishment.SK.Value))
+                        .ToListAsync(cancellationToken);
+
+            var result = establishments.Select(ToEstablishment).ToList();
+
+            return result;
+        }
+
+        internal record EstablishmentQueryResult
+        {
+            public Establishment Establishment { get; set; }
+            public IfdPipeline IfdPipeline { get; set; }
+            public LocalAuthority LocalAuthority { get; set; }
+            public EstablishmentType EstablishmentType { get; set; }
+            public EstablishmentGroupType EstablishmentGroupType { get; internal set; }
+        }
+
+    }
 }

--- a/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
@@ -342,7 +342,7 @@ namespace Dfe.Academies.Infrastructure.Repositories
             public IfdPipeline IfdPipeline { get; set; }
             public LocalAuthority LocalAuthority { get; set; }
             public EstablishmentType EstablishmentType { get; set; }
-            public EstablishmentGroupType EstablishmentGroupType { get; internal set; }
+            public EstablishmentGroupType EstablishmentGroupType { get; set; }
         }
 
     }

--- a/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
+++ b/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
@@ -54,6 +54,18 @@ namespace Dfe.Academies.Application.Establishment
             return (establishments.Select(x => MapToEstablishmentDto(x)).ToList(), establishments.Count);
         }
 
+        public async Task<(List<EstablishmentDto>, int)> SearchByFilters(
+            string establishmentNameStartsWith,
+            long[] groupTypeIds,
+            CancellationToken cancellationToken)
+        {
+            var establishments = await _establishmentRepository
+                .SearchByFilters(establishmentNameStartsWith, groupTypeIds, cancellationToken)
+                .ConfigureAwait(false);
+
+            return (establishments.Select(MapToEstablishmentDto).ToList(), establishments.Count);
+        }
+
         public async Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken)
         {
             var urns = await _establishmentRepository.GetURNsByRegion(regions, cancellationToken);

--- a/Dfe.Academies.Application/Establishment/IEstablishmentQueries.cs
+++ b/Dfe.Academies.Application/Establishment/IEstablishmentQueries.cs
@@ -7,8 +7,12 @@ namespace Dfe.Academies.Application.Establishment
         Task<EstablishmentDto?> GetByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<EstablishmentDto?> GetByUrn(string urn, CancellationToken cancellationToken);
         Task<(List<EstablishmentDto>, int)> Search(string name, string ukPrn, string urn, bool? excludeClosed, bool? matchAny, CancellationToken cancellationToken);
-        
+
         Task<(List<EstablishmentDto>, int)> SearchByNameStartsWith(string name, bool? excludeClosed,CancellationToken cancellationToken);
+        Task<(List<EstablishmentDto>, int)> SearchByFilters(
+            string establishmentNameStartsWith,
+            long[] groupTypeIds,
+            CancellationToken cancellationToken);
         Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken);
         Task<List<EstablishmentDto>> GetByUrns(int[] Urns, CancellationToken cancellationToken);
         Task<List<EstablishmentDto>> GetByUkprns(string[] Ukprns, CancellationToken cancellationToken);

--- a/Dfe.Academies.Domain/Establishment/Establishment.cs
+++ b/Dfe.Academies.Domain/Establishment/Establishment.cs
@@ -98,6 +98,7 @@ namespace Dfe.Academies.Domain.Establishment
         public virtual ICollection<EducationEstablishmentGovernance>? EducationEstablishmentGovernances { get; set; }
         public LocalAuthority? LocalAuthority { get; set; }
         public EstablishmentType? EstablishmentType{ get; set; }
+        public EstablishmentGroupType? EstablishmentGroupType{ get; set; }
 
         public IfdPipeline? IfdPipeline { get; set; }
     }

--- a/Dfe.Academies.Domain/Establishment/EstablishmentGroupType.cs
+++ b/Dfe.Academies.Domain/Establishment/EstablishmentGroupType.cs
@@ -1,0 +1,9 @@
+﻿namespace Dfe.Academies.Domain.Establishment
+{
+    public class EstablishmentGroupType
+    {
+        public long SK { get; set; }
+        public string? Name { get; set; }
+        public string? Code { get; set; }
+    }
+}

--- a/Dfe.Academies.Domain/Interfaces/Repositories/IEstablishmentRepository.cs
+++ b/Dfe.Academies.Domain/Interfaces/Repositories/IEstablishmentRepository.cs
@@ -9,7 +9,11 @@ namespace Dfe.Academies.Domain.Interfaces.Repositories
         Task<List<Establishment.Establishment>> Search(string name, string ukPrn,
          string urn, bool? excludeClosed, bool? matchAny, CancellationToken cancellationToken);
         Task<List<Establishment.Establishment>> SearchByNameStartsWith(string name, bool? excludeClosed, CancellationToken cancellationToken);
-        
+        Task<List<Establishment.Establishment>> SearchByFilters(
+            string name,
+            long[] groupTypeIds,
+            CancellationToken cancellationToken);
+
         Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken);
         Task<List<Establishment.Establishment>> GetByTrust(long? trustId, CancellationToken cancellationToken);
         Task<List<Establishment.Establishment>> GetByUrns(int[] Urns, CancellationToken cancellationToken);

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/Client.g.cs
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/Client.g.cs
@@ -3513,6 +3513,105 @@ namespace GovUK.Dfe.AcademiesApi.Client
         }
 
         /// <summary>
+        /// Searches for Establishments based on a request body.
+        /// </summary>
+        /// <param name="request">Search request model.</param>
+        /// <returns>Successfully executed the search and returned Establishments.</returns>
+        /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishmentsPostAsync(SearchEstablishmentsPostRequestModel request)
+        {
+            return SearchEstablishmentsPostAsync(request, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Searches for Establishments based on a request body.
+        /// </summary>
+        /// <param name="request">Search request model.</param>
+        /// <returns>Successfully executed the search and returned Establishments.</returns>
+        /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishmentsPostAsync(SearchEstablishmentsPostRequestModel request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "v4/establishments"
+                    urlBuilder_.Append("v4/establishments");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new AcademiesApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new AcademiesApiException("Invalid request body.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new AcademiesApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Searches for Establishments by name based on query parameters.
         /// </summary>
         /// <param name="name">Name of the establishment.</param>

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
@@ -422,6 +422,23 @@ namespace GovUK.Dfe.AcademiesApi.Client.Contracts
         System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, bool? excludeClosed, bool? matchAny, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Searches for Establishments based on a request body.
+        /// </summary>
+        /// <param name="request">Search request model.</param>
+        /// <returns>Successfully executed the search and returned Establishments.</returns>
+        /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishmentsPostAsync(SearchEstablishmentsPostRequestModel request);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Searches for Establishments based on a request body.
+        /// </summary>
+        /// <param name="request">Search request model.</param>
+        /// <returns>Successfully executed the search and returned Establishments.</returns>
+        /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishmentsPostAsync(SearchEstablishmentsPostRequestModel request, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Searches for Establishments by name based on query parameters.
         /// </summary>
         /// <param name="name">Name of the establishment.</param>
@@ -3120,6 +3137,66 @@ namespace GovUK.Dfe.AcademiesApi.Client.Contracts
             return Newtonsoft.Json.JsonConvert.DeserializeObject<UkprnRequestModel>(data, new Newtonsoft.Json.JsonSerializerSettings());
 
         }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class SearchEstablishmentsPostRequestModel
+    {
+
+        [Newtonsoft.Json.JsonProperty("establishmentNameStartsWith", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? EstablishmentNameStartsWith { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("groupTypes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public System.Collections.Generic.List<GroupType>? GroupTypes { get; set; } = default!;
+
+        public string ToJson()
+        {
+
+            return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonSerializerSettings());
+
+        }
+        public static SearchEstablishmentsPostRequestModel FromJson(string data)
+        {
+
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<SearchEstablishmentsPostRequestModel>(data, new Newtonsoft.Json.JsonSerializerSettings());
+
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum GroupType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Unknown")]
+        Unknown = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Colleges")]
+        Colleges = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Universities")]
+        Universities = 2,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"IndependentSchools")]
+        IndependentSchools = 3,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"LocalAuthorityMaintainedSchools")]
+        LocalAuthorityMaintainedSchools = 4,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SpecialSchools")]
+        SpecialSchools = 5,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"OtherTypes")]
+        OtherTypes = 6,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Academies")]
+        Academies = 7,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"FreeSchools")]
+        FreeSchools = 8,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"OnlineProvider")]
+        OnlineProvider = 9,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
@@ -973,6 +973,45 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "EstablishmentsV4",
+          "Establishments"
+        ],
+        "summary": "Searches for Establishments based on a request body.",
+        "operationId": "SearchEstablishmentsPostAsync",
+        "requestBody": {
+          "x-name": "request",
+          "description": "Search request model.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchEstablishmentsPostRequestModel"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully executed the search and returned Establishments.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstablishmentDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body."
+          }
+        }
       }
     },
     "/v4/establishments/SearchByNameStartsWith": {
@@ -4619,6 +4658,51 @@
             }
           }
         }
+      },
+      "SearchEstablishmentsPostRequestModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "establishmentNameStartsWith": {
+            "type": "string",
+            "nullable": true
+          },
+          "groupTypes": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/GroupType"
+            }
+          }
+        }
+      },
+      "GroupType": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Unknown",
+          "Colleges",
+          "Universities",
+          "IndependentSchools",
+          "LocalAuthorityMaintainedSchools",
+          "SpecialSchools",
+          "OtherTypes",
+          "Academies",
+          "FreeSchools",
+          "OnlineProvider"
+        ],
+        "enum": [
+          "Unknown",
+          "Colleges",
+          "Universities",
+          "IndependentSchools",
+          "LocalAuthorityMaintainedSchools",
+          "SpecialSchools",
+          "OtherTypes",
+          "Academies",
+          "FreeSchools",
+          "OnlineProvider"
+        ]
       },
       "PagedDataResponseOfSignificantChangeDto": {
         "type": "object",

--- a/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
+++ b/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
@@ -162,6 +162,48 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
         }
 
         [Fact]
+        public async Task SearchByFilters_WhenEstablishmentsReturnedFromRepo_EstablishmentDtoListAndCountIsReturned()
+        {
+            // Arrange
+            var establishments = _fixture.Create<List<Domain.Establishment.Establishment>>();
+            var mockRepo = new Mock<IEstablishmentRepository>();
+            var mockTrustRepo = new Mock<ITrustRepository>();
+            var mockCensusRepo = new Mock<ICensusDataRepository>();
+
+            string name = "Test School";
+            long[] groupTypeIds = [1, 10];
+
+            mockRepo.Setup(x => x.SearchByFilters(
+                    It.Is<string>(v => v == name),
+                    It.Is<long[]>(v => v == groupTypeIds),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(establishments));
+            mockRepo.Setup(x => x.GetMisEstablishmentByURN(It.IsAny<int?>())).Returns(_misEstablishment);
+            mockRepo.Setup(x => x.GetEducationEstablishmentLinksByURN(It.IsAny<long?>())).Returns(_educationEstablishmentLink);
+
+            var establishmentQueries = new EstablishmentQueries(
+                mockRepo.Object, mockTrustRepo.Object, mockCensusRepo.Object);
+
+            CancellationToken cancellationToken = default(global::System.Threading.CancellationToken);
+
+            // Act
+            var result = await establishmentQueries.SearchByFilters(
+                name,
+                groupTypeIds,
+                cancellationToken);
+
+            // Assert
+            result.Should().BeOfType(typeof((List<EstablishmentDto>, int)));
+            result.Item2.Should().Be(establishments.Count);
+
+            foreach (var establishmentDto in result.Item1)
+            {
+                var establishment = establishments.Single(x => x.URN.ToString() == establishmentDto.Urn);
+                Assert.True(HasMappedCorrectly(establishmentDto, establishment, _misEstablishment, _educationEstablishmentLink));
+            }
+        }
+
+        [Fact]
         public async Task GetURNsByRegion_WhenEstablishmentUrnsReturnedFromRepo_IEnumebrableOfIntIsReturned()
         {
             // Arrange

--- a/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
+++ b/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
@@ -153,7 +153,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
                 cancellationToken);
 
             // Assert
-            result.Should().BeOfType(typeof((List<EstablishmentDto>, int)));
+            result.Should().BeOfType<(List<EstablishmentDto>, int)>();
             foreach (var establishmentDto in result.Item1)
             {
                 var establishment = establishments.Single(x => x.URN.ToString() == establishmentDto.Urn);
@@ -193,7 +193,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
                 cancellationToken);
 
             // Assert
-            result.Should().BeOfType(typeof((List<EstablishmentDto>, int)));
+            result.Should().BeOfType<(List<EstablishmentDto>, int)>();
             result.Item2.Should().Be(establishments.Count);
 
             foreach (var establishmentDto in result.Item1)

--- a/TramsDataApi/Controllers/V4/EstablishmentsController.cs
+++ b/TramsDataApi/Controllers/V4/EstablishmentsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -326,6 +327,67 @@ namespace TramsDataApi.Controllers.V4
             var response = new List<EstablishmentDto>(establishments);
 
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Searches for Establishments based on a request body.
+        /// </summary>
+        /// <param name="request">Search request model.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>A list of Establishments that meet the search criteria.</returns>
+        [HttpPost]
+        [Route("establishments")]
+        [SwaggerOperation(Summary = "Search Establishments", Description = "Returns a list of Establishments based on search criteria.")]
+        [SwaggerResponse(200, "Successfully executed the search and returned Establishments.", typeof(List<EstablishmentDto>))]
+        [SwaggerResponse(400, "Invalid request body.")]
+        public async Task<ActionResult<List<EstablishmentDto>>> SearchEstablishmentsPostAsync(
+            [FromBody] SearchEstablishmentsPostRequestModel request,
+            CancellationToken cancellationToken)
+        {
+            if (request == null)
+            {
+                return BadRequest("Request body is required.");
+            }
+
+            var hasName = !string.IsNullOrWhiteSpace(request.EstablishmentNameStartsWith);
+            var groupTypeIds = request.GroupTypes?
+                .Where(x => x != GroupType.Unknown)
+                .Select(x => (long)x)
+                .Distinct()
+                .ToArray() ?? [];
+
+            var hasGroupTypes = groupTypeIds.Length > 0;
+
+            if (!hasName && !hasGroupTypes)
+            {
+                return BadRequest("Provide at least one of `EstablishmentNameStartsWIth` or `GroupTypes`.");
+            }
+
+            _logger.LogInformation(
+                "Searching for establishments by name starts with \"{NameStartsWith}\" and group types count \"{GroupTypesCount}\"",
+                request.EstablishmentNameStartsWith,
+                groupTypeIds.Length);
+
+            var (establishments, recordCount) = await _establishmentQueries
+                .SearchByFilters(
+                    request.EstablishmentNameStartsWith,
+                    groupTypeIds,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Found {Count} establishments for name starts with \"{NameStartsWith}\" and group types count \"{GroupTypesCount}\"",
+                recordCount,
+                request.EstablishmentNameStartsWith,
+                groupTypeIds.Length);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Establishments: {EstablishmentsJson}",
+                    JsonSerializer.Serialize(establishments));
+            }
+
+            return Ok(new List<EstablishmentDto>(establishments));
         }
     }
 }

--- a/TramsDataApi/RequestModels/SearchEstablishmentsPostRequestModel.cs
+++ b/TramsDataApi/RequestModels/SearchEstablishmentsPostRequestModel.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace TramsDataApi.RequestModels
+{
+    public class SearchEstablishmentsPostRequestModel
+    {
+        public string EstablishmentNameStartsWith { get; set; }
+        public List<GroupType> GroupTypes { get; set; }
+    }
+
+    public enum GroupType
+    {
+        Unknown = 0,
+
+        // Align these values with Establishment.EstablishmentGroupTypeId values
+        Colleges = 1,
+        Academies = 10,
+        FreeSchools = 11,
+        Universities = 2,
+        IndependentSchools = 3,
+        LocalAuthorityMaintainedSchools = 4,
+        SpecialSchools = 5,
+        OtherTypes = 9,
+        OnlineProvider = 13
+    }
+
+}


### PR DESCRIPTION
Add POST search endpoint for establishments with filters

Added a new POST /v4/establishments endpoint supporting search by name prefix and group types. Introduced EstablishmentGroupType entity and integrated it into the EF Core model and repository/query layers. Updated OpenAPI spec, client contracts, and added unit tests for the new search functionality. Controller now validates input and logs search operations.