### PR TITLE
Add EstablishmentGroupType to domain, API, and tests

### DIFF
--- a/Dfe.Academies.Api.Infrastructure/MstrContext.cs
+++ b/Dfe.Academies.Api.Infrastructure/MstrContext.cs
@@ -23,6 +23,7 @@ public class MstrContext : DbContext
     public DbSet<TrustType> TrustTypes { get; set; } = null!;
     public DbSet<Establishment> Establishments { get; set; } = null!;
     public DbSet<EstablishmentType> EstablishmentTypes { get; set; } = null!;
+    public DbSet<EstablishmentGroupType> EstablishmentGroupTypes { get; set; } = null!;
     public DbSet<EducationEstablishmentTrust> EducationEstablishmentTrusts { get; set; } = null!;
     public DbSet<LocalAuthority> LocalAuthorities { get; set; } = null!;
     public DbSet<IfdPipeline> IfdPipelines { get; set; } = null!;
@@ -47,6 +48,7 @@ public class MstrContext : DbContext
 
         modelBuilder.Entity<Establishment>(ConfigureEstablishment);
         modelBuilder.Entity<EstablishmentType>(ConfigureEstablishmentType);
+        modelBuilder.Entity<EstablishmentGroupType>(ConfigureEstablishmentGroupType);
         modelBuilder.Entity<EducationEstablishmentTrust>(ConfigureEducationEstablishmentTrust);
         modelBuilder.Entity<LocalAuthority>(ConfigureLocalAuthority);
         modelBuilder.Entity<IfdPipeline>(ConfigureIfdPipeline);
@@ -181,6 +183,12 @@ public class MstrContext : DbContext
             .IsRequired(false);
 
         establishmentConfiguration
+            .HasOne(x => x.EstablishmentGroupType)
+            .WithMany()
+            .HasForeignKey(x => x.EstablishmentTypeId)
+            .IsRequired(false);
+
+        establishmentConfiguration
             .HasOne(x => x.LocalAuthority)
             .WithMany()
             .HasForeignKey(x => x.LocalAuthorityId)
@@ -284,6 +292,11 @@ public class MstrContext : DbContext
         establishmentTypeConfiguration.ToTable("Ref_EducationEstablishmentType", DEFAULT_SCHEMA);
     }
 
+    private static void ConfigureEstablishmentGroupType(EntityTypeBuilder<EstablishmentGroupType> establishmentGroupTypeConfiguration)
+    {
+        establishmentGroupTypeConfiguration.HasKey(e => e.SK);
+        establishmentGroupTypeConfiguration.ToTable("Ref_EducationEstablishmentGroupType", DEFAULT_SCHEMA);
+    }
 
     private static void ConfigureEducationEstablishmentLink(EntityTypeBuilder<EducationEstablishmentLink> educationEstablishmentLinkConfiguration)
     {

--- a/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/EstablishmentRepository.cs
@@ -157,8 +157,9 @@ namespace Dfe.Academies.Infrastructure.Repositories
                  from establishment in context.Establishments
                  from ifdPipeline in context.IfdPipelines.Where(i => i.GeneralDetailsUrn == establishment.PK_GIAS_URN).DefaultIfEmpty()
                  from establishmentType in context.EstablishmentTypes.Where(e => e.SK == establishment.EstablishmentTypeId).DefaultIfEmpty()
+                 from establishmentGroupType in context.EstablishmentGroupTypes.Where(e => e.SK == establishment.EstablishmentGroupTypeId).DefaultIfEmpty()
                  from localAuthority in context.LocalAuthorities.Where(l => l.SK == establishment.LocalAuthorityId).DefaultIfEmpty()
-                 select new EstablishmentQueryResult { Establishment = establishment, IfdPipeline = ifdPipeline, LocalAuthority = localAuthority, EstablishmentType = establishmentType };
+                 select new EstablishmentQueryResult { Establishment = establishment, IfdPipeline = ifdPipeline, LocalAuthority = localAuthority, EstablishmentType = establishmentType, EstablishmentGroupType = establishmentGroupType };
 
             return result;
         }
@@ -169,6 +170,7 @@ namespace Dfe.Academies.Infrastructure.Repositories
             result.IfdPipeline = queryResult.IfdPipeline;
             result.LocalAuthority = queryResult.LocalAuthority;
             result.EstablishmentType = queryResult.EstablishmentType;
+            result.EstablishmentGroupType = queryResult.EstablishmentGroupType;
 
             return result;
         }
@@ -273,6 +275,7 @@ namespace Dfe.Academies.Infrastructure.Repositories
         public IfdPipeline IfdPipeline { get; set; }
         public LocalAuthority LocalAuthority { get; set; }
         public EstablishmentType EstablishmentType { get; set; }
+        public EstablishmentGroupType EstablishmentGroupType { get; set; }
     }
 
 }

--- a/Dfe.Academies.Application/Dfe.Academies.Application.csproj
+++ b/Dfe.Academies.Application/Dfe.Academies.Application.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="GovUK.Dfe.CoreLibs.Contracts" Version="1.0.63" />
+    <PackageReference Include="GovUK.Dfe.CoreLibs.Contracts" Version="1.0.64" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />

--- a/Dfe.Academies.Application/Dfe.Academies.Application.csproj
+++ b/Dfe.Academies.Application/Dfe.Academies.Application.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="GovUK.Dfe.CoreLibs.Contracts" Version="1.0.62" />
+    <PackageReference Include="GovUK.Dfe.CoreLibs.Contracts" Version="1.0.63" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />

--- a/Dfe.Academies.Application/Establishment/EstablishmentDtoBuilder.cs
+++ b/Dfe.Academies.Application/Establishment/EstablishmentDtoBuilder.cs
@@ -201,6 +201,17 @@ namespace Dfe.Academies.Application.Establishment
         {
             return _dto;
         }
+
+        public EstablishmentDtoBuilder WithEstablishmentGroupType(Domain.Establishment.Establishment establishment)
+        {
+            _dto.EstablishmentGroupType = new NameAndCodeDto
+            {
+                Name = establishment?.EstablishmentGroupType?.Name,
+                Code = establishment?.EstablishmentGroupType?.Code
+            };
+
+            return this;
+        }
     }
 }
 

--- a/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
+++ b/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
@@ -98,6 +98,7 @@ namespace Dfe.Academies.Application.Establishment
                 .WithLocalAuthority(establishment)
                 .WithDiocese(establishment)
                 .WithEstablishmentType(establishment)
+                .WithEstablishmentGroupType(establishment)
                 .WithGor(establishment)
                 .WithPhaseOfEducation(establishment)
                 .WithReligiousCharacter(establishment)

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -1,5 +1,6 @@
 ﻿using Dfe.Academies.Domain.Interfaces.Repositories;
 using Dfe.Academies.Domain.Trust;
+using Dfe.Academies.Utils.Extensions;
 using GovUK.Dfe.CoreLibs.Contracts.Academies.V4;
 using GovUK.Dfe.CoreLibs.Contracts.Academies.V4.Establishments;
 using GovUK.Dfe.CoreLibs.Contracts.Academies.V4.Trusts;
@@ -74,7 +75,9 @@ namespace Dfe.Academies.Application.Trust
                     Additional = trust.AddressLine2!,
                     Locality = trust.AddressLine3!
                 },
-                Gor = trust.GORregion
+                Gor = trust.GORregion,
+                GroupUid = trust.GroupUID,
+                OpenDate = trust.IncorporatedOnOpenDate.ToResponseDate(),
             };
         }
     }

--- a/Dfe.Academies.Domain/Establishment/Establishment.cs
+++ b/Dfe.Academies.Domain/Establishment/Establishment.cs
@@ -98,6 +98,7 @@ namespace Dfe.Academies.Domain.Establishment
         public virtual ICollection<EducationEstablishmentGovernance>? EducationEstablishmentGovernances { get; set; }
         public LocalAuthority? LocalAuthority { get; set; }
         public EstablishmentType? EstablishmentType{ get; set; }
+        public EstablishmentGroupType? EstablishmentGroupType{ get; set; }
 
         public IfdPipeline? IfdPipeline { get; set; }
     }

--- a/Dfe.Academies.Domain/Establishment/EstablishmentGroupType.cs
+++ b/Dfe.Academies.Domain/Establishment/EstablishmentGroupType.cs
@@ -1,0 +1,9 @@
+﻿namespace Dfe.Academies.Domain.Establishment
+{
+    public class EstablishmentGroupType
+    {
+        public long SK { get; set; }
+        public string? Name { get; set; }
+        public string? Code { get; set; }
+    }
+}

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
@@ -3279,6 +3279,12 @@ namespace GovUK.Dfe.AcademiesApi.Client.Contracts
         [Newtonsoft.Json.JsonProperty("gor", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Gor { get; set; } = default!;
 
+        [Newtonsoft.Json.JsonProperty("groupUid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? GroupUid { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("openDate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? OpenDate { get; set; } = default!;
+
         public string ToJson()
         {
 

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
@@ -2904,6 +2904,9 @@ namespace GovUK.Dfe.AcademiesApi.Client.Contracts
         [Newtonsoft.Json.JsonProperty("establishmentType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NameAndCodeDto? EstablishmentType { get; set; } = default!;
 
+        [Newtonsoft.Json.JsonProperty("establishmentGroupType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public NameAndCodeDto? EstablishmentGroupType { get; set; } = default!;
+
         [Newtonsoft.Json.JsonProperty("gor", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NameAndCodeDto? Gor { get; set; } = default!;
 

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
@@ -4471,6 +4471,9 @@
           "establishmentType": {
             "$ref": "#/components/schemas/NameAndCodeDto"
           },
+          "establishmentGroupType": {
+            "$ref": "#/components/schemas/NameAndCodeDto"
+          },
           "gor": {
             "$ref": "#/components/schemas/NameAndCodeDto"
           },

--- a/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
+++ b/GovUK.Dfe.AcademiesApi.Client/Generated/swagger.json
@@ -4769,6 +4769,14 @@
           "gor": {
             "type": "string",
             "nullable": true
+          },
+          "groupUid": {
+            "type": "string",
+            "nullable": true
+          },
+          "openDate": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
+++ b/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
@@ -306,6 +306,9 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
                 dto.EstablishmentType.Name == establishment.EstablishmentType?.Name &&
                 dto.EstablishmentType.Code == establishment.EstablishmentType?.Code &&
 
+                dto.EstablishmentGroupType.Name == establishment.EstablishmentGroupType?.Name &&
+                dto.EstablishmentGroupType.Code == establishment.EstablishmentGroupType?.Code &&
+
                 dto.Gor.Name == establishment.GORregion &&
 
                 dto.PhaseOfEducation.Name == establishment.PhaseOfEducation &&


### PR DESCRIPTION
Add EstablishmentGroupType to domain, API, and tests

Introduced EstablishmentGroupType entity and integrated it into the domain model, DbContext, and Entity Framework configuration. Updated Establishment and related repository logic to support EstablishmentGroupType. Extended EstablishmentDto, builder, API contract, and OpenAPI spec to expose this property. Enhanced unit tests to cover the new field. Upgraded GovUK.Dfe.CoreLibs.Contracts to v1.0.63.